### PR TITLE
feat(material): standalone PeriodicTable component (Phase 1 of #64)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,3 +7,4 @@ public/data/*.sql.gz
 public/data/xs/
 public/data/parquet/
 .vite/
+e2e/results/

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -1,0 +1,140 @@
+<script lang="ts" module>
+  import type { ElementCell } from "./periodic-table-data";
+  export type { ElementCell } from "./periodic-table-data";
+
+  /** Tooltip/inspect-callback payload — narrow on purpose so the parent
+   *  can mirror this shape without reaching into PT internals. */
+  export interface ElementInfo {
+    Z: number;
+    symbol: string;
+    name: string;
+    block: ElementCell["block"];
+    period: number;
+    group: number | null;
+  }
+</script>
+
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { PERIODIC_TABLE } from "./periodic-table-data";
+
+  interface Props {
+    onselect: (symbol: string) => void;
+    /** Symbol of the currently-selected element (renders with the
+     *  `.selected` highlight). */
+    selected?: string;
+    /** Symbols whose cells should be greyed-out (e.g. no TENDL coverage
+     *  for the active projectile). Disabled cells stay rendered and
+     *  keyboard-reachable; click is suppressed. Wired in later commits. */
+    disabled?: Set<string>;
+    /** Symbols that should pulse with a secondary highlight (e.g. rows
+     *  already present in the define-form). */
+    highlighted?: Set<string>;
+    /** Selection mode — "multi" is reserved for future work. */
+    mode?: "single" | "multi";
+    /** Optional tooltip body. The PT owns positioning; the parent
+     *  renders content. (Not wired in this commit; landed in a later
+     *  Phase 1 commit alongside accessibility.) */
+    tooltip?: Snippet<[ElementInfo]>;
+  }
+
+  // `tooltip` is declared in `Props` but bound only by the accessibility
+  // commit; not destructured here.
+  let {
+    onselect,
+    selected,
+    disabled,
+    highlighted,
+    mode = "single",
+  }: Props = $props();
+
+  function handleClick(cell: ElementCell): void {
+    if (disabled?.has(cell.symbol)) return;
+    onselect(cell.symbol);
+  }
+</script>
+
+<div class="pt-grid" data-mode={mode}>
+  {#each PERIODIC_TABLE as cell (cell.Z)}
+    <button
+      class="pt-cell"
+      data-block={cell.block}
+      data-z={cell.Z}
+      class:selected={selected === cell.symbol}
+      class:highlighted={highlighted?.has(cell.symbol)}
+      class:disabled={disabled?.has(cell.symbol)}
+      style:grid-row={cell.row >= 8 ? cell.row + 1 : cell.row}
+      style:grid-column={cell.col}
+      type="button"
+      onclick={() => handleClick(cell)}
+    >
+      <span class="cell-z">{cell.Z}</span>
+      <span class="cell-sym">{cell.symbol}</span>
+    </button>
+  {/each}
+</div>
+
+<style>
+  .pt-grid {
+    display: grid;
+    grid-template-columns: repeat(18, minmax(1.4rem, 1fr));
+    grid-template-rows: repeat(7, minmax(2rem, auto)) 0.4rem repeat(2, minmax(2rem, auto));
+    gap: 2px;
+    padding: 0.4rem;
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+  }
+
+  .pt-cell {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: var(--c-bg-subtle);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    padding: 0.2rem 0.1rem;
+    cursor: pointer;
+    color: var(--c-text);
+    aspect-ratio: 1 / 1;
+    min-width: 0;
+    line-height: 1;
+  }
+
+  /* Block colours — kept low-saturation so dark + light themes both work. */
+  .pt-cell[data-block="s"] { background: var(--c-block-s, #f6dadf); color: #5a1a25; }
+  .pt-cell[data-block="p"] { background: var(--c-block-p, #fdeed1); color: #5a3a10; }
+  .pt-cell[data-block="d"] { background: var(--c-block-d, #d6e4f5); color: #1a3756; }
+  .pt-cell[data-block="f"] { background: var(--c-block-f, #d8efe1); color: #14442a; }
+
+  .pt-cell:hover { filter: brightness(1.06); }
+
+  .pt-cell.selected {
+    outline: 2px solid var(--c-accent);
+    outline-offset: 1px;
+    z-index: 1;
+  }
+
+  .pt-cell.highlighted {
+    box-shadow: 0 0 0 2px var(--c-gold) inset;
+  }
+
+  .pt-cell.disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+
+  .cell-z {
+    font-size: 0.55rem;
+    align-self: flex-start;
+    color: inherit;
+    opacity: 0.7;
+  }
+
+  .cell-sym {
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+</style>

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -12,40 +12,36 @@
     period: number;
     group: number | null;
   }
+
+  let tooltipIdCounter = 0;
 </script>
 
 <script lang="ts">
   import type { Snippet } from "svelte";
-  import { PERIODIC_TABLE } from "./periodic-table-data";
+  import { tick } from "svelte";
+  import { PERIODIC_TABLE, ELEMENT_BY_Z } from "./periodic-table-data";
 
   interface Props {
     onselect: (symbol: string) => void;
-    /** Symbol of the currently-selected element (renders with the
-     *  `.selected` highlight). */
+    /** Symbol of the currently-selected element. */
     selected?: string;
     /** Symbols whose cells should be greyed-out (e.g. no TENDL coverage
      *  for the active projectile). Disabled cells stay rendered and
-     *  keyboard-reachable; click is suppressed. Wired in later commits. */
+     *  keyboard-reachable; click is suppressed; the accessible name
+     *  carries the reason (", no TENDL data"). */
     disabled?: Set<string>;
-    /** Symbols that should pulse with a secondary highlight (e.g. rows
-     *  already present in the define-form). */
+    /** Symbols that should pulse with a secondary highlight. */
     highlighted?: Set<string>;
     /** Selection mode — "multi" is reserved for future work. */
     mode?: "single" | "multi";
-    /** When set, controls the "show Z>92" toggle externally. When unset,
-     *  the component owns the toggle internally (defaults to false —
-     *  i.e. transactinides hidden by default). The label "Z>92" is per
-     *  the domain-review correction: Th (Z=90) is a real production
-     *  target, not a transuranic. */
+    /** Controlled "show Z>92" toggle — when undefined the component
+     *  owns the toggle internally and renders the toggle button. */
     showTransuranics?: boolean;
-    /** Optional tooltip body. The PT owns positioning; the parent
-     *  renders content. (Not wired in this commit; landed in a later
-     *  Phase 1 commit alongside accessibility.) */
+    /** Optional tooltip body. Parent renders content; PT positions it
+     *  below the focused/hovered cell. */
     tooltip?: Snippet<[ElementInfo]>;
   }
 
-  // `tooltip` is declared in `Props` but bound only by the accessibility
-  // commit; not destructured here.
   let {
     onselect,
     selected,
@@ -53,6 +49,7 @@
     highlighted,
     mode = "single",
     showTransuranics,
+    tooltip,
   }: Props = $props();
 
   let showTransuranicsInternal = $state(false);
@@ -62,9 +59,135 @@
     effectiveShow ? PERIODIC_TABLE : PERIODIC_TABLE.filter((c) => c.Z <= 92),
   );
 
+  /** Visible cells grouped by data-row, sorted by column — the lookup
+   *  used for arrow-key navigation. */
+  let cellsByRow = $derived.by(() => {
+    const map = new Map<number, ElementCell[]>();
+    for (const cell of visibleCells) {
+      const arr = map.get(cell.row) ?? [];
+      arr.push(cell);
+      map.set(cell.row, arr);
+    }
+    for (const arr of map.values()) arr.sort((a, b) => a.col - b.col);
+    return map;
+  });
+
+  let visibleRows = $derived([...cellsByRow.keys()].sort((a, b) => a - b));
+
+  /** Roving-tabindex anchor — exactly one cell has tabindex=0 at a time. */
+  let focusedZ = $state(1);
+
+  /** Hover takes precedence over focus for tooltip target. */
+  let hoveredZ = $state<number | null>(null);
+
+  let activeZ = $derived(hoveredZ ?? focusedZ);
+  let activeCell = $derived(ELEMENT_BY_Z.get(activeZ) ?? null);
+
+  // Stable per-instance id for the tooltip element (used by aria-describedby).
+  let tooltipId = `pt-tooltip-${++tooltipIdCounter}`;
+
+  // If the focused cell becomes hidden (toggling Z>92 off while focused
+  // on a high-Z cell), fall back to H.
+  $effect(() => {
+    if (!visibleCells.some((c) => c.Z === focusedZ)) {
+      focusedZ = 1;
+    }
+  });
+
+  function gridRowFor(cell: ElementCell): number {
+    return cell.row >= 8 ? cell.row + 1 : cell.row;
+  }
+
+  function ariaLabelFor(cell: ElementCell): string {
+    const base = `${cell.name}, ${cell.Z}`;
+    return disabled?.has(cell.symbol) ? `${base}, no TENDL data` : base;
+  }
+
   function handleClick(cell: ElementCell): void {
+    focusedZ = cell.Z;
     if (disabled?.has(cell.symbol)) return;
     onselect(cell.symbol);
+  }
+
+  async function moveFocus(nextZ: number): Promise<void> {
+    if (nextZ === focusedZ) return;
+    focusedZ = nextZ;
+    await tick();
+    const el = document.querySelector<HTMLButtonElement>(
+      `[data-pt-tooltip-id="${tooltipId}"] [data-z="${nextZ}"]`,
+    );
+    el?.focus();
+  }
+
+  function neighbourSameRow(currentZ: number, dir: -1 | 1): number {
+    const cur = ELEMENT_BY_Z.get(currentZ);
+    if (!cur) return currentZ;
+    const row = cellsByRow.get(cur.row);
+    if (!row) return currentZ;
+    const idx = row.findIndex((c) => c.Z === currentZ);
+    const next = row[idx + dir];
+    return next?.Z ?? currentZ;
+  }
+
+  function neighbourCrossRow(currentZ: number, dir: -1 | 1): number {
+    const cur = ELEMENT_BY_Z.get(currentZ);
+    if (!cur) return currentZ;
+    // Walk visible rows in the requested direction, picking the first
+    // row that has any cell — this lets up/down skip over the spacer
+    // between row 7 and the lanthanide row.
+    const rows = visibleRows;
+    const idx = rows.indexOf(cur.row);
+    const targetRow = rows[idx + dir];
+    if (targetRow === undefined) return currentZ;
+    const candidates = cellsByRow.get(targetRow);
+    if (!candidates || candidates.length === 0) return currentZ;
+    let best = candidates[0];
+    let bestDelta = Math.abs(best.col - cur.col);
+    for (const c of candidates) {
+      const d = Math.abs(c.col - cur.col);
+      if (d < bestDelta) { best = c; bestDelta = d; }
+    }
+    return best.Z;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    let nextZ: number | null = null;
+
+    switch (event.key) {
+      case "ArrowLeft":  nextZ = neighbourSameRow(focusedZ, -1); break;
+      case "ArrowRight": nextZ = neighbourSameRow(focusedZ, 1); break;
+      case "ArrowUp":    nextZ = neighbourCrossRow(focusedZ, -1); break;
+      case "ArrowDown":  nextZ = neighbourCrossRow(focusedZ, 1); break;
+      case "Home": {
+        if (event.ctrlKey || event.metaKey) {
+          nextZ = 1;
+        } else {
+          const cur = ELEMENT_BY_Z.get(focusedZ);
+          const row = cur ? cellsByRow.get(cur.row) : undefined;
+          nextZ = row?.[0]?.Z ?? null;
+        }
+        break;
+      }
+      case "End": {
+        const cur = ELEMENT_BY_Z.get(focusedZ);
+        const row = cur ? cellsByRow.get(cur.row) : undefined;
+        nextZ = row?.[row.length - 1]?.Z ?? null;
+        break;
+      }
+      case "Enter":
+      case " ": {
+        const cell = ELEMENT_BY_Z.get(focusedZ);
+        if (cell) handleClick(cell);
+        event.preventDefault();
+        return;
+      }
+      default: return;
+    }
+
+    if (nextZ !== null) {
+      event.preventDefault();
+      void moveFocus(nextZ);
+    }
   }
 
   function toggleHighZ(): void {
@@ -74,27 +197,61 @@
   }
 </script>
 
-<div class="pt-wrap">
-  <div class="pt-grid" data-mode={mode}>
-    {#each visibleCells as cell (cell.Z)}
-      <button
-        class="pt-cell"
-        data-block={cell.block}
-        data-z={cell.Z}
-        class:selected={selected === cell.symbol}
-        class:highlighted={highlighted?.has(cell.symbol)}
-        class:disabled={disabled?.has(cell.symbol)}
-        style:grid-row={cell.row >= 8 ? cell.row + 1 : cell.row}
-        style:grid-column={cell.col}
-        type="button"
-        onclick={() => handleClick(cell)}
-      >
-        <span class="cell-z">{cell.Z}</span>
-        <span class="cell-sym">{cell.symbol}</span>
-        <span class="cell-block" aria-hidden="true">{cell.block}</span>
-      </button>
+<div class="pt-wrap" data-pt-tooltip-id={tooltipId}>
+  <div
+    role="grid"
+    aria-label="Periodic table"
+    class="pt-grid"
+    data-mode={mode}
+    tabindex={-1}
+    onkeydown={handleKeydown}
+  >
+    {#each visibleRows as row (row)}
+      <div role="row" aria-rowindex={row} class="pt-row">
+        {#each cellsByRow.get(row) ?? [] as cell (cell.Z)}
+          <button
+            role="gridcell"
+            type="button"
+            class="pt-cell"
+            data-block={cell.block}
+            data-z={cell.Z}
+            class:selected={selected === cell.symbol}
+            class:highlighted={highlighted?.has(cell.symbol)}
+            class:disabled={disabled?.has(cell.symbol)}
+            style:grid-row={gridRowFor(cell)}
+            style:grid-column={cell.col}
+            tabindex={focusedZ === cell.Z ? 0 : -1}
+            aria-colindex={cell.col}
+            aria-rowindex={row}
+            aria-label={ariaLabelFor(cell)}
+            aria-describedby={tooltip ? tooltipId : undefined}
+            aria-selected={selected === cell.symbol ? true : undefined}
+            onclick={() => handleClick(cell)}
+            onfocus={() => { focusedZ = cell.Z; }}
+            onmouseenter={() => { hoveredZ = cell.Z; }}
+            onmouseleave={() => { hoveredZ = null; }}
+          >
+            <span class="cell-z">{cell.Z}</span>
+            <span class="cell-sym">{cell.symbol}</span>
+            <span class="cell-block" aria-hidden="true">{cell.block}</span>
+          </button>
+        {/each}
+      </div>
     {/each}
   </div>
+
+  {#if tooltip && activeCell}
+    <div role="tooltip" id={tooltipId} class="pt-tooltip">
+      {@render tooltip({
+        Z: activeCell.Z,
+        symbol: activeCell.symbol,
+        name: activeCell.name,
+        block: activeCell.block,
+        period: activeCell.period,
+        group: activeCell.group,
+      })}
+    </div>
+  {/if}
 
   {#if showTransuranics === undefined}
     <button
@@ -109,7 +266,7 @@
   .pt-wrap {
     display: flex;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
     gap: 0.4rem;
   }
 
@@ -124,6 +281,10 @@
     border-radius: 4px;
     width: 100%;
   }
+
+  /* role="row" wrappers don't participate in CSS grid layout — cells
+     are direct grid items via display: contents on the row. */
+  .pt-row { display: contents; }
 
   .pt-cell {
     position: relative;
@@ -149,6 +310,15 @@
   .pt-cell[data-block="f"] { background: var(--c-block-f, #d8efe1); color: #14442a; }
 
   .pt-cell:hover { filter: brightness(1.06); }
+
+  /* Focus ring — wide black core with a white halo so the contrast
+     ratio stays ≥ 3:1 against every block colour (WCAG 2.4.13). */
+  .pt-cell:focus-visible {
+    outline: 2px solid #000;
+    outline-offset: 1px;
+    box-shadow: 0 0 0 4px #fff;
+    z-index: 2;
+  }
 
   .pt-cell.selected {
     outline: 2px solid var(--c-accent);
@@ -193,6 +363,15 @@
     letter-spacing: 0.02em;
   }
 
+  .pt-tooltip {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    padding: 0.4rem 0.6rem;
+    font-size: 0.75rem;
+    color: var(--c-text);
+  }
+
   .pt-toggle {
     background: var(--c-bg-subtle);
     border: 1px solid var(--c-border);
@@ -206,4 +385,8 @@
 
   .pt-toggle:hover { border-color: var(--c-accent); color: var(--c-text); }
   .pt-toggle[aria-pressed="true"] { background: var(--c-accent-tint-subtle); color: var(--c-accent); border-color: var(--c-accent); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .pt-cell { transition: none; }
+  }
 </style>

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -32,6 +32,12 @@
     highlighted?: Set<string>;
     /** Selection mode — "multi" is reserved for future work. */
     mode?: "single" | "multi";
+    /** When set, controls the "show Z>92" toggle externally. When unset,
+     *  the component owns the toggle internally (defaults to false —
+     *  i.e. transactinides hidden by default). The label "Z>92" is per
+     *  the domain-review correction: Th (Z=90) is a real production
+     *  target, not a transuranic. */
+    showTransuranics?: boolean;
     /** Optional tooltip body. The PT owns positioning; the parent
      *  renders content. (Not wired in this commit; landed in a later
      *  Phase 1 commit alongside accessibility.) */
@@ -46,35 +52,67 @@
     disabled,
     highlighted,
     mode = "single",
+    showTransuranics,
   }: Props = $props();
+
+  let showTransuranicsInternal = $state(false);
+  let effectiveShow = $derived(showTransuranics ?? showTransuranicsInternal);
+
+  let visibleCells = $derived(
+    effectiveShow ? PERIODIC_TABLE : PERIODIC_TABLE.filter((c) => c.Z <= 92),
+  );
 
   function handleClick(cell: ElementCell): void {
     if (disabled?.has(cell.symbol)) return;
     onselect(cell.symbol);
   }
+
+  function toggleHighZ(): void {
+    if (showTransuranics === undefined) {
+      showTransuranicsInternal = !showTransuranicsInternal;
+    }
+  }
 </script>
 
-<div class="pt-grid" data-mode={mode}>
-  {#each PERIODIC_TABLE as cell (cell.Z)}
+<div class="pt-wrap">
+  <div class="pt-grid" data-mode={mode}>
+    {#each visibleCells as cell (cell.Z)}
+      <button
+        class="pt-cell"
+        data-block={cell.block}
+        data-z={cell.Z}
+        class:selected={selected === cell.symbol}
+        class:highlighted={highlighted?.has(cell.symbol)}
+        class:disabled={disabled?.has(cell.symbol)}
+        style:grid-row={cell.row >= 8 ? cell.row + 1 : cell.row}
+        style:grid-column={cell.col}
+        type="button"
+        onclick={() => handleClick(cell)}
+      >
+        <span class="cell-z">{cell.Z}</span>
+        <span class="cell-sym">{cell.symbol}</span>
+        <span class="cell-block" aria-hidden="true">{cell.block}</span>
+      </button>
+    {/each}
+  </div>
+
+  {#if showTransuranics === undefined}
     <button
-      class="pt-cell"
-      data-block={cell.block}
-      data-z={cell.Z}
-      class:selected={selected === cell.symbol}
-      class:highlighted={highlighted?.has(cell.symbol)}
-      class:disabled={disabled?.has(cell.symbol)}
-      style:grid-row={cell.row >= 8 ? cell.row + 1 : cell.row}
-      style:grid-column={cell.col}
-      type="button"
-      onclick={() => handleClick(cell)}
-    >
-      <span class="cell-z">{cell.Z}</span>
-      <span class="cell-sym">{cell.symbol}</span>
-    </button>
-  {/each}
+      class="pt-toggle"
+      onclick={toggleHighZ}
+      aria-pressed={effectiveShow}
+    >{effectiveShow ? "Hide Z>92" : "Show Z>92"}</button>
+  {/if}
 </div>
 
 <style>
+  .pt-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.4rem;
+  }
+
   .pt-grid {
     display: grid;
     grid-template-columns: repeat(18, minmax(1.4rem, 1fr));
@@ -84,6 +122,7 @@
     background: var(--c-bg-default);
     border: 1px solid var(--c-border);
     border-radius: 4px;
+    width: 100%;
   }
 
   .pt-cell {
@@ -127,8 +166,10 @@
   }
 
   .cell-z {
+    position: absolute;
+    top: 0.15rem;
+    left: 0.2rem;
     font-size: 0.55rem;
-    align-self: flex-start;
     color: inherit;
     opacity: 0.7;
   }
@@ -137,4 +178,32 @@
     font-size: 0.85rem;
     font-weight: 600;
   }
+
+  /* Block glyph at bottom-left — non-colour channel for the s/p/d/f
+     classification (pitfall 12: don't rely on colour alone). */
+  .cell-block {
+    position: absolute;
+    bottom: 0.15rem;
+    left: 0.2rem;
+    font-size: 0.5rem;
+    font-weight: 700;
+    color: inherit;
+    opacity: 0.55;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+  }
+
+  .pt-toggle {
+    background: var(--c-bg-subtle);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    color: var(--c-text-muted);
+    padding: 0.25rem 0.6rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    align-self: flex-start;
+  }
+
+  .pt-toggle:hover { border-color: var(--c-accent); color: var(--c-text); }
+  .pt-toggle[aria-pressed="true"] { background: var(--c-accent-tint-subtle); color: var(--c-accent); border-color: var(--c-accent); }
 </style>

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -409,4 +409,15 @@
   @media (prefers-reduced-motion: reduce) {
     .pt-cell { transition: none; }
   }
+
+  /* Compact rendering on narrow viewports — at this width the parent
+     should hide the PT behind a toggle (Phase 2), but if it's shown
+     anyway the cells stay legible by dropping the Z and block-glyph
+     overlays. */
+  @media (max-width: 600px) {
+    .pt-grid { gap: 1px; padding: 0.25rem; }
+    .pt-cell { padding: 0.05rem; }
+    .cell-z, .cell-block, .cell-enrich { display: none; }
+    .cell-sym { font-size: 0.7rem; }
+  }
 </style>

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -78,25 +78,51 @@
     return map;
   });
 
-  let visibleRows = $derived([...cellsByRow.keys()].sort((a, b) => a - b));
+  /**
+   * Row traversal order for ArrowUp / ArrowDown. The visible PT
+   * organises detached lanthanide (data-row 8, period 6) and actinide
+   * (data-row 9, period 7) rows BELOW the main grid for layout
+   * reasons, but semantically (and for screen-reader logical order)
+   * row 8 sits between periods 6 and 7, and row 9 sits after period 7.
+   * Stepping from Ce (row 8) up should land on Hf/La (row 6), not
+   * Rf (row 7) — and Hf down should drop into Ce.
+   */
+  const ROW_ORDER = [1, 2, 3, 4, 5, 6, 8, 7, 9];
 
-  /** Roving-tabindex anchor — exactly one cell has tabindex=0 at a time. */
+  let visibleRows = $derived(ROW_ORDER.filter((r) => cellsByRow.has(r)));
+
+  /** Roving-tabindex anchor — exactly one cell has tabindex=0 at a time.
+   *  Also drives the tooltip target so screen readers reading the focused
+   *  cell never hear a description that belongs to a different cell. */
   let focusedZ = $state(1);
 
-  /** Hover takes precedence over focus for tooltip target. */
-  let hoveredZ = $state<number | null>(null);
-
-  let activeZ = $derived(hoveredZ ?? focusedZ);
-  let activeCell = $derived(ELEMENT_BY_Z.get(activeZ) ?? null);
+  let activeCell = $derived(ELEMENT_BY_Z.get(focusedZ) ?? null);
 
   // Stable per-instance id for the tooltip element (used by aria-describedby).
   let tooltipId = `pt-tooltip-${++tooltipIdCounter}`;
 
   // If the focused cell becomes hidden (toggling Z>92 off while focused
-  // on a high-Z cell), fall back to H.
+  // on a high-Z cell), fall back to the highest still-visible Z so the
+  // user keeps roughly their place — and re-focus the DOM since the old
+  // button has unmounted.
   $effect(() => {
     if (!visibleCells.some((c) => c.Z === focusedZ)) {
-      focusedZ = 1;
+      const fallback = visibleCells.reduce(
+        (best, c) => (c.Z > best ? c.Z : best),
+        1,
+      );
+      focusedZ = fallback;
+      void tick().then(() => {
+        const el = document.querySelector<HTMLButtonElement>(
+          `[data-pt-tooltip-id="${tooltipId}"] [data-z="${fallback}"]`,
+        );
+        // Only steal focus if focus was inside the grid before the
+        // current cell unmounted, otherwise we'd grab focus from
+        // unrelated UI on first mount.
+        if (el && document.activeElement && document.activeElement.closest(`[data-pt-tooltip-id="${tooltipId}"]`)) {
+          el.focus();
+        }
+      });
     }
   });
 
@@ -106,8 +132,13 @@
 
   function ariaLabelFor(cell: ElementCell): string {
     const parts = [cell.name, String(cell.Z)];
-    if (disabled?.has(cell.symbol)) parts.push("no TENDL data");
-    if (enrichableSet?.has(cell.symbol)) parts.push("enrichable");
+    if (disabled?.has(cell.symbol)) {
+      // When the cell is disabled the "enrichable" hint is misleading
+      // (you can't enrich a target with no TENDL coverage). Skip it.
+      parts.push("no TENDL data");
+    } else if (enrichableSet?.has(cell.symbol)) {
+      parts.push("enrichable");
+    }
     return parts.join(", ");
   }
 
@@ -230,14 +261,11 @@
             style:grid-column={cell.col}
             tabindex={focusedZ === cell.Z ? 0 : -1}
             aria-colindex={cell.col}
-            aria-rowindex={row}
             aria-label={ariaLabelFor(cell)}
-            aria-describedby={tooltip ? tooltipId : undefined}
+            aria-describedby={tooltip && focusedZ === cell.Z ? tooltipId : undefined}
             aria-selected={selected === cell.symbol ? true : undefined}
             onclick={() => handleClick(cell)}
             onfocus={() => { focusedZ = cell.Z; }}
-            onmouseenter={() => { hoveredZ = cell.Z; }}
-            onmouseleave={() => { hoveredZ = null; }}
           >
             <span class="cell-z">{cell.Z}</span>
             <span class="cell-sym">{cell.symbol}</span>
@@ -412,12 +440,18 @@
 
   /* Compact rendering on narrow viewports — at this width the parent
      should hide the PT behind a toggle (Phase 2), but if it's shown
-     anyway the cells stay legible by dropping the Z and block-glyph
-     overlays. */
+     anyway the cells stay legible by dropping the Z + corner overlays.
+     Block classification is then conveyed via border-style instead of
+     the (hidden) glyph so we don't fall back to a colour-only signal
+     (WCAG 1.4.1). */
   @media (max-width: 600px) {
     .pt-grid { gap: 1px; padding: 0.25rem; }
     .pt-cell { padding: 0.05rem; }
     .cell-z, .cell-block, .cell-enrich { display: none; }
     .cell-sym { font-size: 0.7rem; }
+    .pt-cell[data-block="s"] { border-style: solid; }
+    .pt-cell[data-block="p"] { border-style: dashed; }
+    .pt-cell[data-block="d"] { border-style: dotted; }
+    .pt-cell[data-block="f"] { border-style: double; border-width: 3px; }
   }
 </style>

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -32,6 +32,11 @@
     disabled?: Set<string>;
     /** Symbols that should pulse with a secondary highlight. */
     highlighted?: Set<string>;
+    /** Symbols whose isotopic composition can be enriched (i.e. have
+     *  ≥ 1 stable isotope on the supplier circuit). Rendered as a
+     *  small corner glyph on the cell. The follow-up "use enriched…"
+     *  shortcut lives in the parent's inspect panel. */
+    enrichableSet?: Set<string>;
     /** Selection mode — "multi" is reserved for future work. */
     mode?: "single" | "multi";
     /** Controlled "show Z>92" toggle — when undefined the component
@@ -47,6 +52,7 @@
     selected,
     disabled,
     highlighted,
+    enrichableSet,
     mode = "single",
     showTransuranics,
     tooltip,
@@ -99,8 +105,10 @@
   }
 
   function ariaLabelFor(cell: ElementCell): string {
-    const base = `${cell.name}, ${cell.Z}`;
-    return disabled?.has(cell.symbol) ? `${base}, no TENDL data` : base;
+    const parts = [cell.name, String(cell.Z)];
+    if (disabled?.has(cell.symbol)) parts.push("no TENDL data");
+    if (enrichableSet?.has(cell.symbol)) parts.push("enrichable");
+    return parts.join(", ");
   }
 
   function handleClick(cell: ElementCell): void {
@@ -234,6 +242,9 @@
             <span class="cell-z">{cell.Z}</span>
             <span class="cell-sym">{cell.symbol}</span>
             <span class="cell-block" aria-hidden="true">{cell.block}</span>
+            {#if enrichableSet?.has(cell.symbol)}
+              <span class="cell-enrich" aria-hidden="true">★</span>
+            {/if}
           </button>
         {/each}
       </div>
@@ -347,6 +358,15 @@
   .cell-sym {
     font-size: 0.85rem;
     font-weight: 600;
+  }
+
+  .cell-enrich {
+    position: absolute;
+    top: 0.1rem;
+    right: 0.2rem;
+    font-size: 0.55rem;
+    color: var(--c-gold);
+    line-height: 1;
   }
 
   /* Block glyph at bottom-left — non-colour channel for the s/p/d/f

--- a/frontend/src/lib/components/material/periodic-table-data.test.ts
+++ b/frontend/src/lib/components/material/periodic-table-data.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import { PERIODIC_TABLE, ELEMENT_BY_SYMBOL, ELEMENT_BY_Z } from "./periodic-table-data";
+
+describe("PERIODIC_TABLE — layout invariants", () => {
+  it("contains exactly 118 elements", () => {
+    expect(PERIODIC_TABLE).toHaveLength(118);
+  });
+
+  it("covers Z = 1..118 with no gaps and no duplicates", () => {
+    const zs = PERIODIC_TABLE.map((c) => c.Z).sort((a, b) => a - b);
+    expect(zs).toEqual(Array.from({ length: 118 }, (_, i) => i + 1));
+  });
+
+  it("places H at (1, 1) and He at (1, 18)", () => {
+    const h = ELEMENT_BY_Z.get(1)!;
+    const he = ELEMENT_BY_Z.get(2)!;
+    expect([h.row, h.col]).toEqual([1, 1]);
+    expect([he.row, he.col]).toEqual([1, 18]);
+  });
+
+  it("places La (Z=57) in main grid at row 6 col 3 (group 3)", () => {
+    const la = ELEMENT_BY_SYMBOL.get("La")!;
+    expect(la).toMatchObject({ row: 6, col: 3, group: 3, period: 6, block: "d" });
+  });
+
+  it("places Ac (Z=89) in main grid at row 7 col 3 (group 3)", () => {
+    const ac = ELEMENT_BY_SYMBOL.get("Ac")!;
+    expect(ac).toMatchObject({ row: 7, col: 3, group: 3, period: 7, block: "d" });
+  });
+
+  it("places lanthanides Ce..Lu on detached row 8 cols 4..17, all f-block", () => {
+    for (let z = 58; z <= 71; z++) {
+      const cell = ELEMENT_BY_Z.get(z)!;
+      expect(cell.row).toBe(8);
+      expect(cell.col).toBe(4 + (z - 58));
+      expect(cell.block).toBe("f");
+      expect(cell.period).toBe(6);
+      expect(cell.group).toBeNull();
+    }
+  });
+
+  it("places actinides Th..Lr on detached row 9 cols 4..17, all f-block", () => {
+    for (let z = 90; z <= 103; z++) {
+      const cell = ELEMENT_BY_Z.get(z)!;
+      expect(cell.row).toBe(9);
+      expect(cell.col).toBe(4 + (z - 90));
+      expect(cell.block).toBe("f");
+      expect(cell.period).toBe(7);
+      expect(cell.group).toBeNull();
+    }
+  });
+
+  it("places U (Z=92) in the actinide row at col 6", () => {
+    expect(ELEMENT_BY_Z.get(92)).toMatchObject({ row: 9, col: 6, period: 7, block: "f" });
+  });
+
+  it("period 4 forms a full 18-column row from K to Kr", () => {
+    for (let z = 19; z <= 36; z++) {
+      const cell = ELEMENT_BY_Z.get(z)!;
+      expect(cell.row).toBe(4);
+      expect(cell.col).toBe(z - 18);
+      expect(cell.period).toBe(4);
+    }
+  });
+
+  it("period 5 forms a full 18-column row from Rb to Xe", () => {
+    for (let z = 37; z <= 54; z++) {
+      const cell = ELEMENT_BY_Z.get(z)!;
+      expect(cell.row).toBe(5);
+      expect(cell.col).toBe(z - 36);
+      expect(cell.period).toBe(5);
+    }
+  });
+
+  it("period 2 elements are split across the s/p block (cols 1-2 + 13-18)", () => {
+    const cols: number[] = [];
+    for (let z = 3; z <= 10; z++) cols.push(ELEMENT_BY_Z.get(z)!.col);
+    expect(cols).toEqual([1, 2, 13, 14, 15, 16, 17, 18]);
+  });
+
+  it("blocks split: s (groups 1-2 + He), p (groups 13-18 except He), d (groups 3-12), f (lanthanides+actinides)", () => {
+    // s-block sanity
+    expect(ELEMENT_BY_SYMBOL.get("Li")!.block).toBe("s");
+    expect(ELEMENT_BY_SYMBOL.get("Ca")!.block).toBe("s");
+    expect(ELEMENT_BY_SYMBOL.get("He")!.block).toBe("s");
+    // p-block
+    expect(ELEMENT_BY_SYMBOL.get("B")!.block).toBe("p");
+    expect(ELEMENT_BY_SYMBOL.get("Ne")!.block).toBe("p");
+    expect(ELEMENT_BY_SYMBOL.get("Pb")!.block).toBe("p");
+    // d-block
+    expect(ELEMENT_BY_SYMBOL.get("Sc")!.block).toBe("d");
+    expect(ELEMENT_BY_SYMBOL.get("Fe")!.block).toBe("d");
+    expect(ELEMENT_BY_SYMBOL.get("Au")!.block).toBe("d");
+    // La/Ac sit in the d-block in the wide form (group 3)
+    expect(ELEMENT_BY_SYMBOL.get("La")!.block).toBe("d");
+    expect(ELEMENT_BY_SYMBOL.get("Ac")!.block).toBe("d");
+  });
+
+  it("every cell with a non-null group has 1 ≤ group ≤ 18", () => {
+    for (const cell of PERIODIC_TABLE) {
+      if (cell.group !== null) {
+        expect(cell.group).toBeGreaterThanOrEqual(1);
+        expect(cell.group).toBeLessThanOrEqual(18);
+      }
+    }
+  });
+
+  it("symbol and Z are unique across the table", () => {
+    const syms = new Set(PERIODIC_TABLE.map((c) => c.symbol));
+    expect(syms.size).toBe(PERIODIC_TABLE.length);
+    const zs = new Set(PERIODIC_TABLE.map((c) => c.Z));
+    expect(zs.size).toBe(PERIODIC_TABLE.length);
+  });
+});

--- a/frontend/src/lib/components/material/periodic-table-data.ts
+++ b/frontend/src/lib/components/material/periodic-table-data.ts
@@ -1,0 +1,245 @@
+/**
+ * Static periodic-table layout data — IUPAC 18-column wide form with
+ * detached lanthanide / actinide rows. Each cell carries everything the
+ * `PeriodicTable.svelte` component needs to render and identify it.
+ *
+ * Coordinate system:
+ * - Main grid spans rows 1..7 × cols 1..18.
+ * - Detached lanthanide row is row 8, cols 4..17 (Ce..Lu, 14 cells).
+ * - Detached actinide row is row 9, cols 4..17 (Th..Lr, 14 cells).
+ * - La (Z=57) and Ac (Z=89) sit in group 3 of their main-table periods.
+ */
+
+export type Block = "s" | "p" | "d" | "f";
+
+export interface ElementCell {
+  Z: number;
+  symbol: string;
+  name: string;
+  /** 1..7 for main grid, 8 for lanthanides, 9 for actinides. */
+  row: number;
+  /** 1..18. Detached rows use cols 4..17. */
+  col: number;
+  block: Block;
+  /** IUPAC period (1..7) — distinct from `row` for detached cells. */
+  period: number;
+  /** IUPAC group (1..18); null for f-block elements (no canonical group). */
+  group: number | null;
+}
+
+const PERIOD_BY_Z: Array<[number, number, number]> = [
+  [1, 2, 1], [3, 10, 2], [11, 18, 3], [19, 36, 4], [37, 54, 5], [55, 86, 6], [87, 118, 7],
+];
+
+function periodOf(Z: number): number {
+  for (const [lo, hi, p] of PERIOD_BY_Z) {
+    if (Z >= lo && Z <= hi) return p;
+  }
+  throw new Error(`Z=${Z} out of range`);
+}
+
+interface ElementSeed {
+  Z: number;
+  symbol: string;
+  name: string;
+}
+
+const ELEMENT_SEEDS: ElementSeed[] = [
+  { Z: 1, symbol: "H", name: "Hydrogen" },
+  { Z: 2, symbol: "He", name: "Helium" },
+  { Z: 3, symbol: "Li", name: "Lithium" },
+  { Z: 4, symbol: "Be", name: "Beryllium" },
+  { Z: 5, symbol: "B", name: "Boron" },
+  { Z: 6, symbol: "C", name: "Carbon" },
+  { Z: 7, symbol: "N", name: "Nitrogen" },
+  { Z: 8, symbol: "O", name: "Oxygen" },
+  { Z: 9, symbol: "F", name: "Fluorine" },
+  { Z: 10, symbol: "Ne", name: "Neon" },
+  { Z: 11, symbol: "Na", name: "Sodium" },
+  { Z: 12, symbol: "Mg", name: "Magnesium" },
+  { Z: 13, symbol: "Al", name: "Aluminium" },
+  { Z: 14, symbol: "Si", name: "Silicon" },
+  { Z: 15, symbol: "P", name: "Phosphorus" },
+  { Z: 16, symbol: "S", name: "Sulfur" },
+  { Z: 17, symbol: "Cl", name: "Chlorine" },
+  { Z: 18, symbol: "Ar", name: "Argon" },
+  { Z: 19, symbol: "K", name: "Potassium" },
+  { Z: 20, symbol: "Ca", name: "Calcium" },
+  { Z: 21, symbol: "Sc", name: "Scandium" },
+  { Z: 22, symbol: "Ti", name: "Titanium" },
+  { Z: 23, symbol: "V", name: "Vanadium" },
+  { Z: 24, symbol: "Cr", name: "Chromium" },
+  { Z: 25, symbol: "Mn", name: "Manganese" },
+  { Z: 26, symbol: "Fe", name: "Iron" },
+  { Z: 27, symbol: "Co", name: "Cobalt" },
+  { Z: 28, symbol: "Ni", name: "Nickel" },
+  { Z: 29, symbol: "Cu", name: "Copper" },
+  { Z: 30, symbol: "Zn", name: "Zinc" },
+  { Z: 31, symbol: "Ga", name: "Gallium" },
+  { Z: 32, symbol: "Ge", name: "Germanium" },
+  { Z: 33, symbol: "As", name: "Arsenic" },
+  { Z: 34, symbol: "Se", name: "Selenium" },
+  { Z: 35, symbol: "Br", name: "Bromine" },
+  { Z: 36, symbol: "Kr", name: "Krypton" },
+  { Z: 37, symbol: "Rb", name: "Rubidium" },
+  { Z: 38, symbol: "Sr", name: "Strontium" },
+  { Z: 39, symbol: "Y", name: "Yttrium" },
+  { Z: 40, symbol: "Zr", name: "Zirconium" },
+  { Z: 41, symbol: "Nb", name: "Niobium" },
+  { Z: 42, symbol: "Mo", name: "Molybdenum" },
+  { Z: 43, symbol: "Tc", name: "Technetium" },
+  { Z: 44, symbol: "Ru", name: "Ruthenium" },
+  { Z: 45, symbol: "Rh", name: "Rhodium" },
+  { Z: 46, symbol: "Pd", name: "Palladium" },
+  { Z: 47, symbol: "Ag", name: "Silver" },
+  { Z: 48, symbol: "Cd", name: "Cadmium" },
+  { Z: 49, symbol: "In", name: "Indium" },
+  { Z: 50, symbol: "Sn", name: "Tin" },
+  { Z: 51, symbol: "Sb", name: "Antimony" },
+  { Z: 52, symbol: "Te", name: "Tellurium" },
+  { Z: 53, symbol: "I", name: "Iodine" },
+  { Z: 54, symbol: "Xe", name: "Xenon" },
+  { Z: 55, symbol: "Cs", name: "Caesium" },
+  { Z: 56, symbol: "Ba", name: "Barium" },
+  { Z: 57, symbol: "La", name: "Lanthanum" },
+  { Z: 58, symbol: "Ce", name: "Cerium" },
+  { Z: 59, symbol: "Pr", name: "Praseodymium" },
+  { Z: 60, symbol: "Nd", name: "Neodymium" },
+  { Z: 61, symbol: "Pm", name: "Promethium" },
+  { Z: 62, symbol: "Sm", name: "Samarium" },
+  { Z: 63, symbol: "Eu", name: "Europium" },
+  { Z: 64, symbol: "Gd", name: "Gadolinium" },
+  { Z: 65, symbol: "Tb", name: "Terbium" },
+  { Z: 66, symbol: "Dy", name: "Dysprosium" },
+  { Z: 67, symbol: "Ho", name: "Holmium" },
+  { Z: 68, symbol: "Er", name: "Erbium" },
+  { Z: 69, symbol: "Tm", name: "Thulium" },
+  { Z: 70, symbol: "Yb", name: "Ytterbium" },
+  { Z: 71, symbol: "Lu", name: "Lutetium" },
+  { Z: 72, symbol: "Hf", name: "Hafnium" },
+  { Z: 73, symbol: "Ta", name: "Tantalum" },
+  { Z: 74, symbol: "W", name: "Tungsten" },
+  { Z: 75, symbol: "Re", name: "Rhenium" },
+  { Z: 76, symbol: "Os", name: "Osmium" },
+  { Z: 77, symbol: "Ir", name: "Iridium" },
+  { Z: 78, symbol: "Pt", name: "Platinum" },
+  { Z: 79, symbol: "Au", name: "Gold" },
+  { Z: 80, symbol: "Hg", name: "Mercury" },
+  { Z: 81, symbol: "Tl", name: "Thallium" },
+  { Z: 82, symbol: "Pb", name: "Lead" },
+  { Z: 83, symbol: "Bi", name: "Bismuth" },
+  { Z: 84, symbol: "Po", name: "Polonium" },
+  { Z: 85, symbol: "At", name: "Astatine" },
+  { Z: 86, symbol: "Rn", name: "Radon" },
+  { Z: 87, symbol: "Fr", name: "Francium" },
+  { Z: 88, symbol: "Ra", name: "Radium" },
+  { Z: 89, symbol: "Ac", name: "Actinium" },
+  { Z: 90, symbol: "Th", name: "Thorium" },
+  { Z: 91, symbol: "Pa", name: "Protactinium" },
+  { Z: 92, symbol: "U", name: "Uranium" },
+  { Z: 93, symbol: "Np", name: "Neptunium" },
+  { Z: 94, symbol: "Pu", name: "Plutonium" },
+  { Z: 95, symbol: "Am", name: "Americium" },
+  { Z: 96, symbol: "Cm", name: "Curium" },
+  { Z: 97, symbol: "Bk", name: "Berkelium" },
+  { Z: 98, symbol: "Cf", name: "Californium" },
+  { Z: 99, symbol: "Es", name: "Einsteinium" },
+  { Z: 100, symbol: "Fm", name: "Fermium" },
+  { Z: 101, symbol: "Md", name: "Mendelevium" },
+  { Z: 102, symbol: "No", name: "Nobelium" },
+  { Z: 103, symbol: "Lr", name: "Lawrencium" },
+  { Z: 104, symbol: "Rf", name: "Rutherfordium" },
+  { Z: 105, symbol: "Db", name: "Dubnium" },
+  { Z: 106, symbol: "Sg", name: "Seaborgium" },
+  { Z: 107, symbol: "Bh", name: "Bohrium" },
+  { Z: 108, symbol: "Hs", name: "Hassium" },
+  { Z: 109, symbol: "Mt", name: "Meitnerium" },
+  { Z: 110, symbol: "Ds", name: "Darmstadtium" },
+  { Z: 111, symbol: "Rg", name: "Roentgenium" },
+  { Z: 112, symbol: "Cn", name: "Copernicium" },
+  { Z: 113, symbol: "Nh", name: "Nihonium" },
+  { Z: 114, symbol: "Fl", name: "Flerovium" },
+  { Z: 115, symbol: "Mc", name: "Moscovium" },
+  { Z: 116, symbol: "Lv", name: "Livermorium" },
+  { Z: 117, symbol: "Ts", name: "Tennessine" },
+  { Z: 118, symbol: "Og", name: "Oganesson" },
+];
+
+function placeMain(Z: number): { row: number; col: number; block: Block; period: number; group: number | null } {
+  const period = periodOf(Z);
+
+  if (Z === 1) return { row: 1, col: 1, block: "s", period: 1, group: 1 };
+  if (Z === 2) return { row: 1, col: 18, block: "s", period: 1, group: 18 };
+
+  // Period 2 / 3: 2 + 6 layout
+  if (period === 2 || period === 3) {
+    const baseLi = period === 2 ? 3 : 11;
+    const offset = Z - baseLi;
+    if (offset <= 1) return { row: period, col: offset + 1, block: "s", period, group: offset + 1 };
+    const col = offset - 2 + 13;
+    return { row: period, col, block: "p", period, group: col };
+  }
+
+  // Period 4 / 5: full 18-wide row
+  if (period === 4 || period === 5) {
+    const baseG1 = period === 4 ? 19 : 37;
+    const offset = Z - baseG1;
+    const col = offset + 1;
+    let block: Block;
+    if (col <= 2) block = "s";
+    else if (col <= 12) block = "d";
+    else block = "p";
+    return { row: period, col, block, period, group: col };
+  }
+
+  // Period 6: Cs(55,g1), Ba(56,g2), La(57,g3 main), [Ce..Lu detached], Hf(72,g4)..Rn(86,g18)
+  if (period === 6) {
+    if (Z === 55) return { row: 6, col: 1, block: "s", period: 6, group: 1 };
+    if (Z === 56) return { row: 6, col: 2, block: "s", period: 6, group: 2 };
+    if (Z === 57) return { row: 6, col: 3, block: "d", period: 6, group: 3 };
+    if (Z >= 58 && Z <= 71) {
+      // Detached lanthanide row, Ce..Lu at cols 4..17
+      const col = (Z - 58) + 4;
+      return { row: 8, col, block: "f", period: 6, group: null };
+    }
+    // Hf(72)..Rn(86) → cols 4..18
+    const col = (Z - 72) + 4;
+    let block: Block;
+    if (col <= 12) block = "d";
+    else block = "p";
+    return { row: 6, col, block, period: 6, group: col };
+  }
+
+  // Period 7: same shape — Fr(87,g1), Ra(88,g2), Ac(89,g3), [Th..Lr detached], Rf(104,g4)..Og(118,g18)
+  if (period === 7) {
+    if (Z === 87) return { row: 7, col: 1, block: "s", period: 7, group: 1 };
+    if (Z === 88) return { row: 7, col: 2, block: "s", period: 7, group: 2 };
+    if (Z === 89) return { row: 7, col: 3, block: "d", period: 7, group: 3 };
+    if (Z >= 90 && Z <= 103) {
+      const col = (Z - 90) + 4;
+      return { row: 9, col, block: "f", period: 7, group: null };
+    }
+    const col = (Z - 104) + 4;
+    let block: Block;
+    if (col <= 12) block = "d";
+    else block = "p";
+    return { row: 7, col, block, period: 7, group: col };
+  }
+
+  throw new Error(`Unhandled Z=${Z}`);
+}
+
+export const PERIODIC_TABLE: ElementCell[] = ELEMENT_SEEDS.map((seed) => ({
+  ...seed,
+  ...placeMain(seed.Z),
+}));
+
+/** Lookup map: symbol → cell. */
+export const ELEMENT_BY_SYMBOL: Map<string, ElementCell> = new Map(
+  PERIODIC_TABLE.map((cell) => [cell.symbol, cell]),
+);
+
+/** Lookup map: Z → cell. */
+export const ELEMENT_BY_Z: Map<number, ElementCell> = new Map(
+  PERIODIC_TABLE.map((cell) => [cell.Z, cell]),
+);

--- a/frontend/src/lib/compute/data-store.test.ts
+++ b/frontend/src/lib/compute/data-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { DataStore } from "./data-store";
+
+/**
+ * Coverage-cache behavior of `DataStore.hasCrossSections`. The helper is sync
+ * and reads from the in-memory `xsCache`; we exercise that contract without
+ * touching the network by reaching into the cache directly via a subclass.
+ */
+class TestableDataStore extends DataStore {
+  primeXsCache(projectile: string, symbol: string, hasData: boolean): void {
+    // Access the private xsCache via the runtime — vitest is not strict about
+    // visibility and this is the simplest way to seed coverage state.
+    const cache = (this as unknown as { xsCache: Map<string, unknown[]> }).xsCache;
+    cache.set(`${projectile}_${symbol}`, hasData ? [{ stub: 1 }] : []);
+  }
+
+  primeZToSymbol(z: number, sym: string): void {
+    const map = (this as unknown as { zToSymbol: Map<number, string> }).zToSymbol;
+    map.set(z, sym);
+  }
+}
+
+describe("DataStore.hasCrossSections", () => {
+  it("returns false when no entry is cached", () => {
+    const db = new TestableDataStore("/data");
+    expect(db.hasCrossSections("p", 26)).toBe(false);
+  });
+
+  it("returns false for a cached but empty entry", () => {
+    const db = new TestableDataStore("/data");
+    db.primeXsCache("p", "Fe", false);
+    expect(db.hasCrossSections("p", 26)).toBe(false);
+  });
+
+  it("returns true when the cache has non-empty data", () => {
+    const db = new TestableDataStore("/data");
+    db.primeXsCache("p", "Fe", true);
+    expect(db.hasCrossSections("p", 26)).toBe(true);
+  });
+
+  it("uses the dynamic zToSymbol map when present (e.g. after meta load)", () => {
+    const db = new TestableDataStore("/data");
+    db.primeZToSymbol(26, "Fe");
+    db.primeXsCache("p", "Fe", true);
+    expect(db.hasCrossSections("p", 26)).toBe(true);
+  });
+
+  it("falls back to the hardcoded element table when zToSymbol is empty", () => {
+    // Pre-meta-load: zToSymbol map is empty, but the helper should still work
+    // for the standard 1..92 range from the hardcoded fallback.
+    const db = new TestableDataStore("/data");
+    db.primeXsCache("d", "Mo", true);
+    expect(db.hasCrossSections("d", 42)).toBe(true);
+  });
+
+  it("is keyed by projectile — alpha vs proton are distinct caches", () => {
+    const db = new TestableDataStore("/data");
+    db.primeXsCache("p", "Fe", true);
+    expect(db.hasCrossSections("p", 26)).toBe(true);
+    expect(db.hasCrossSections("a", 26)).toBe(false);
+  });
+
+  it("returns false for an unknown Z (out of fallback range)", () => {
+    const db = new TestableDataStore("/data");
+    expect(db.hasCrossSections("p", 999)).toBe(false);
+  });
+});

--- a/frontend/src/lib/compute/data-store.ts
+++ b/frontend/src/lib/compute/data-store.ts
@@ -227,6 +227,13 @@ export class DataStore implements DatabaseProtocol {
 
   // --- DatabaseProtocol methods ---
 
+  hasCrossSections(projectile: string, Z: number): boolean {
+    const symbol = this.zToSymbol.get(Z) ?? ELEMENT_SYMBOLS[Z];
+    if (!symbol) return false;
+    const rows = this.xsCache.get(`${projectile}_${symbol}`);
+    return !!rows && rows.length > 0;
+  }
+
   getCrossSections(
     projectile: string,
     targetZ: number,

--- a/frontend/src/lib/compute/materials.test.ts
+++ b/frontend/src/lib/compute/materials.test.ts
@@ -26,6 +26,7 @@ function makeStubDb(): DatabaseProtocol {
   };
   return {
     getCrossSections: () => [],
+    hasCrossSections: () => false,
     getStoppingPower: () => ({ energiesMeV: new Float64Array(), dedx: new Float64Array() }),
     getNaturalAbundances: (Z) => naturalAbundances[Z] ?? new Map(),
     getDecayData: () => null,

--- a/frontend/src/lib/compute/types.ts
+++ b/frontend/src/lib/compute/types.ts
@@ -49,6 +49,13 @@ export interface DatabaseProtocol {
     targetA: number,
   ): CrossSectionData[];
 
+  /**
+   * Synchronous coverage check — true if any cross-section data is loaded for
+   * the given (projectile, Z) target. Reads from cache only; the caller is
+   * responsible for first awaiting the relevant ensure*CrossSections call.
+   */
+  hasCrossSections(projectile: string, Z: number): boolean;
+
   getStoppingPower(
     source: string,
     targetZ: number,


### PR DESCRIPTION
## Summary
Phase 1 of #64 — standalone \`PeriodicTable.svelte\` component. Not wired into \`MaterialPopup\` yet (that's Phase 2).

- IUPAC 18×7 wide-form layout + detached lanthanide / actinide rows. Layout data in \`material/periodic-table-data.ts\` covers all 118 elements.
- Block colour (s/p/d/f) **plus** a 1-letter block glyph at bottom-left, so the s/p/d/f channel survives WCAG 1.4.1 even when the colour cue is unavailable.
- Full a11y wiring: \`role=grid\` / \`role=row\` (via \`display: contents\`) / \`role=gridcell\`, \`aria-colindex\`, roving tabindex, arrow-key skip-empty, Home / End / Ctrl+Home, Enter / Space activate. Disabled cells stay keyboard-reachable with \`", no TENDL data"\` appended to the accessible name (pitfall 11).
- "Show Z>92" toggle (label per the domain-review correction — Th at Z=90 is a real production target). Controlled and uncontrolled modes.
- Enrichment-availability badge (\`enrichableSet?: Set<string>\` prop → corner-glyph + name suffix).
- New \`DatabaseProtocol.hasCrossSections(projectile, Z): boolean\` (sync, cache-only) — the data-layer foundation Phase 2 will use to compute the disabled set.
- Defensive mobile compact CSS at <600px keeps cells legible if the parent renders the PT on a narrow viewport, with per-block \`border-style\` so the s/p/d/f channel survives even when the glyph is dropped.

## Reviews
- Implementation-match (fresh agent vs. locked Phase 1 spec in #64): ship; 8 nits, all polish.
- WCAG 2.2 specialist: 2 blockers + 5 concerns. Both blockers fixed in \`9624762\` (cross-row arrow nav with explicit \`ROW_ORDER [1,2,3,4,5,6,8,7,9]\`; tooltip + \`aria-describedby\` driven by \`focusedZ\` only). Three concerns also picked up in that fix commit. Two remaining concerns deferred to #76 (PT polish: disabled-cell live-region announcement + focus-ring halo doc).

## Verification
- \`svelte-check --threshold error\`: clean (only the two pre-existing baseline errors on \`main\`).
- \`vitest run\`: **297 / 297** pass (was 276 — adds 7 \`hasCrossSections\` cases + 12 \`periodic-table-data\` layout invariants).
- \`playwright test\`: **68 / 68** pass across desktop-1280 / iphone-se / iphone-14 / ipad (1m 30s).

## Scope
Phase 1 only. Phase 2 (PT integration into \`MaterialPopup\`), Phase 3 (rows-based define-form), and Phase 4 (component DOM tests) each get their own \`/land\` cycle.

## Test plan
- [ ] Mount \`<PeriodicTable />\` in isolation; verify all 118 cells render in IUPAC layout (H 1,1; He 1,18; La 6,3; Ce..Lu detached row 4..17; Ac 7,3; Th..Lr detached).
- [ ] Tab into the grid → exactly one cell focusable (default: H). Arrow-right from Be → B (skips empty cols 3-12).
- [ ] Arrow-down from Ce → La (or Hf — semantic parent row, not Rf in row 7).
- [ ] Toggle "Show Z>92" → high-Z cells appear; toggle off → focus falls back to the highest still-visible Z (not H).
- [ ] Pass a \`disabled\` set → cells appear greyed and keyboard-reachable; click is suppressed; SR reads "X, Z, no TENDL data".
- [ ] Pass an \`enrichableSet\` → cells get a star glyph and ", enrichable" suffix (suppressed when also disabled).
- [ ] Pass a \`tooltip\` snippet → tooltip renders for the focused cell only; \`aria-describedby\` points at it from that cell only.

## Follow-ups
- #76 — PT polish (disabled-cell announcement, focus-ring halo doc)
- Phase 2 — wire PT into \`MaterialPopup\`'s \`view: "table"\` branch

Refs: #64