### PR TITLE
feat(materials): populate MATERIAL_CATALOG with canonical cyclotron-targetry materials (#65)

### DIFF
--- a/frontend/src/lib/compute/materials.test.ts
+++ b/frontend/src/lib/compute/materials.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 import {
+  ELEMENT_DENSITIES,
   MATERIAL_CATALOG,
   resolveMaterial,
   type CatalogEntry,
 } from "./materials";
+import { SYMBOL_TO_Z } from "../utils/formula";
 import type { DatabaseProtocol } from "./types";
 
 /**
@@ -52,6 +54,22 @@ describe("MATERIAL_CATALOG — schema invariants", () => {
         expect(Object.keys(entry.massFractions).length).toBeGreaterThan(0);
       });
 
+      it("each element in massFractions is a known symbol", () => {
+        for (const sym of Object.keys(entry.massFractions)) {
+          expect(SYMBOL_TO_Z).toHaveProperty(sym);
+        }
+      });
+
+      it("at least one element has a tabulated bulk density (sanity)", () => {
+        // Every catalog entry should contain at least one element we know the
+        // density of — otherwise the resolver has no natural fallback when the
+        // entry itself is missing a density (defensive invariant).
+        const has = Object.keys(entry.massFractions).some(
+          (s) => ELEMENT_DENSITIES[s] !== undefined,
+        );
+        expect(has).toBe(true);
+      });
+
       if (entry.defaultEnrichment) {
         it("each defaultEnrichment element appears in massFractions", () => {
           for (const el of Object.keys(entry.defaultEnrichment!)) {
@@ -65,7 +83,47 @@ describe("MATERIAL_CATALOG — schema invariants", () => {
             expect(sum).toBeCloseTo(1, 6);
           }
         });
+
+        it("each defaultEnrichment mass number is plausible (1 ≤ A ≤ 300)", () => {
+          for (const [, abundances] of Object.entries(entry.defaultEnrichment!)) {
+            for (const a of Object.keys(abundances)) {
+              const A = Number(a);
+              expect(A).toBeGreaterThanOrEqual(1);
+              expect(A).toBeLessThanOrEqual(300);
+            }
+          }
+        });
       }
+    });
+  }
+});
+
+describe("MATERIAL_CATALOG — naming collision safety (pitfall 7)", () => {
+  it("no catalog key collides with `Element-Mass` isotope form (e.g. 'zn-68')", () => {
+    // Free-text path in resolveMaterial strips `-\d+`; a catalog key matching
+    // `{1-2 letter symbol}-{1-3 digit mass number}` would silently reinterpret
+    // the user's isotope input as an enriched target. Alloy designations like
+    // `al-6061` (4-digit number, not a mass) and `inconel-625` (7+ char prefix)
+    // don't collide with this form.
+    const forbidden = /^[a-z]{1,2}-\d{1,3}$/;
+    for (const key of Object.keys(MATERIAL_CATALOG)) {
+      expect(key, `catalog key "${key}" collides with Element-Mass isotope input`).not.toMatch(forbidden);
+    }
+  });
+});
+
+describe("MATERIAL_CATALOG — key resolution via resolveMaterial", () => {
+  const db = makeStubDb();
+  for (const key of Object.keys(MATERIAL_CATALOG)) {
+    it(`"${key}" resolves to non-empty elements + positive density`, () => {
+      const { elements, density } = resolveMaterial(db, key);
+      expect(density).toBeGreaterThan(0);
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    it(`"${key}" is case-insensitive on lookup`, () => {
+      const { density } = resolveMaterial(db, key.toUpperCase());
+      expect(density).toBeGreaterThan(0);
     });
   }
 });

--- a/frontend/src/lib/compute/materials.test.ts
+++ b/frontend/src/lib/compute/materials.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import {
+  MATERIAL_CATALOG,
+  resolveMaterial,
+  type CatalogEntry,
+} from "./materials";
+import type { DatabaseProtocol } from "./types";
+
+/**
+ * Minimal in-memory stub of DatabaseProtocol — only implements the two methods
+ * that material resolution exercises (`getElementZ`, `getNaturalAbundances`).
+ */
+function makeStubDb(): DatabaseProtocol {
+  const naturalAbundances: Record<number, Map<number, { abundance: number; atomicMass: number }>> = {
+    6: new Map([[12, { abundance: 0.989, atomicMass: 12.0 }], [13, { abundance: 0.011, atomicMass: 13.003 }]]),
+    24: new Map([[50, { abundance: 0.0435, atomicMass: 49.946 }], [52, { abundance: 0.8379, atomicMass: 51.941 }], [53, { abundance: 0.095, atomicMass: 52.941 }], [54, { abundance: 0.0237, atomicMass: 53.939 }]]),
+    25: new Map([[55, { abundance: 1.0, atomicMass: 54.938 }]]),
+    26: new Map([[54, { abundance: 0.0585, atomicMass: 53.940 }], [56, { abundance: 0.9175, atomicMass: 55.935 }], [57, { abundance: 0.0212, atomicMass: 56.935 }], [58, { abundance: 0.0028, atomicMass: 57.933 }]]),
+    27: new Map([[59, { abundance: 1.0, atomicMass: 58.933 }]]),
+    28: new Map([[58, { abundance: 0.6808, atomicMass: 57.935 }], [60, { abundance: 0.2622, atomicMass: 59.931 }], [61, { abundance: 0.0114, atomicMass: 60.931 }], [62, { abundance: 0.0363, atomicMass: 61.928 }], [64, { abundance: 0.0093, atomicMass: 63.928 }]]),
+    30: new Map([[64, { abundance: 0.4917, atomicMass: 63.929 }], [66, { abundance: 0.2773, atomicMass: 65.926 }], [67, { abundance: 0.0404, atomicMass: 66.927 }], [68, { abundance: 0.1845, atomicMass: 67.925 }], [70, { abundance: 0.0061, atomicMass: 69.925 }]]),
+    42: new Map([[92, { abundance: 0.1453, atomicMass: 91.907 }], [94, { abundance: 0.0915, atomicMass: 93.905 }], [95, { abundance: 0.1584, atomicMass: 94.906 }], [96, { abundance: 0.1667, atomicMass: 95.905 }], [97, { abundance: 0.0960, atomicMass: 96.906 }], [98, { abundance: 0.2439, atomicMass: 97.905 }], [100, { abundance: 0.0982, atomicMass: 99.907 }]]),
+    74: new Map([[180, { abundance: 0.0012, atomicMass: 179.947 }], [182, { abundance: 0.2650, atomicMass: 181.948 }], [183, { abundance: 0.1431, atomicMass: 182.950 }], [184, { abundance: 0.3064, atomicMass: 183.951 }], [186, { abundance: 0.2843, atomicMass: 185.954 }]]),
+  };
+  return {
+    getCrossSections: () => [],
+    getStoppingPower: () => ({ energiesMeV: new Float64Array(), dedx: new Float64Array() }),
+    getNaturalAbundances: (Z) => naturalAbundances[Z] ?? new Map(),
+    getDecayData: () => null,
+    getDoseConstant: () => null,
+    getElementSymbol: () => "",
+    getElementZ: () => 0,
+  };
+}
+
+function massFractionsSum(entry: CatalogEntry): number {
+  return Object.values(entry.massFractions).reduce((s, v) => s + v, 0);
+}
+
+describe("MATERIAL_CATALOG — schema invariants", () => {
+  for (const [name, entry] of Object.entries(MATERIAL_CATALOG)) {
+    describe(`entry "${name}"`, () => {
+      it("mass fractions sum to 1 (±1e-6)", () => {
+        expect(massFractionsSum(entry)).toBeCloseTo(1, 6);
+      });
+
+      it("density is positive", () => {
+        expect(entry.density).toBeGreaterThan(0);
+      });
+
+      it("has non-empty massFractions", () => {
+        expect(Object.keys(entry.massFractions).length).toBeGreaterThan(0);
+      });
+
+      if (entry.defaultEnrichment) {
+        it("each defaultEnrichment element appears in massFractions", () => {
+          for (const el of Object.keys(entry.defaultEnrichment!)) {
+            expect(entry.massFractions).toHaveProperty(el);
+          }
+        });
+
+        it("each defaultEnrichment abundance map sums to 1 (±1e-6)", () => {
+          for (const [, abundances] of Object.entries(entry.defaultEnrichment!)) {
+            const sum = Object.values(abundances).reduce((s, v) => s + v, 0);
+            expect(sum).toBeCloseTo(1, 6);
+          }
+        });
+      }
+    });
+  }
+});
+
+describe("resolveMaterial — baseline (havar, no enrichment)", () => {
+  it("resolves havar to 8 elements with natural abundance", () => {
+    const db = makeStubDb();
+    const { elements, density } = resolveMaterial(db, "havar");
+    expect(density).toBe(8.3);
+    const symbols = elements.map(([e]) => e.symbol).sort();
+    expect(symbols).toEqual(["C", "Co", "Cr", "Fe", "Mn", "Mo", "Ni", "W"]);
+    // Natural composition: Fe-56 should be ~91.75% of iron isotopes.
+    const fe = elements.find(([e]) => e.symbol === "Fe")?.[0];
+    expect(fe?.isotopes.get(56)).toBeCloseTo(0.9175, 4);
+  });
+});
+
+describe("resolveMaterial — defaultEnrichment", () => {
+  it("applies catalog defaultEnrichment when no override is given", () => {
+    const db = makeStubDb();
+    MATERIAL_CATALOG["__test-enriched-zn__"] = {
+      density: 7.13,
+      massFractions: { Zn: 1.0 },
+      defaultEnrichment: { Zn: { 68: 0.98, 66: 0.02 } },
+    };
+    try {
+      const { elements } = resolveMaterial(db, "__test-enriched-zn__");
+      const zn = elements.find(([e]) => e.symbol === "Zn")?.[0];
+      expect(zn?.isotopes.get(68)).toBeCloseTo(0.98, 6);
+      expect(zn?.isotopes.get(66)).toBeCloseTo(0.02, 6);
+      // Natural 64Zn (49.17%) should be gone — enrichment replaces natural.
+      expect(zn?.isotopes.get(64)).toBeUndefined();
+    } finally {
+      delete MATERIAL_CATALOG["__test-enriched-zn__"];
+    }
+  });
+
+  it("explicit override takes precedence over defaultEnrichment per element", () => {
+    const db = makeStubDb();
+    MATERIAL_CATALOG["__test-enriched-zn__"] = {
+      density: 7.13,
+      massFractions: { Zn: 1.0 },
+      defaultEnrichment: { Zn: { 68: 0.98, 66: 0.02 } },
+    };
+    try {
+      const explicit = { Zn: new Map([[70, 1.0]]) };
+      const { elements } = resolveMaterial(db, "__test-enriched-zn__", explicit);
+      const zn = elements.find(([e]) => e.symbol === "Zn")?.[0];
+      expect(zn?.isotopes.get(70)).toBeCloseTo(1.0, 6);
+      expect(zn?.isotopes.get(68)).toBeUndefined();
+    } finally {
+      delete MATERIAL_CATALOG["__test-enriched-zn__"];
+    }
+  });
+
+  it("override for one element falls back to default for another (multi-element)", () => {
+    const db = makeStubDb();
+    MATERIAL_CATALOG["__test-multi__"] = {
+      density: 5.0,
+      massFractions: { Zn: 0.5, Mo: 0.5 },
+      defaultEnrichment: {
+        Zn: { 68: 0.98, 66: 0.02 },
+        Mo: { 100: 0.96, 98: 0.04 },
+      },
+    };
+    try {
+      const explicit = { Zn: new Map([[64, 1.0]]) };
+      const { elements } = resolveMaterial(db, "__test-multi__", explicit);
+      const zn = elements.find(([e]) => e.symbol === "Zn")?.[0];
+      const mo = elements.find(([e]) => e.symbol === "Mo")?.[0];
+      expect(zn?.isotopes.get(64)).toBeCloseTo(1.0, 6);
+      expect(mo?.isotopes.get(100)).toBeCloseTo(0.96, 6);
+      expect(mo?.isotopes.get(98)).toBeCloseTo(0.04, 6);
+    } finally {
+      delete MATERIAL_CATALOG["__test-multi__"];
+    }
+  });
+});

--- a/frontend/src/lib/compute/materials.test.ts
+++ b/frontend/src/lib/compute/materials.test.ts
@@ -179,6 +179,24 @@ describe("resolveMaterial — defaultEnrichment", () => {
     }
   });
 
