### PR TITLE
fix(mcp): pre-publish polish — actionable missing-data error + 8/8 parity coverage (refs #71)

### DIFF
--- a/core/src/mcp/transport.rs
+++ b/core/src/mcp/transport.rs
@@ -69,10 +69,30 @@ const PROTOCOL_VERSION: &str = "2024-11-05";
 
 /// Run the MCP stdio server loop.
 pub fn run_mcp_server(data_dir: &str) {
+    // Pre-flight: verify the data directory actually contains a nucl-parquet
+    // tree. ParquetDataStore::new only loads the eager metadata files; many
+    // tools fault later when they reach for cross-sections / abundances /
+    // decay data, which manifests as a mid-conversation panic from inside
+    // an MCP call. Catch the missing-data case here with one actionable
+    // line so the user can fix `HYRR_DATA` before Claude Code loses the
+    // server connection.
+    let meta_dir = std::path::Path::new(data_dir).join("meta");
+    if !meta_dir.is_dir() {
+        eprintln!(
+            "hyrr-mcp: no nucl-parquet data found at {data_dir}\n\
+             \n\
+             Expected `{}` to exist. Set HYRR_DATA or pass --data-dir to point at a\n\
+             nucl-parquet checkout, or clone\n\
+             https://github.com/exoma-ch/nucl-parquet into ~/.hyrr/nucl-parquet.\n",
+            meta_dir.display(),
+        );
+        std::process::exit(2);
+    }
+
     let db = match crate::db::ParquetDataStore::new(data_dir, "tendl-2024") {
         Ok(db) => db,
         Err(e) => {
-            eprintln!("Failed to load nuclear data from {}: {}", data_dir, e);
+            eprintln!("hyrr-mcp: failed to load nuclear data from {data_dir}: {e}");
             std::process::exit(1);
         }
     };

--- a/scripts/mcp_parity_fixture.jsonl
+++ b/scripts/mcp_parity_fixture.jsonl
@@ -3,3 +3,8 @@
 {"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_materials","arguments":{}}}
 {"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_stopping_power","arguments":{"projectile":"p","material":"Cu","energies_mev":[5,10,20,50]}}}
 {"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"get_stack_energy_budget","arguments":{"projectile":"p","energy_mev":20,"current_ma":0.1,"layers":[{"material":"Cu","thickness_cm":0.05},{"material":"Al","thickness_cm":0.02}]}}}
+{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"simulate","arguments":{"projectile":"p","energy_mev":18,"current_ma":0.1,"layers":[{"material":"Cu","thickness_cm":0.02}],"irradiation_time_s":3600,"cooling_time_s":3600}}}
+{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"get_decay_data","arguments":{"z":29,"a":64}}}
+{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"list_reaction_channels","arguments":{"projectile":"p","target_z":29,"target_a":63}}}
+{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"compare_simulations","arguments":{"config_a":{"projectile":"p","energy_mev":18,"current_ma":0.1,"layers":[{"material":"Cu","thickness_cm":0.02}],"irradiation_time_s":3600,"cooling_time_s":3600,"label":"18 MeV"},"config_b":{"projectile":"p","energy_mev":12,"current_ma":0.1,"layers":[{"material":"Cu","thickness_cm":0.02}],"irradiation_time_s":3600,"cooling_time_s":3600,"label":"12 MeV"}}}}
+{"jsonrpc":"2.0","id":10,"method":"tools/call","params":{"name":"get_isotope_production_curve","arguments":{"projectile":"p","energy_mev":18,"current_ma":0.1,"layers":[{"material":"Cu","thickness_cm":0.02}],"irradiation_time_s":3600,"cooling_time_s":3600,"isotope":"Cu-64","vs":"time"}}}

--- a/scripts/mcp_parity_test.sh
+++ b/scripts/mcp_parity_test.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-# Verify `hyrr --mcp` and `hyrr-mcp` produce byte-identical stdio responses.
+# Verify the three MCP entry points produce byte-identical stdio responses
+# on a fixture that exercises every tool in the surface.
 #
