### PR TITLE
refactor(mcp): cosmetics — depth-rates assert + sort rename + classifiers (refs #71)

### DIFF
--- a/core/src/mcp/tools.rs
+++ b/core/src/mcp/tools.rs
@@ -598,10 +598,16 @@ fn tool_compare_simulations(db: &dyn DatabaseProtocol, args: &Value) -> Result<S
     let mut all_names: Vec<String> = iso_a.keys().chain(iso_b.keys()).cloned().collect();
     all_names.sort();
     all_names.dedup();
-    all_names.sort_by(|a, b| {
-        let max_a = iso_a.get(a).copied().unwrap_or(0.0).max(iso_b.get(a).copied().unwrap_or(0.0));
-        let max_b = iso_a.get(b).copied().unwrap_or(0.0).max(iso_b.get(b).copied().unwrap_or(0.0));
-        max_b.partial_cmp(&max_a).unwrap_or(std::cmp::Ordering::Equal)
+    // Sort isotopes by their peak activity across both configs (descending),
+    // so the most-produced ones appear first regardless of which side
+    // dominates. `peak_lhs` / `peak_rhs` are the cross-config peaks for
+    // the left and right entries being compared, NOT for configs A and B.
+    all_names.sort_by(|lhs, rhs| {
+        let peak_lhs = iso_a.get(lhs).copied().unwrap_or(0.0)
+            .max(iso_b.get(lhs).copied().unwrap_or(0.0));
+        let peak_rhs = iso_a.get(rhs).copied().unwrap_or(0.0)
+            .max(iso_b.get(rhs).copied().unwrap_or(0.0));
+        peak_rhs.partial_cmp(&peak_lhs).unwrap_or(std::cmp::Ordering::Equal)
     });
 
     let mut output = String::new();
@@ -801,6 +807,16 @@ fn tool_get_isotope_production_curve(
             if lr.depth_profile.is_empty() || rates.is_empty() {
                 return Err("Layer has no depth profile (thickness not resolved)".to_string());
             }
+            // Invariant: depth_profile and per-isotope production rates are
+            // sibling arrays sized off depth_raw.depths in compute.rs, so
+            // length parity must hold. Guard so a future regression can't
+            // silently truncate the table via zip.
+            assert_eq!(
+                lr.depth_profile.len(),
+                rates.len(),
+                "depth_profile / depth_production_rates length mismatch — \
+                 compute_stack invariant broken",
+            );
             output.push_str(&format!(
                 "Local production rate [atoms/s/cm] along depth, layer {}. {} points.\n\n",
                 layer_idx + 1,

--- a/py-mcp/pyproject.toml
+++ b/py-mcp/pyproject.toml
@@ -11,20 +11,29 @@ license = { text = "MIT" }
 requires-python = ">=3.11"
 authors = [{ name = "MorePET" }]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Rust",
     "Topic :: Scientific/Engineering :: Physics",
 ]
+keywords = ["mcp", "model-context-protocol", "claude", "nuclear", "isotope", "cyclotron", "radionuclide"]
 
 [project.scripts]
 hyrr-mcp = "hyrr_mcp:main"
 
 [project.urls]
 Homepage = "https://github.com/exoma-ch/hyrr"
+Repository = "https://github.com/exoma-ch/hyrr"
 Issues = "https://github.com/exoma-ch/hyrr/issues"
+"Source — Rust MCP module" = "https://github.com/exoma-ch/hyrr/tree/main/core/src/mcp"
 
 [tool.maturin]
 python-source = "python"


### PR DESCRIPTION
Three reviewer-flagged cosmetic nits batched into one small PR. No behavior change.

## Summary

1. **`compare_simulations` sort comparator** — rename `max_a`/`max_b` → `peak_lhs`/`peak_rhs` and add a comment so future readers don't conflate the comparator's left/right operands with the configs being compared.

2. **`get_isotope_production_curve` (vs=depth)** — `assert_eq!` on `depth_profile.len() == rates.len()`. Today they're sibling arrays sized off `depth_raw.depths` in `compute.rs` so parity holds; the assert guards against a future regression there silently truncating the table via `zip`.

3. **`py-mcp/pyproject.toml` PyPI metadata polish:**
   - Dev status: `3 - Alpha` → `2 - Pre-Alpha` (consistent with root pyproject at 0.1.0)
   - Add `Programming Language :: Python :: 3.12` and `3.13` classifiers (ABI3 wheel covers them)
   - Add `Operating System ::` classifiers (MacOS, POSIX :: Linux, Microsoft :: Windows)
   - Add `Programming Language :: Rust` classifier
   - Add `keywords` for PyPI search (mcp, model-context-protocol, claude, nuclear, isotope, cyclotron, radionuclide)
   - Add `Repository` URL and direct link to `core/src/mcp/` so PyPI visitors land on the SSoT module

## Test plan

- [x] `cargo check -p hyrr-mcp` clean
- [x] `pyproject.toml` parses (visual check; will be re-validated by `maturin build` when the release workflow next runs)
- [ ] No CI changes; existing lint + test (3.12) jobs run as usual

Refs: #71