+  it("empty override Map keeps the catalog default (does not wipe isotopes)", () => {
+    const db = makeStubDb();
+    MATERIAL_CATALOG["__test-enriched-zn__"] = {
+      density: 7.13,
+      massFractions: { Zn: 1.0 },
+      defaultEnrichment: { Zn: { 68: 0.98, 66: 0.02 } },
+    };
+    try {
+      const explicit = { Zn: new Map<number, number>() }; // empty = "not provided"
+      const { elements } = resolveMaterial(db, "__test-enriched-zn__", explicit);
+      const zn = elements.find(([e]) => e.symbol === "Zn")?.[0];
+      expect(zn?.isotopes.get(68)).toBeCloseTo(0.98, 6);
+      expect(zn?.isotopes.get(66)).toBeCloseTo(0.02, 6);
+    } finally {
+      delete MATERIAL_CATALOG["__test-enriched-zn__"];
+    }
+  });
+
   it("override for one element falls back to default for another (multi-element)", () => {
     const db = makeStubDb();
     MATERIAL_CATALOG["__test-multi__"] = {

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -48,6 +48,46 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
     role: "structural",
     notes: "Cobalt-based alloy, common beam-window material",
   },
+
+  // ─── Monitor foils (natural composition) ───────────────────────────
+  natcu: {
+    density: 8.96,
+    massFractions: { Cu: 1.0 },
+    role: "monitor",
+    notes: "Natural Cu monitor foil; IAEA-recommended (p,X) monitor reactions",
+  },
+  natti: {
+    density: 4.51,
+    massFractions: { Ti: 1.0 },
+    role: "monitor",
+    notes: "Natural Ti monitor foil; natTi(p,X)48V common monitor",
+  },
+  natni: {
+    density: 8.91,
+    massFractions: { Ni: 1.0 },
+    role: "monitor",
+    notes: "Natural Ni monitor foil",
+  },
+
+  // ─── Monoisotopic / simple natural targets ─────────────────────────
+  y89: {
+    density: 4.47,
+    massFractions: { Y: 1.0 },
+    role: "target",
+    notes: "89Y (monoisotopic natural); 89Y(p,n)89Zr for immunoPET",
+  },
+  graphite: {
+    density: 1.80,
+    massFractions: { C: 1.0 },
+    role: "window",
+    notes: "Reactor-grade graphite (degrader stock). Density varies 1.6–2.26",
+  },
+  "be-window": {
+    density: 1.85,
+    massFractions: { Be: 1.0 },
+    role: "window",
+    notes: "Beryllium cyclotron window. Be metal is toxic — handle per local SOP",
+  },
 };
 
 /**

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -88,6 +88,73 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
     role: "window",
     notes: "Beryllium cyclotron window. Be metal is toxic — handle per local SOP",
   },
+
+  // ─── Enriched-isotope targets ──────────────────────────────────────
+  // Naming convention: `{A}{Symbol}-{role}` avoids collision with the
+  // `Element-Mass` free-text form (e.g. "Zn-68") that resolveMaterial
+  // strips at line ~188.
+  "zn68-electrodeposit": {
+    density: 7.13,
+    massFractions: { Zn: 1.0 },
+    defaultEnrichment: { Zn: { 68: 0.98, 66: 0.015, 67: 0.003, 64: 0.002 } },
+    role: "target",
+    notes: "68Zn electrodeposit at 98% enrichment; 68Zn(p,n)68Ga",
+  },
+  "ni64-electrodeposit": {
+    density: 8.91,
+    massFractions: { Ni: 1.0 },
+    defaultEnrichment: { Ni: { 64: 0.95, 62: 0.03, 60: 0.015, 58: 0.005 } },
+    role: "target",
+    notes: "64Ni electrodeposit at 95% enrichment; 64Ni(p,n)64Cu",
+  },
+  "mo100-pellet": {
+    density: 10.28,
+    massFractions: { Mo: 1.0 },
+    defaultEnrichment: { Mo: { 100: 0.96, 98: 0.02, 97: 0.01, 96: 0.01 } },
+    role: "target",
+    notes: "100Mo pressed pellet at 96% enrichment; 100Mo(p,2n)99mTc",
+  },
+  "ca44-target": {
+    density: 1.55,
+    massFractions: { Ca: 1.0 },
+    defaultEnrichment: { Ca: { 44: 0.97, 40: 0.025, 42: 0.003, 48: 0.002 } },
+    role: "target",
+    notes: "44Ca target at 97% enrichment; 44Ca(p,n)44Sc for PET",
+  },
+  "ra226-target": {
+    density: 5.50,
+    massFractions: { Ra: 1.0 },
+    defaultEnrichment: { Ra: { 226: 1.0 } },
+    role: "target",
+    notes:
+      "226Ra target (monoisotopic); α-emitter precursor — licensing + handling" +
+      " restrictions apply (226Ra is a high-radiotoxicity source)",
+  },
+  "th232-target": {
+    density: 11.72,
+    massFractions: { Th: 1.0 },
+    defaultEnrichment: { Th: { 232: 1.0 } },
+    role: "target",
+    notes:
+      "232Th target (monoisotopic natural); route to 225Ac, 99Mo, etc. — export" +
+      " controls apply",
+  },
+  "u238-target": {
+    density: 19.05,
+    massFractions: { U: 1.0 },
+    defaultEnrichment: { U: { 238: 0.9975, 235: 0.0025 } },
+    role: "target",
+    notes:
+      "Depleted U target (~0.25% 235U); route to 99Mo via fission. Export +" +
+      " licensing controls apply",
+  },
+  natu: {
+    density: 19.05,
+    massFractions: { U: 1.0 },
+    defaultEnrichment: { U: { 238: 0.992742, 235: 0.007204, 234: 0.000054 } },
+    role: "target",
+    notes: "Natural U (0.72% 235U). Licensing + export controls apply",
+  },
 };
 
 /**

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -123,14 +123,27 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
       " Irradiated pellets accumulate long-lived 93mNb contaminants",
   },
   "ca44-carbonate": {
-    // 44CaCO3 pressed pellet — the practical delivered form. Ca metal targets
-    // are not used in medical isotope practice (air-reactive, low m.p.).
+    // 44CaCO3 pressed pellet — the more common commercial delivery form
+    // (stable, non-hygroscopic). Ca metal targets are not used in practice
+    // (air-reactive, low m.p.).
     // M(CaCO3) = 40.078 + 12.011 + 3*15.999 = 100.086
     density: 2.80,
     massFractions: { Ca: 0.40045, C: 0.12001, O: 0.47954 },
     defaultEnrichment: { Ca: { 44: 0.97, 40: 0.025, 42: 0.003, 48: 0.002 } },
     role: "target",
     notes: "44CaCO3 pressed pellet at 97% enrichment on Ca; 44Ca(p,n)44Sc for PET",
+  },
+  "ca44-oxide": {
+    // 44CaO pressed pellet — higher Ca atomic density than the carbonate
+    // (~1.8× Ca per cm³), but hygroscopic and harder to store.
+    // M(CaO) = 40.078 + 15.999 = 56.077
+    density: 3.35,
+    massFractions: { Ca: 0.71469, O: 0.28531 },
+    defaultEnrichment: { Ca: { 44: 0.97, 40: 0.025, 42: 0.003, 48: 0.002 } },
+    role: "target",
+    notes:
+      "44CaO pressed pellet at 97% enrichment on Ca; higher Ca density than" +
+      " 44CaCO3 but hygroscopic (handle + store under inert atmosphere)",
   },
   "ra226-target": {
     density: 5.50,

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -46,7 +46,9 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
       W: 0.028, Mo: 0.02, Mn: 0.016, C: 0.002,
     },
     role: "structural",
-    notes: "Cobalt-based alloy, common beam-window material",
+    notes:
+      "Cobalt-based alloy, common beam-window material. Co dust is an IARC" +
+      " 2A carcinogen — machining/grinding is controlled in many jurisdictions",
   },
 
   // ─── Monitor foils (natural composition) ───────────────────────────
@@ -96,30 +98,39 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
   "zn68-electrodeposit": {
     density: 7.13,
     massFractions: { Zn: 1.0 },
-    defaultEnrichment: { Zn: { 68: 0.98, 66: 0.015, 67: 0.003, 64: 0.002 } },
+    // Typical commercial 98% 68Zn remainder (Trace Sciences / Isoflex specs):
+    defaultEnrichment: { Zn: { 68: 0.982, 66: 0.01, 67: 0.004, 64: 0.003, 70: 0.001 } },
     role: "target",
     notes: "68Zn electrodeposit at 98% enrichment; 68Zn(p,n)68Ga",
   },
   "ni64-electrodeposit": {
     density: 8.91,
     massFractions: { Ni: 1.0 },
-    defaultEnrichment: { Ni: { 64: 0.95, 62: 0.03, 60: 0.015, 58: 0.005 } },
+    // Typical commercial 95% 64Ni remainder: 60Ni > 62Ni > 58Ni (per supplier specs).
+    defaultEnrichment: { Ni: { 64: 0.95, 60: 0.025, 62: 0.02, 58: 0.005 } },
     role: "target",
     notes: "64Ni electrodeposit at 95% enrichment; 64Ni(p,n)64Cu",
   },
   "mo100-pellet": {
-    density: 10.28,
+    // Sintered pressed-powder pellet typical bulk density 9.0–9.8 g/cm³
+    // (domain review: 70–85% of bulk Mo = 7.2–8.7 pre-sinter; 9.5+ sintered).
+    density: 9.5,
     massFractions: { Mo: 1.0 },
     defaultEnrichment: { Mo: { 100: 0.96, 98: 0.02, 97: 0.01, 96: 0.01 } },
     role: "target",
-    notes: "100Mo pressed pellet at 96% enrichment; 100Mo(p,2n)99mTc",
+    notes:
+      "100Mo sintered pressed-powder pellet at 96% enrichment; 100Mo(p,2n)99mTc." +
+      " Irradiated pellets accumulate long-lived 93mNb contaminants",
   },
-  "ca44-target": {
-    density: 1.55,
-    massFractions: { Ca: 1.0 },
+  "ca44-carbonate": {
+    // 44CaCO3 pressed pellet — the practical delivered form. Ca metal targets
+    // are not used in medical isotope practice (air-reactive, low m.p.).
+    // M(CaCO3) = 40.078 + 12.011 + 3*15.999 = 100.086
+    density: 2.80,
+    massFractions: { Ca: 0.40045, C: 0.12001, O: 0.47954 },
     defaultEnrichment: { Ca: { 44: 0.97, 40: 0.025, 42: 0.003, 48: 0.002 } },
     role: "target",
-    notes: "44Ca target at 97% enrichment; 44Ca(p,n)44Sc for PET",
+    notes: "44CaCO3 pressed pellet at 97% enrichment on Ca; 44Ca(p,n)44Sc for PET",
   },
   "ra226-target": {
     density: 5.50,
@@ -127,8 +138,9 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
     defaultEnrichment: { Ra: { 226: 1.0 } },
     role: "target",
     notes:
-      "226Ra target (monoisotopic); α-emitter precursor — licensing + handling" +
-      " restrictions apply (226Ra is a high-radiotoxicity source)",
+      "226Ra (bulk-metal density; practical form is RaCl2 or Ra(NO3)2 on a" +
+      " backing — override density for your actual form). α-emitter precursor;" +
+      " licensing + handling restrictions apply (high radiotoxicity)",
   },
   "th232-target": {
     density: 11.72,
@@ -142,11 +154,12 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
   "u238-target": {
     density: 19.05,
     massFractions: { U: 1.0 },
-    defaultEnrichment: { U: { 238: 0.9975, 235: 0.0025 } },
+    // Depleted U with trace 234U (commercial typical 5–10 ppm).
+    defaultEnrichment: { U: { 238: 0.99749, 235: 0.0025, 234: 0.00001 } },
     role: "target",
     notes:
-      "Depleted U target (~0.25% 235U); route to 99Mo via fission. Export +" +
-      " licensing controls apply",
+      "Depleted U target (~0.25% 235U, trace 234U); route to 99Mo via fission." +
+      " Export + licensing controls apply",
   },
   natu: {
     density: 19.05,

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -15,10 +15,27 @@ import type { DatabaseProtocol, Element } from "./types";
 
 export { parseFormula, formulaToMassFractions, SYMBOL_TO_Z, STANDARD_ATOMIC_WEIGHT };
 
-/** Known material definitions: density and mass fractions by element. */
+/** Catalog-entry role — drives category filtering + search ranking. */
+export type CatalogRole =
+  | "monitor"
+  | "target"
+  | "window"
+  | "structural"
+  | "compound"
+  | "gas";
+
+/**
+ * Known material definitions.
+ *
+ * `defaultEnrichment` is applied by `resolveMaterial` when no caller-provided
+ * `overrides` are given. Explicit overrides always take precedence, per-element.
+ */
 export interface CatalogEntry {
   density: number;
   massFractions: Record<string, number>;
+  defaultEnrichment?: Record<string, Record<number, number>>;
+  role?: CatalogRole;
+  notes?: string;
 }
 
 export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
@@ -28,8 +45,31 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
       Co: 0.42, Cr: 0.20, Ni: 0.13, Fe: 0.184,
       W: 0.028, Mo: 0.02, Mn: 0.016, C: 0.002,
     },
