### PR TITLE
fix(ci): set retention-days: 1 on Pages artifact

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/dist
+          retention-days: 1
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- Adds `retention-days: 1` to the `actions/upload-pages-artifact@v3` step in `deploy-frontend.yml`
- Pages artifacts only need to survive between the `build` and `deploy` jobs (minutes), not the default 90 days
- Reduces GitHub Actions artifact storage usage

## Test plan
- [x] YAML syntax validated with `python3 -c "import yaml, sys; yaml.safe_load(open(sys.argv[1]))" .github/workflows/deploy-frontend.yml`
- [ ] Verify next Pages deployment succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)