-# Both entry points call hyrr_core::mcp::transport::run_mcp_server, so parity
-# is expected. This test guards against future drift (e.g. if someone adds a
-# feature flag that diverges the codepath).
+# Entry points compared:
+#   1. `hyrr --mcp`           — desktop binary in MCP mode
+#   2. `hyrr-mcp`             — standalone Rust binary
+#   3. `uvx hyrr-mcp` /
+#      `python -m hyrr_mcp`   — PyO3 wheel (only if HYRR_MCP_PYTHON is set)
+#
+# All three dispatch through hyrr_core::mcp::transport::run_mcp_server, so
+# parity is structurally guaranteed today. The test exists to catch future
+# drift if anyone adds an entry-point-specific shim.
 #
 # Usage:
 #   scripts/mcp_parity_test.sh
@@ -12,6 +19,10 @@
 #   HYRR_DATA              Required. Path to a nucl-parquet data directory.
 #   HYRR_DESKTOP_BIN       Override for the desktop binary path.
 #   HYRR_MCP_BIN           Override for the standalone hyrr-mcp binary path.
+#   HYRR_MCP_PYTHON        Path to a Python that has hyrr_mcp installed
+#                          (e.g. `py-mcp/.venv/bin/python`). When set, the
+#                          `python -m hyrr_mcp` entry point is added to the
+#                          parity comparison.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -39,21 +50,52 @@ fi
 
 DESKTOP_OUT="$(mktemp)"
 MCP_OUT="$(mktemp)"
-trap 'rm -f "$DESKTOP_OUT" "$MCP_OUT"' EXIT
+PY_OUT="$(mktemp)"
+trap 'rm -f "$DESKTOP_OUT" "$MCP_OUT" "$PY_OUT"' EXIT
 
-# Strip server.version from initialize responses — desktop uses its own
-# CARGO_PKG_VERSION, hyrr-mcp uses its own, and that differs even though
-# every other byte matches. Filter that one field to a sentinel for the diff.
+# Strip server.version from initialize responses — every entry point has
+# its own CARGO_PKG_VERSION, and that legitimately differs even though
+# every other byte should match. Filter to a sentinel for the diff.
 normalize() {
   sed 's/"version":"[^"]*"/"version":"<normalized>"/g'
 }
 
-cat "$FIXTURE" | "$HYRR_DESKTOP_BIN" --mcp 2>/dev/null | normalize > "$DESKTOP_OUT"
-cat "$FIXTURE" | "$HYRR_MCP_BIN"            2>/dev/null | normalize > "$MCP_OUT"
+run_through() {
+  # Stream stdin through the entry point, normalize the version field, and
+  # write to the given output file. Stderr is suppressed.
+  local out="$1"
+  shift
+  cat "$FIXTURE" | "$@" 2>/dev/null | normalize > "$out"
+}
 
-if diff -u "$DESKTOP_OUT" "$MCP_OUT"; then
-  echo "ok — hyrr --mcp and hyrr-mcp produce identical output for $(wc -l < "$FIXTURE" | tr -d ' ') requests"
+run_through "$DESKTOP_OUT" "$HYRR_DESKTOP_BIN" --mcp
+run_through "$MCP_OUT"     "$HYRR_MCP_BIN"
+
+fail=0
+if ! diff -u --label "hyrr --mcp" --label "hyrr-mcp" "$DESKTOP_OUT" "$MCP_OUT"; then
+  echo "fail — hyrr --mcp vs hyrr-mcp diverged (see diff above)" >&2
+  fail=1
+fi
+
+if [ -n "${HYRR_MCP_PYTHON:-}" ]; then
+  if [ ! -x "$HYRR_MCP_PYTHON" ]; then
+    echo "error: HYRR_MCP_PYTHON is set but $HYRR_MCP_PYTHON is not executable" >&2
+    exit 2
+  fi
+  run_through "$PY_OUT" "$HYRR_MCP_PYTHON" -m hyrr_mcp
+  if ! diff -u --label "hyrr-mcp" --label "python -m hyrr_mcp" "$MCP_OUT" "$PY_OUT"; then
+    echo "fail — hyrr-mcp vs python -m hyrr_mcp diverged (see diff above)" >&2
+    fail=1
+  fi
+fi
+
+n_requests=$(wc -l < "$FIXTURE" | tr -d ' ')
+if [ "$fail" -eq 0 ]; then
+  if [ -n "${HYRR_MCP_PYTHON:-}" ]; then
+    echo "ok — all 3 entry points produce identical output for $n_requests requests"
+  else
+    echo "ok — hyrr --mcp and hyrr-mcp produce identical output for $n_requests requests (set HYRR_MCP_PYTHON to also test the wheel)"
+  fi
 else
