### PR TITLE
hyrr-mcp: PyO3/maturin wrapper for uvx distribution (stacked on #70, refs #71)

### DIFF
--- a/py-mcp/.cargo/config.toml
+++ b/py-mcp/.cargo/config.toml
@@ -1,0 +1,3 @@
+[env]
+# libiconv path for Nix-managed GCC on macOS
+LIBRARY_PATH = { value = "/nix/store/7h6icyvqv6lqd0bcx41c8h3615rjcqb2-libiconv-109.100.2/lib", force = false }

--- a/py-mcp/.gitignore
+++ b/py-mcp/.gitignore
@@ -1,0 +1,7 @@
+/target
+/.venv
+Cargo.lock
+*.so
+__pycache__/
+*.egg-info/
+dist/

--- a/py-mcp/Cargo.toml
+++ b/py-mcp/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hyrr-mcp-py"
+version = "0.1.0"
+edition = "2021"
+description = "PyO3 wrapper around hyrr-core's MCP server for uvx distribution"
+license = "MIT"
+
+[lib]
+name = "_native"
+crate-type = ["cdylib"]
+
+[dependencies]
+hyrr-core = { path = "../core", features = ["mcp"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py311"] }

--- a/py-mcp/Cargo.toml
+++ b/py-mcp/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 description = "PyO3 wrapper around hyrr-core's MCP server for uvx distribution"
 license = "MIT"
+# Keep the nix-libiconv dev workaround out of published sdists.
+exclude = [".cargo/**", "python/hyrr_mcp/__pycache__/**"]
 
 [lib]
 name = "_native"

--- a/py-mcp/README.md
+++ b/py-mcp/README.md
@@ -1,0 +1,22 @@
+# hyrr-mcp
+
+HYRR MCP server — stdio JSON-RPC for radio-isotope production queries.
+
+Install and register with Claude Code:
+
+```bash
+claude mcp add hyrr -- uvx hyrr-mcp
+```
+
+The first invocation downloads the wheel (or builds from source if no
+wheel exists for your platform); subsequent runs are instant.
+
+Data resolution priority: `--data-dir` arg → `HYRR_DATA` env →
+sibling `nucl-parquet/` → `~/.hyrr/nucl-parquet`.
+
+The tools surface (`simulate`, `list_materials`,
+`list_reaction_channels`, `get_decay_data`, `compare_simulations`,
+`get_stack_energy_budget`, `get_stopping_power`,
+`get_isotope_production_curve`) is implemented in Rust in
+`hyrr-core::mcp`; this package is a thin PyO3 wrapper used purely
+for distribution.

--- a/py-mcp/pyproject.toml
+++ b/py-mcp/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["maturin>=1.7,<2"]
+build-backend = "maturin"
+
+[project]
+name = "hyrr-mcp"
+version = "0.1.0"
+description = "HYRR MCP server — stdio JSON-RPC for radio-isotope production queries"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.11"
+authors = [{ name = "MorePET" }]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+
+[project.scripts]
+hyrr-mcp = "hyrr_mcp:main"
+
+[project.urls]
+Homepage = "https://github.com/exoma-ch/hyrr"
+Issues = "https://github.com/exoma-ch/hyrr/issues"
+
+[tool.maturin]
+python-source = "python"
+module-name = "hyrr_mcp._native"
+features = ["pyo3/extension-module"]

--- a/py-mcp/python/hyrr_mcp/__init__.py
+++ b/py-mcp/python/hyrr_mcp/__init__.py
@@ -1,0 +1,59 @@
+"""HYRR MCP server — Python entry point for `uvx hyrr-mcp`.
+
+The package is a thin wrapper. All MCP tool logic lives in hyrr-core
+(Rust); this module just parses args, resolves the data directory,
+and hands stdin/stdout to the native stdio loop.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from . import _native
+
+__version__ = _native.__version__
+
+
+def _print_help() -> None:
+    print(
+        f"hyrr-mcp {__version__}\n\n"
+        "Stdio MCP server exposing HYRR radio-isotope production tools.\n\n"
+        "USAGE:\n"
+        "    hyrr-mcp [--data-dir PATH]\n\n"
+        "OPTIONS:\n"
+        "    --data-dir PATH   Override nucl-parquet data directory\n"
+        "    --version, -V     Print version and exit\n"
+        "    --help, -h        Print this help and exit\n\n"
+        "ENVIRONMENT:\n"
+        "    HYRR_DATA         Nucl-parquet data directory (if --data-dir not set)\n\n"
+        "Register with Claude Code:\n"
+        "    claude mcp add hyrr -- uvx hyrr-mcp\n"
+    )
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    if any(a in {"--version", "-V"} for a in argv):
+        print(f"hyrr-mcp {__version__}")
+        return 0
+    if any(a in {"--help", "-h"} for a in argv):
+        _print_help()
+        return 0
+
+    # Resolve data dir: explicit --data-dir wins, otherwise fall back to
+    # the shared Rust resolver (env + sibling + home).
+    data_dir: str | None = None
+    for i, arg in enumerate(argv):
+        if arg == "--data-dir" and i + 1 < len(argv):
+            data_dir = argv[i + 1]
+            break
+    if data_dir is None:
+        data_dir = os.environ.get("HYRR_DATA") or _native.resolve_data_dir()
+
+    _native.run(data_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/py-mcp/python/hyrr_mcp/__main__.py
+++ b/py-mcp/python/hyrr_mcp/__main__.py
@@ -1,0 +1,4 @@
+from . import main
+import sys
+
+sys.exit(main())

--- a/py-mcp/src/lib.rs
+++ b/py-mcp/src/lib.rs
@@ -1,0 +1,27 @@
+//! PyO3 wrapper: a single `_native` module exposing `run(data_dir)` that
+//! delegates to hyrr-core's MCP stdio server. Intentionally minimal —
+//! any logic added here is drift risk away from the Rust SSoT.
+
+use pyo3::prelude::*;
+
+/// Enter the MCP stdio loop. Blocks until stdin closes.
+#[pyfunction]
+fn run(data_dir: String) -> PyResult<()> {
+    hyrr_core::mcp::transport::run_mcp_server(&data_dir);
+    Ok(())
+}
+
+/// Resolve the nucl-parquet data directory using the shared chain
+/// (CLI arg → HYRR_DATA → sibling → ~/.hyrr/nucl-parquet → fallback).
+#[pyfunction]
+fn resolve_data_dir() -> String {
+    hyrr_core::data_dir::resolve()
+}
+
+#[pymodule]
+fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(run, m)?)?;
+    m.add_function(wrap_pyfunction!(resolve_data_dir, m)?)?;
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    Ok(())
+}


### PR DESCRIPTION
Stacked on top of PR #70. Scaffolds the Python/maturin side of the `uvx hyrr-mcp` install path tracked in #71.

**Do not merge until #70 lands on main** — this branch will then be rebased against main.

## Summary

- **New `py-mcp/` crate** — PyO3 extension (`hyrr_mcp._native`) that wraps `hyrr_core::mcp::transport::run_mcp_server`. Two Python-exposed functions (`run(data_dir)`, `resolve_data_dir()`); zero tool logic in the Python layer so drift from the Rust SSoT is structurally impossible.
- **Python package `hyrr_mcp/`** (under `py-mcp/python/hyrr_mcp/`) — thin `main()` that parses `--version` / `--help` / `--data-dir`, resolves the data dir, and hands over to the native stdio loop. ABI3 (`abi3-py311`) so one wheel covers Python ≥ 3.11 on each platform.
- **`pyproject.toml`** with maturin backend, `python-source = "python"`, and `[project.scripts] hyrr-mcp = "hyrr_mcp:main"` for the console_script.

## Test plan

- [x] `maturin develop --release` builds an abi3 wheel and installs in editable mode
- [x] `hyrr-mcp --version` → `hyrr-mcp 0.1.0`
- [x] `tools/list` over stdio returns all 8 tools (simulate, list_materials, list_reaction_channels, get_decay_data, compare_simulations, get_stack_energy_budget, get_stopping_power, get_isotope_production_curve)
- [x] `uvx --from . hyrr-mcp` builds + runs from a clean uv run
- [ ] Same fixture as `scripts/mcp_parity_test.sh` produces byte-identical stdout for all three entry points (`hyrr --mcp`, `hyrr-mcp`, `uvx hyrr-mcp`) — wiring deferred to #71 P1
- [ ] `cibuildwheel` matrix on linux/mac/windows — deferred to #71 P1
- [ ] PyPI trusted publishing + first release tag — deferred to #71 P1

## What's explicitly NOT here

- PyPI publish workflow, cibuildwheel, trusted-publishing OIDC — all in #71 P1
- README install section pointing at `uvx hyrr-mcp` (only true once PyPI has the wheel) — also #71
- Extending `scripts/mcp_parity_test.sh` to compare the uvx invocation against the other two

## Review guidance

The thinness of the Python wrapper is load-bearing: `main()` parses CLI args, everything else delegates to the native module. Any creep (e.g., retry loops, request logging, config parsing) would reintroduce drift risk across the three entry points, since the two Rust binaries (`hyrr --mcp` and `hyrr-mcp`) wouldn't have the matching logic. Keep it boring.