### PR TITLE
feat(mcp): --library / HYRR_LIBRARY override across all entry points (refs #71)

### DIFF
--- a/core/src/mcp/transport.rs
+++ b/core/src/mcp/transport.rs
@@ -67,8 +67,24 @@ const SERVER_NAME: &str = "hyrr";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
-/// Run the MCP stdio server loop.
+/// Default nuclear data library when none is specified.
+pub const DEFAULT_LIBRARY: &str = "tendl-2024";
+
+/// Run the MCP stdio server loop with the default library (`tendl-2024`).
+///
+/// Convenience wrapper around [`run_mcp_server_with_library`].
 pub fn run_mcp_server(data_dir: &str) {
+    run_mcp_server_with_library(data_dir, DEFAULT_LIBRARY);
+}
+
+/// Run the MCP stdio server loop pinned to `library`.
+///
+/// `library` is the data-library identifier (e.g. `"tendl-2024"`,
+/// `"endfb-8.1"`); it must correspond to a `<data_dir>/<library>/` tree.
+/// The server's `library_used` echo footer reflects this value, and every
+/// tool's data fetches happen against this library for the lifetime of
+/// the process.
+pub fn run_mcp_server_with_library(data_dir: &str, library: &str) {
     // Pre-flight: verify the data directory actually contains a nucl-parquet
     // tree. ParquetDataStore::new only loads the eager metadata files; many
     // tools fault later when they reach for cross-sections / abundances /
@@ -89,10 +105,22 @@ pub fn run_mcp_server(data_dir: &str) {
         std::process::exit(2);
     }
 
-    let db = match crate::db::ParquetDataStore::new(data_dir, "tendl-2024") {
+    let lib_dir = std::path::Path::new(data_dir).join(library);
+    if !lib_dir.is_dir() {
+        eprintln!(
+            "hyrr-mcp: nuclear data library `{library}` not found in {data_dir}\n\
+             \n\
+             Expected `{}` to exist. Pick a different library with HYRR_LIBRARY\n\
+             or --library, or run `nucl-parquet download {library}` to fetch it.\n",
+            lib_dir.display(),
+        );
+        std::process::exit(2);
+    }
+
+    let db = match crate::db::ParquetDataStore::new(data_dir, library) {
         Ok(db) => db,
         Err(e) => {
-            eprintln!("hyrr-mcp: failed to load nuclear data from {data_dir}: {e}");
+            eprintln!("hyrr-mcp: failed to load nuclear data from {data_dir} (library {library}): {e}");
             std::process::exit(1);
         }
     };

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -12,7 +12,8 @@ fn main() {
     if args.iter().any(|a| a == "--mcp") {
         // MCP mode: stdio JSON-RPC server, no GUI
         let data_dir = hyrr_core::data_dir::resolve();
-        hyrr_core::mcp::transport::run_mcp_server(&data_dir);
+        let library = resolve_mcp_library(&args);
+        hyrr_core::mcp::transport::run_mcp_server_with_library(&data_dir, &library);
         return;
     }
 
@@ -30,3 +31,20 @@ fn main() {
         .expect("error while running tauri application");
 }
 
+/// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`
+/// env → `tendl-2024` (DEFAULT_LIBRARY).
+fn resolve_mcp_library(args: &[String]) -> String {
+    if args.len() >= 2 {
+        for i in 0..args.len() - 1 {
+            if args[i] == "--library" {
+                return args[i + 1].clone();
+            }
+        }
+    }
+    if let Ok(id) = std::env::var("HYRR_LIBRARY") {
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    hyrr_core::mcp::transport::DEFAULT_LIBRARY.to_string()
+}

--- a/hyrr-mcp/src/main.rs
+++ b/hyrr-mcp/src/main.rs
@@ -16,7 +16,26 @@ fn main() {
     }
 
     let data_dir = hyrr_core::data_dir::resolve();
-    hyrr_core::mcp::transport::run_mcp_server(&data_dir);
+    let library = resolve_library(&args);
+    hyrr_core::mcp::transport::run_mcp_server_with_library(&data_dir, &library);
+}
+
+/// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`
+/// env → `tendl-2024` (DEFAULT_LIBRARY).
+fn resolve_library(args: &[String]) -> String {
+    if args.len() >= 2 {
+        for i in 0..args.len() - 1 {
+            if args[i] == "--library" {
+                return args[i + 1].clone();
+            }
+        }
+    }
+    if let Ok(id) = std::env::var("HYRR_LIBRARY") {
+        if !id.is_empty() {
+            return id;
+        }
+    }
+    hyrr_core::mcp::transport::DEFAULT_LIBRARY.to_string()
 }
 
 fn print_help() {
@@ -26,15 +45,17 @@ fn print_help() {
          Stdio MCP server exposing HYRR radio-isotope production tools.\n\
          \n\
          USAGE:\n    \
-             hyrr-mcp [--data-dir <PATH>]\n\
+             hyrr-mcp [--data-dir <PATH>] [--library <ID>]\n\
          \n\
          OPTIONS:\n    \
              --data-dir <PATH>  Override nucl-parquet data directory\n    \
+             --library <ID>     Nuclear data library, e.g. tendl-2024 (default), endfb-8.1\n    \
              --version, -V      Print version and exit\n    \
              --help, -h         Print this help and exit\n\
          \n\
          ENVIRONMENT:\n    \
-             HYRR_DATA          Nucl-parquet data directory (if --data-dir not set)\n\
+             HYRR_DATA          Nucl-parquet data directory (if --data-dir not set)\n    \
+             HYRR_LIBRARY       Nuclear data library (if --library not set)\n\
          \n\
          Data resolution priority:\n    \
              1. --data-dir argument\n    \

--- a/py-mcp/python/hyrr_mcp/__init__.py
+++ b/py-mcp/python/hyrr_mcp/__init__.py
@@ -16,20 +16,30 @@ __version__ = _native.__version__
 
 
 def _print_help() -> None:
+    default_lib = _native.default_library()
     print(
         f"hyrr-mcp {__version__}\n\n"
         "Stdio MCP server exposing HYRR radio-isotope production tools.\n\n"
         "USAGE:\n"
-        "    hyrr-mcp [--data-dir PATH]\n\n"
+        "    hyrr-mcp [--data-dir PATH] [--library ID]\n\n"
         "OPTIONS:\n"
         "    --data-dir PATH   Override nucl-parquet data directory\n"
+        f"    --library ID      Nuclear data library, e.g. {default_lib} (default), endfb-8.1\n"
         "    --version, -V     Print version and exit\n"
         "    --help, -h        Print this help and exit\n\n"
         "ENVIRONMENT:\n"
-        "    HYRR_DATA         Nucl-parquet data directory (if --data-dir not set)\n\n"
+        "    HYRR_DATA         Nucl-parquet data directory (if --data-dir not set)\n"
+        "    HYRR_LIBRARY      Nuclear data library (if --library not set)\n\n"
         "Register with Claude Code:\n"
         "    claude mcp add hyrr -- uvx hyrr-mcp\n"
     )
+
+
+def _arg_value(argv: list[str], flag: str) -> str | None:
+    for i, arg in enumerate(argv):
+        if arg == flag and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
 
 
 def main() -> int:
@@ -43,15 +53,14 @@ def main() -> int:
 
     # Resolve data dir: explicit --data-dir wins, otherwise fall back to
     # the shared Rust resolver (env + sibling + home).
-    data_dir: str | None = None
-    for i, arg in enumerate(argv):
-        if arg == "--data-dir" and i + 1 < len(argv):
-            data_dir = argv[i + 1]
-            break
+    data_dir = _arg_value(argv, "--data-dir")
     if data_dir is None:
         data_dir = os.environ.get("HYRR_DATA") or _native.resolve_data_dir()
 
-    _native.run(data_dir)
+    # Resolve library: --library arg → HYRR_LIBRARY env → DEFAULT_LIBRARY.
+    library = _arg_value(argv, "--library") or os.environ.get("HYRR_LIBRARY") or None
+
+    _native.run(data_dir, library)
     return 0
 
 

--- a/py-mcp/src/lib.rs
+++ b/py-mcp/src/lib.rs
@@ -4,10 +4,16 @@
 
 use pyo3::prelude::*;
 
-/// Enter the MCP stdio loop. Blocks until stdin closes.
+/// Enter the MCP stdio loop pinned to the given nuclear data library.
+///
+/// Blocks until stdin closes.
 #[pyfunction]
-fn run(data_dir: String) -> PyResult<()> {
-    hyrr_core::mcp::transport::run_mcp_server(&data_dir);
+#[pyo3(signature = (data_dir, library=None))]
+fn run(data_dir: String, library: Option<String>) -> PyResult<()> {
+    let lib = library.unwrap_or_else(|| {
+        hyrr_core::mcp::transport::DEFAULT_LIBRARY.to_string()
+    });
+    hyrr_core::mcp::transport::run_mcp_server_with_library(&data_dir, &lib);
     Ok(())
 }
 
@@ -18,10 +24,17 @@ fn resolve_data_dir() -> String {
     hyrr_core::data_dir::resolve()
 }
 
+/// Default nuclear data library identifier (e.g. "tendl-2024").
+#[pyfunction]
+fn default_library() -> &'static str {
+    hyrr_core::mcp::transport::DEFAULT_LIBRARY
+}
+
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run, m)?)?;
     m.add_function(wrap_pyfunction!(resolve_data_dir, m)?)?;
+    m.add_function(wrap_pyfunction!(default_library, m)?)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }


### PR DESCRIPTION
Reviewer follow-up from #67/#71. `transport.rs` hardcoded `"tendl-2024"`, and there was no way for the user to pick anything else. The `library_used` echo footer was honest about what got used; the capability to pick was missing. This contradicted the scientific-correctness story — TENDL vs ENDF/B-VIII.1 vs JENDL-5 matters for deuteron channels.

## Surface change

- `core/src/mcp/transport.rs` gains:
  - `pub const DEFAULT_LIBRARY: &str = "tendl-2024";`
  - `pub fn run_mcp_server_with_library(data_dir, library)`
  - `run_mcp_server(data_dir)` is preserved as a thin wrapper that passes `DEFAULT_LIBRARY`, so every existing caller keeps working.
- Pre-flight check now also verifies `<data_dir>/<library>/` exists with an actionable stderr message if not (mirrors the missing-data-dir guard from #79).

Wired through every entry point with the same priority chain (`--library` arg → `HYRR_LIBRARY` env → `DEFAULT_LIBRARY`):

- `hyrr-mcp/src/main.rs` — `resolve_library()` helper, `--library` documented in `--help`.
- `desktop/src-tauri/src/main.rs` — `resolve_mcp_library()` helper for the `--mcp` branch.
- `py-mcp/src/lib.rs` — `_native.run()` now takes optional `library` argument; new `_native.default_library()` helper.
- `py-mcp/python/hyrr_mcp/__init__.py` — parses `--library` / `HYRR_LIBRARY` alongside the existing data-dir logic, passes to the native module.

## Test plan

- [x] `cargo build --release` from `hyrr-mcp/` clean
- [x] `cargo build` from `desktop/src-tauri/` clean
- [x] `scripts/mcp_parity_test.sh` passes 10/10 byte-identical with default library
- [x] `HYRR_LIBRARY=tendl-2024 hyrr-mcp` works, footer reads `*Library: tendl-2024*`
- [x] `HYRR_LIBRARY=does-not-exist hyrr-mcp` exits 2 with one-line actionable message:
  ```
  hyrr-mcp: nuclear data library `does-not-exist` not found in <data_dir>

  Expected `<data_dir>/does-not-exist` to exist. Pick a different library with
  HYRR_LIBRARY or --library, or run `nucl-parquet download does-not-exist` to fetch it.
  ```
- [ ] Python wheel parity (`HYRR_MCP_PYTHON=...`) — will be exercised by the cibuildwheel job once a tag is pushed.

## Explicitly NOT in this PR

**Per-tool `library` argument override.** Today the library is chosen at server startup; per-call switching would need a db cache keyed by library and is its own design discussion. If the env + CLI flag turns out to be insufficient in practice, I'll file a follow-up.

Refs: #71