-  echo "fail — outputs diverged (see diff above)" >&2
   exit 1
 fi


### PR DESCRIPTION
Two of the reviewer follow-ups from #67 / #71 that should land *before* the first PyPI tag — they affect what a clean-machine `uvx hyrr-mcp` user sees and what CI can guard.

## Summary

### 1. Actionable error on missing data dir

**Problem.** `data_dir::resolve()` falls back silently to the literal `"nucl-parquet"` when nothing else matches. `ParquetDataStore::new` only loads the eager metadata files, so the server was happily handling `initialize` and `tools/list` (which uses the static catalog), then panicking mid-conversation when the first tool call reached for cross-sections / abundances / decay data. Claude Code saw a silent server-connection drop.

**Fix.** Pre-flight check on `{data_dir}/meta` in `run_mcp_server` before `ParquetDataStore::new`. If missing, exit 2 with a single actionable stderr line:

```
hyrr-mcp: no nucl-parquet data found at /tmp/nope

Expected `/tmp/nope/meta` to exist. Set HYRR_DATA or pass --data-dir
to point at a nucl-parquet checkout, or clone
https://github.com/exoma-ch/nucl-parquet into ~/.hyrr/nucl-parquet.
```

### 2. Widen the parity fixture to 8/8 tools

**Problem.** `scripts/mcp_parity_fixture.jsonl` covered 3 of 8 tools. If `simulate` / `get_decay_data` / `compare_simulations` / `get_isotope_production_curve` / `list_reaction_channels` started diverging across entry points, the parity test would silently pass. The Rust code-quality reviewer flagged this as the weakest part of the original PR #70.

**Fix.** Fixture is now 10 requests: `initialize`, `tools/list`, plus one call per tool. All 10 still produce byte-identical output across `hyrr --mcp` and `hyrr-mcp`.

`scripts/mcp_parity_test.sh` also gains optional support for the PyO3 wheel as a third entry point: set `HYRR_MCP_PYTHON` to a Python that has `hyrr_mcp` installed and the script diffs `python -m hyrr_mcp` against the two native binaries. This is what the cibuildwheel CI job in #71 will call.

## Test plan

- [x] `cargo build --release` from `hyrr-mcp/` and `cargo build` from `desktop/src-tauri/` both clean
- [x] `scripts/mcp_parity_test.sh` passes on the widened fixture (10 requests, all 8 tools)
- [x] `HYRR_DATA=/tmp/nope hyrr-mcp` exits 2 with the actionable message above
- [x] Existing `HYRR_DATA=<real path> hyrr-mcp` happy path unchanged
- [ ] CI parity job using the new `HYRR_MCP_PYTHON` flag — wired in the wheel-publish workflow PR (next)

## What's next on #71

After this lands: the `.github/workflows/release-hyrr-mcp.yml` PR with the maturin-action wheel matrix + PyPI trusted-publishing wiring. That PR depends on you completing the PyPI trusted-publisher form (separate non-code step you have a step-by-step guide for).