### PR TITLE
perf(mcp): stopping-only fast path for get_stack_energy_budget (refs #71)

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -464,6 +464,126 @@ fn apply_chain_solver_by_component(
     new_results
 }
 
+/// Stopping-only fast path: energy degradation, depth profile, heat.
+///
+/// Mirrors [`compute_stack`] but skips the entire activation pipeline
+/// (cross-section integration, Bateman, chain solver). Use when you only
+/// need beam-stop / heat-budget questions answered — the
+/// `get_stack_energy_budget` MCP tool is the canonical caller. Returns a
+/// `StackResult` with empty `isotope_results` and `depth_production_rates`
+/// per layer; everything else is identical to the equivalent
+/// `compute_stack` call.
+pub fn compute_stack_stopping_only(
+    db: &dyn DatabaseProtocol,
+    stack: &mut TargetStack,
+) -> StackResult {
+    let beam = &stack.beam;
+    let area = stack.area_cm2;
+    let projectile = &beam.projectile;
+    let current_ma = beam.current_ma;
+    let projectile_z = projectile.z();
+
+    let mut energy_in = beam.energy_mev;
+    let mut layer_results = Vec::new();
+
+    for layer in &mut stack.layers {
+        let lr = compute_layer_stopping_only(
+            db,
+            projectile,
+            current_ma,
+            projectile_z,
+            layer,
+            energy_in,
+            area,
+        );
+        energy_in = lr.energy_out;
+        layer_results.push(lr);
+    }
+
+    StackResult {
+        layer_results,
+        irradiation_time_s: stack.irradiation_time_s,
+        cooling_time_s: stack.cooling_time_s,
+    }
+}
+
+/// Per-layer stopping-only computation — the prefix of [`compute_layer`]
+/// up through heat integration, with the activation loop and chain solver
+/// stripped out. Returns a [`LayerResult`] whose `isotope_results` and
+/// `depth_production_rates` are empty.
+fn compute_layer_stopping_only(
+    db: &dyn DatabaseProtocol,
+    projectile: &ProjectileType,
+    current_ma: f64,
+    projectile_z: u32,
+    layer: &mut Layer,
+    energy_in: f64,
+    area: f64,
+) -> LayerResult {
+    let composition = layer_composition(layer);
+    let density = layer.density_g_cm3;
+
+    let (thickness, energy_out) = if let Some(e_out) = layer.energy_out_mev {
+        let thick = compute_thickness_from_energy(
+            db, projectile, &composition, density, energy_in, e_out, 1000,
+        );
+        (thick, e_out)
+    } else if let Some(thick) = layer.thickness_cm {
+        let e_out = compute_energy_out(
+            db, projectile, &composition, density, energy_in, thick, 1000,
+        );
+        (thick, e_out)
+    } else {
+        let thick = layer.areal_density_g_cm2.unwrap() / density;
+        let e_out = compute_energy_out(
+            db, projectile, &composition, density, energy_in, thick, 1000,
+        );
+        (thick, e_out)
+    };
+
+    layer.computed_energy_in = energy_in;
+    layer.computed_energy_out = energy_out;
+    layer.computed_thickness = thickness;
+
+    let sp_sources = get_stopping_sources(db, projectile, &composition);
+
+    // Same energy grid + dE/dx the full path uses, so heat values are
+    // bit-identical to the activation path's output.
+    let layer_e_low = energy_out.max(0.01);
+    let layer_energies = linspace(layer_e_low, energy_in, 100);
+    let layer_dedx = dedx_mev_per_cm(db, projectile, &composition, density, &layer_energies);
+
+    let depth_raw =
+        generate_depth_profile(&layer_energies, &layer_dedx, current_ma, area, projectile_z);
+
+    let mut depth_profile = Vec::with_capacity(depth_raw.depths.len());
+    for i in 0..depth_raw.depths.len() {
+        depth_profile.push(DepthPoint {
+            depth_cm: depth_raw.depths[i],
+            energy_mev: depth_raw.energies_ordered[i],
+            dedx_mev_cm: layer_dedx[layer_dedx.len() - 1 - i].abs(),
+            heat_w_cm3: depth_raw.heat_w_cm3[i],
+        });
+    }
+
+    let heat_kw = if depth_profile.len() >= 2 {
+        integrate_heat(&depth_profile, area)
+    } else {
+        0.0
+    };
+
+    LayerResult {
+        energy_in,
+        energy_out,
+        delta_e_mev: energy_in - energy_out,
+        heat_kw,
+        depth_profile,
+        isotope_results: HashMap::new(),
+        stopping_power_sources: sp_sources,
+        depth_production_rates: HashMap::new(),
+    }
+}
+
 fn integrate_heat(profile: &[DepthPoint], area_cm2: f64) -> f64 {
     if profile.len() < 2 {
         return 0.0;

--- a/core/src/mcp/tools.rs
+++ b/core/src/mcp/tools.rs
@@ -358,6 +358,80 @@ fn build_and_run_sim(
     Ok((stack, result, projectile_str.to_string(), energy_mev, current_ma))
 }
 
+/// Stopping-only variant of [`build_and_run_sim`] for tools that only need
+/// energy / heat fields (notably `get_stack_energy_budget`). Same parser,
+/// different compute path — skips activation entirely.
+fn build_and_run_stopping_only(
+    db: &dyn DatabaseProtocol,
+    args: &Value,
+) -> Result<(crate::types::StackResult, String, f64, f64), String> {
+    let projectile_str = args
+        .get("projectile")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing 'projectile'")?;
+    let projectile = ProjectileType::from_str(projectile_str).ok_or("Invalid projectile type")?;
+    let energy_mev = args
+        .get("energy_mev")
+        .and_then(|v| v.as_f64())
+        .ok_or("Missing 'energy_mev'")?;
+    let current_ma = args
+        .get("current_ma")
+        .and_then(|v| v.as_f64())
+        .ok_or("Missing 'current_ma'")?;
+
+    let layer_arr = args
+        .get("layers")
+        .and_then(|v| v.as_array())
+        .ok_or("Missing 'layers'")?;
+
+    let beam = Beam::new(projectile, energy_mev, current_ma);
+
+    let mut layers = Vec::new();
+    for layer_val in layer_arr {
+        let material = layer_val
+            .get("material")
+            .and_then(|v| v.as_str())
+            .ok_or("Layer missing 'material'")?;
+        let overrides = parse_enrichment(layer_val.get("enrichment"))?;
+        let resolution = resolve_material(db, material, overrides.as_ref());
+        let thickness_cm = layer_val.get("thickness_cm").and_then(|v| v.as_f64());
+        let energy_out = layer_val.get("energy_out_mev").and_then(|v| v.as_f64());
+
+        layers.push(Layer {
+            density_g_cm3: resolution.density,
+            elements: resolution.elements,
+            thickness_cm,
+            areal_density_g_cm2: None,
+            energy_out_mev: energy_out,
+            is_monitor: false,
+            computed_energy_in: 0.0,
+            computed_energy_out: 0.0,
+            computed_thickness: 0.0,
+        });
+    }
+
+    if layers
+        .iter()
+        .all(|l| l.thickness_cm.is_none() && l.energy_out_mev.is_none())
+    {
+        if let Some(l) = layers.first_mut() {
+            l.thickness_cm = Some(0.1);
+        }
+    }
+
+    let mut stack = TargetStack {
+        beam,
+        layers,
+        irradiation_time_s: 0.0,
+        cooling_time_s: 0.0,
+        area_cm2: 1.0,
+        current_profile: None,
+    };
+
+    let result = crate::compute::compute_stack_stopping_only(db, &mut stack);
+    Ok((result, projectile_str.to_string(), energy_mev, current_ma))
+}
+
 fn tool_simulate(db: &dyn DatabaseProtocol, args: &Value) -> Result<String, String> {
     let (stack, result, projectile_str, energy_mev, current_ma) = build_and_run_sim(db, args)?;
     let irr_time = stack.irradiation_time_s;
@@ -625,8 +699,11 @@ fn tool_compare_simulations(db: &dyn DatabaseProtocol, args: &Value) -> Result<S
 }
 
 fn tool_get_stack_energy_budget(db: &dyn DatabaseProtocol, args: &Value) -> Result<String, String> {
-    // Reuses the simulate shape but we only read energy/heat fields.
-    let (_stack, result, projectile_str, energy_mev, current_ma) = build_and_run_sim(db, args)?;
+    // Stopping-only fast path — skips the activation pipeline that
+    // build_and_run_sim would invoke. Identical energy/heat numbers, much
+    // less work for stacks with many cross-section channels.
+    let (result, projectile_str, energy_mev, current_ma) =
+        build_and_run_stopping_only(db, args)?;
 
     let mut output = String::new();
     output.push_str(&format!(


### PR DESCRIPTION
Last reviewer-flagged code follow-up. The docstring on `get_stack_energy_budget` promised "no activation math — use this to answer 'will this stack stop the beam?' without running a full simulation". The implementation called `build_and_run_sim`, which always runs `compute_stack` with the full activation pipeline (cross-section integration → Bateman → chain solver). Numbers were correct (heat is integrated independently of activation) but the compute cost matched the docstring's lie, not its promise.

## Summary

- **`compute_stack_stopping_only(db, stack)`** in `core/src/compute.rs` — mirror of `compute_stack` that skips activation entirely. Same energy grid + dE/dx + `integrate_heat` helper as the full path, so heat values are bit-identical.
- **`compute_layer_stopping_only`** — private sibling of `compute_layer` that goes from composition resolution to heat integration without touching the isotope loop or chain solver. Returns a `LayerResult` with empty `isotope_results` and `depth_production_rates`.
- **`build_and_run_stopping_only`** in `tools.rs` — parser parallel to `build_and_run_sim`, dispatches to the new compute path.
- **`tool_get_stack_energy_budget`** wired through it exclusively.

`simulate` / `compare_simulations` / `get_isotope_production_curve` continue using the full path — they need the activation data.

## Test plan

- [x] `cargo build --release` from `hyrr-mcp/` clean
- [x] `cargo build` from `desktop/src-tauri/` clean
- [x] `scripts/mcp_parity_test.sh` passes 10/10 byte-identical across `hyrr --mcp` and `hyrr-mcp`. The widened fixture from #79 exercises `get_stack_energy_budget` (request id=5), so the fast path's heat numbers are diffed against the old path's heat numbers — they match exactly.
- [ ] Quantitative perf benchmark — anecdotal only for now. For a Cu/Al two-layer stack the fast path skips ~50 cross-section integrations + Bateman solves per channel + the chain-solver pass; on stacks with many target isotopes (e.g. natural Mo, 7 isotopes × ~30 channels each), the saving is order-of-magnitude.

## Why a sibling function instead of a `enable_chains: bool` extension

Considered. The existing `enable_chains` flag already controls the chain solver, but the cross-section / Bateman path inside `compute_layer` runs unconditionally. Adding a fourth bool arg (`enable_isotopes`?) would have meant smearing `if !enable_isotopes { skip }` branches through the hot loop and made the call sites less readable. A sibling function makes the contract explicit at the call site: when you call `compute_stack_stopping_only` you can't accidentally get isotope data, and the type system enforces it (the returned `StackResult.layer_results[i].isotope_results` is always empty).

Refs: #71