+    role: "structural",
+    notes: "Cobalt-based alloy, common beam-window material",
   },
 };
+
+/**
+ * Merge caller-provided overrides with a catalog entry's `defaultEnrichment`.
+ * Per-element: caller overrides win; otherwise fall back to the catalog default.
+ */
+function mergeEnrichmentWithDefaults(
+  defaults: Record<string, Record<number, number>> | undefined,
+  overrides: Record<string, Map<number, number>> | undefined,
+): Record<string, Map<number, number>> | undefined {
+  if (!defaults) return overrides;
+  const merged: Record<string, Map<number, number>> = {};
+  for (const [sym, abundances] of Object.entries(defaults)) {
+    const m = new Map<number, number>();
+    for (const [a, f] of Object.entries(abundances)) m.set(Number(a), f);
+    merged[sym] = m;
+  }
+  if (overrides) {
+    for (const [sym, m] of Object.entries(overrides)) merged[sym] = m;
+  }
+  return merged;
+}
 
 /** Convert mass fractions to atom fractions. */
 export function massToAtomFractions(
@@ -165,7 +205,8 @@ export function resolveMaterial(
   const lowerIdent = identifier.toLowerCase();
   const catalogEntry = MATERIAL_CATALOG[lowerIdent];
   if (catalogEntry) {
-    const elements = resolveIsotopics(db, catalogEntry.massFractions, false, overrides);
+    const effective = mergeEnrichmentWithDefaults(catalogEntry.defaultEnrichment, overrides);
+    const elements = resolveIsotopics(db, catalogEntry.massFractions, false, effective);
     return { elements, density: catalogEntry.density, molecularWeight: 0 };
   }
 

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -155,6 +155,87 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
     role: "target",
     notes: "Natural U (0.72% 235U). Licensing + export controls apply",
   },
+
+  // ─── Compounds ─────────────────────────────────────────────────────
+  // Natural abundance; mass fractions derived from formula weight.
+  baco3: {
+    density: 4.29,
+    // M = 137.33 + 12.01 + 3*16.00 = 197.34
+    massFractions: { Ba: 0.69591, C: 0.06086, O: 0.24323 },
+    role: "compound",
+    notes: "Barium carbonate; target matrix for enriched-Ba production routes",
+  },
+  zno: {
+    density: 5.61,
+    // M = 65.38 + 16.00 = 81.38
+    massFractions: { Zn: 0.80340, O: 0.19660 },
+    role: "compound",
+    notes: "Zinc oxide; compact target form",
+  },
+  moo3: {
+    density: 4.69,
+    // M = 95.96 + 3*16.00 = 143.96
+    massFractions: { Mo: 0.66657, O: 0.33343 },
+    role: "compound",
+    notes: "Molybdenum trioxide; pressed-pellet matrix for 100Mo production",
+  },
+  "h2o-18-enriched": {
+    density: 1.11,
+    // M = 2*1.008 + 17.999 = 20.015 (enriched water)
+    massFractions: { H: 0.10072, O: 0.89928 },
+    defaultEnrichment: { O: { 18: 0.97, 16: 0.025, 17: 0.005 } },
+    role: "compound",
+    notes:
+      "Enriched H2[18O] water at 97% 18O; 18O(p,n)18F. Separate key from the" +
+      " legacy `H2O-18` compound entry, which stays unenriched",
+  },
+
+  // ─── Structural / windows ──────────────────────────────────────────
+  "nb-1zr": {
+    density: 8.57,
+    massFractions: { Nb: 0.99, Zr: 0.01 },
+    role: "structural",
+    notes: "Niobium–1% zirconium; high-temperature target backing",
+  },
+  ss316l: {
+    density: 7.99,
+    massFractions: {
+      Fe: 0.654, Cr: 0.17, Ni: 0.12, Mo: 0.025, Mn: 0.02,
+      Si: 0.01, C: 0.001,
+    },
+    role: "structural",
+    notes:
+      "Austenitic stainless steel, low-carbon grade (midpoint-of-spec" +
+      " composition)",
+  },
+  "inconel-625": {
+    density: 8.44,
+    // Midpoint-of-range per ASM (pitfall 2); Ni adjusted so sum == 1.000.
+    massFractions: {
+      Ni: 0.585, Cr: 0.22, Mo: 0.09, Fe: 0.05, Nb: 0.035,
+      Al: 0.004, Ti: 0.004, Mn: 0.005, Si: 0.005, C: 0.002,
+    },
+    role: "structural",
+    notes: "Ni-based high-temperature superalloy (midpoint-of-spec composition)",
+  },
+  "al-6061": {
+    density: 2.70,
+    massFractions: {
+      Al: 0.979, Mg: 0.010, Si: 0.006, Cu: 0.003, Cr: 0.002,
+    },
+    role: "structural",
+    notes: "Aluminium wrought alloy; common target-holder material",
+  },
+  kapton: {
+    density: 1.42,
+    // C22H10N2O5 polyimide: M = 22*12.011 + 10*1.008 + 2*14.007 + 5*15.999
+    //                        = 264.242 + 10.080 + 28.014 + 79.995 = 382.331
+    massFractions: {
+      C: 0.69113, H: 0.02637, N: 0.07328, O: 0.20922,
+    },
+    role: "window",
+    notes: "Polyimide film (DuPont Kapton); common thin-window material",
+  },
 };
 
 /**

--- a/frontend/src/lib/compute/materials.ts
+++ b/frontend/src/lib/compute/materials.ts
@@ -267,7 +267,12 @@ function mergeEnrichmentWithDefaults(
     merged[sym] = m;
   }
   if (overrides) {
-    for (const [sym, m] of Object.entries(overrides)) merged[sym] = m;
+    for (const [sym, m] of Object.entries(overrides)) {
+      // Empty override Map is treated as "not provided" — keeps the catalog
+      // default rather than silently wiping the element to zero isotopes.
+      if (m.size === 0) continue;
+      merged[sym] = m;
+    }
   }
   return merged;
 }


### PR DESCRIPTION
## Summary

- Expands `MATERIAL_CATALOG` from 1 entry (Havar) to 24 canonical cyclotron-targetry materials across monitor / target / window / structural / compound roles.
- Adds `role`, `notes`, and `defaultEnrichment` fields to `CatalogEntry`; `resolveMaterial` applies catalog defaults when no caller-provided enrichment override is given, with per-element precedence.
- 201 unit tests on `materials.test.ts` cover schema invariants, naming-collision safety, resolver round-trip, and enrichment precedence / empty-override edge case.

Closes #65.
Auto-resolves the common-case symptom of #57 (catalog materials now inspect correctly with role/notes metadata).

## What's in the catalog

| Role        | Entries |
|-------------|---------|
| Monitor     | natCu, natTi, natNi |
| Target      | Y89 (nat), Zn68-electrodeposit, Ni64-electrodeposit, Mo100-pellet, Ca44-carbonate, Ra226, Th232, U238, natU |
| Window      | Graphite, Be-window, Kapton |
| Compound    | BaCO3, ZnO, MoO3, H2O-18-enriched |
| Structural  | Havar, Nb-1Zr, SS316L, Inconel-625, Al-6061 |

Enriched targets carry commercial-spec `defaultEnrichment` vectors (Zn68@98%, Ni64@95%, Mo100@96%, Ca44@97%, etc.) with realistic remainder distributions per supplier norms.

## Review rounds

Two fresh-agent reviews per /land workflow:

1. **Implementation match** (round 1): "Ship it, no blockers." Flagged 5 non-blocking improvements; the highest-impact one (empty-override edge case in `mergeEnrichmentWithDefaults`) is fixed here; the rest are tracked as follow-ups.
2. **Physics / domain** (round 2): Flagged 2 blockers — Ca44 form/density was off by ~2× (bulk Ca metal density vs actual CaCO3 pellet form), Mo100 density was bulk Mo vs sintered pellet. Both fixed. Accuracy corrections also applied: Zn68/Ni64 enrichment remainders per supplier norm, trace 234U in U238, Ra226 form clarified, Co dust safety note on Havar.

## Naming-collision safety (pitfall 7)

Catalog keys use `{A}{Symbol}-{role}` form (e.g. `zn68-electrodeposit`, not `zn-68`) to avoid collision with the free-text `Element-Mass` isotope identifier path in `resolveMaterial`. Enforced by a regex-based invariant test.

`H2O-18-enriched` is a **separate key** from the legacy `H2O-18` entry in `COMPOUND_DENSITIES`, which stays unchanged — no silent-semantic-change for existing users (pitfall 3).

## Follow-ups filed

- **#68** — Add gas-target catalog entries (¹⁸O₂, ¹²⁴Xe, ⁸⁶SrCO₃). Highest-impact missing material per domain review.
- **#64** P1 — Role-based filter tabs in MaterialPopup (blocked on the popup split in #64 Phase 0).

## Deferred from this PR (intentional)

- **Playwright smoke** (natCu → simulate → activity table): per-entry `resolveMaterial` round-trip in vitest covers the same code path; browser-level smoke can be added in a separate PR once the PR #64 UI changes land.

## Test plan

- [x] `npx vitest run` — 266/266 green across all frontend suites (6 files).
- [x] `npx vitest run src/lib/compute/materials.test.ts` — 201 tests green.
- [x] `npx svelte-check` — 2 pre-existing errors (both on `main`, unrelated to this branch: `backend.ts:66` and `BugReportModal.svelte:185`). No new errors.
- [ ] Manual smoke after merge: select `natCu` in MaterialPopup → simulate → activity table populates.
- [ ] Manual smoke after merge: select `Zn68-electrodeposit` → verify 98% ⁶⁸Zn isotopics without setting explicit enrichment.