### PR TITLE
fix(ci): reduce release dist artifact retention to 30 days

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           name: dist
           path: dist/
+          retention-days: 30
 
   publish-pypi:
     needs: build


### PR DESCRIPTION
## Summary
- Adds `retention-days: 30` to the `actions/upload-artifact@v4` step in `release.yml`
- Reduces default 90-day retention to 30 days for post-release debugging artifacts
- Addresses high GitHub Actions storage usage

## Test plan
- [x] YAML syntax validated with `python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" .github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)