### PR TITLE
feat(material): rows-based DefineForm (#64 Phase 3)

### DIFF
--- a/frontend/e2e/material-define-rows.spec.ts
+++ b/frontend/e2e/material-define-rows.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "@playwright/test";
+
+/** Same TC-99m preset used by the other material-popup e2e specs. */
+const TC99M_URL =
+  "/hyrr/#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+
+async function waitReady(page: import("@playwright/test").Page) {
+  await page.waitForSelector(".status-bar", { state: "hidden", timeout: 30_000 }).catch(() => {});
+  await page.waitForSelector(".activity-table-enhanced", { timeout: 30_000 });
+}
+
+test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TC99M_URL);
+    await waitReady(page);
+  });
+
+  test("build Fe 50%, Cu balance via + button → Save & Use", async ({ page }) => {
+    // Open the layer-material picker for the first layer.
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+
+    // Open the define-form section.
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    // First "+ element" → PT modal.
+    await page.getByRole("button", { name: "+ element" }).click();
+    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeVisible();
+
+    // Click Fe (Z=26).
+    await page.locator('[data-z="26"]').click();
+    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeHidden();
+
+    // The new row's value input should be focused; type 50.
+    await page.keyboard.type("50");
+
+    // Second "+ element" → PT modal → pick Cu (Z=29).
+    await page.getByRole("button", { name: "+ element" }).click();
+    await page.locator('[data-z="29"]').click();
+    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeHidden();
+
+    // Mark the Cu row as balance.
+    const cuRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "Cu" });
+    await cuRow.getByRole("radio").check();
+
+    // Density auto-fills from the mass-ratio computation; just verify the
+    // Save button is enabled and click it.
+    const saveBtn = page.getByRole("button", { name: /Save & Use/ });
+    await expect(saveBtn).toBeEnabled();
+    await saveBtn.click();
+
+    // Popup closes and the layer material name updates to the new custom.
+    await page.waitForSelector(".material-popup", { state: "hidden", timeout: 5_000 });
+    await expect(page.locator(".material-name").first()).toContainText(/Fe50/);
+  });
+
+  test("paste-formula input commits on blur and populates rows", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    const paste = page.getByPlaceholder(/Al2O3.*Al 80/);
+    await paste.fill("Al 80%, Cu 5%, Zn %");
+    await paste.blur();
+
+    // Expect three rows.
+    await expect(page.locator('[role="row"][data-row-id]')).toHaveCount(3);
+    // Zn row should be marked as balance (radio checked).
+    const znRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "Zn" });
+    await expect(znRow.getByRole("radio")).toBeChecked();
+  });
+});

--- a/frontend/e2e/material-define-rows.spec.ts
+++ b/frontend/e2e/material-define-rows.spec.ts
@@ -31,7 +31,12 @@ test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
     await page.locator('[data-z="26"]').click();
     await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeHidden();
 
-    // The new row's value input should be focused; type 50.
+    // §3.4 contract: focus lands on the new row's value input.
+    const feValueInput = page
+      .locator('[role="row"][data-row-id]')
+      .filter({ hasText: "Fe" })
+      .locator(".value-input");
+    await expect(feValueInput).toBeFocused();
     await page.keyboard.type("50");
 
     // Second "+ element" → PT modal → pick Cu (Z=29).

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -17,8 +17,10 @@
     serialise,
     toRows,
     validate,
+    type Issue,
     type Row,
   } from "./define-form-rows";
+  import DefineFormRow from "./DefineFormRow.svelte";
 
   interface Props {
     /** Set (reactively) to open the form in edit mode with these values.
@@ -63,6 +65,40 @@
 
   const validationErrors = $derived(validation.filter((i) => i.level === "error"));
   const canCommit = $derived(rows.length > 0 && validationErrors.length === 0 && !!formulaPreview);
+  const formIssues = $derived(validation.filter((i) => !i.rowId));
+  const issuesByRow = $derived.by(() => {
+    const byRow = new Map<string, Issue[]>();
+    for (const i of validation) {
+      if (i.rowId) {
+        const arr = byRow.get(i.rowId) ?? [];
+        arr.push(i);
+        byRow.set(i.rowId, arr);
+      }
+    }
+    return byRow;
+  });
+
+  /** Stable radiogroup name so the browser enforces single-balance selection. */
+  const balanceRadioName = `define-balance-${Math.random().toString(36).slice(2, 10)}`;
+
+  /** Splice a row immutably with a partial patch. When isBalance flips on,
+   *  also clear it from every other row so only one survives. */
+  function patchRow(id: string, patch: Partial<Row>) {
+    rows = rows.map((r) => {
+      if (r.id === id) {
+        return { ...r, ...patch };
+      }
+      // Force-clear other rows' isBalance when the patch turns one on.
+      if (patch.isBalance === true && r.isBalance) {
+        return { ...r, isBalance: false };
+      }
+      return r;
+    });
+  }
+
+  function removeRow(id: string) {
+    rows = rows.filter((r) => r.id !== id);
+  }
 
   // Seed/reset from the editInitial prop. This effect watches the prop, not
   // rows/textDraft, so it does not violate the "no $effect on rows or
@@ -147,20 +183,20 @@
 
   {#if defineOpen}
     <div class="define-form">
-      <div class="rows-section">
+      <div class="rows-section" role="grid" aria-label="Material composition rows">
         <span class="rows-heading">Composition</span>
         {#if rows.length === 0}
           <p class="empty-hint">No elements yet — paste a formula or pick from the periodic table (coming soon).</p>
         {:else}
-          <ul class="rows-list">
-            {#each rows as r (r.id)}
-              <li class="row-item">
-                <span class="row-symbol">{r.symbol}</span>
-                <span class="row-value">{r.isBalance ? "balance" : (r.value ?? "—")}</span>
-                <span class="row-unit">{r.unit}</span>
-              </li>
-            {/each}
-          </ul>
+          {#each rows as r (r.id)}
+            <DefineFormRow
+              row={r}
+              radioName={balanceRadioName}
+              issues={issuesByRow.get(r.id) ?? []}
+              onchange={(patch) => patchRow(r.id, patch)}
+              onremove={() => removeRow(r.id)}
+            />
+          {/each}
         {/if}
 
         {#if formulaPreview}
@@ -211,7 +247,7 @@
       {#if formError}
         <p class="form-error">{formError}</p>
       {/if}
-      {#each validation as issue}
+      {#each formIssues as issue}
         <p class="form-{issue.level}">{issue.message}</p>
       {/each}
 
@@ -280,30 +316,6 @@
     margin: 0;
     font-style: italic;
   }
-
-  .rows-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-  }
-
-  .row-item {
-    display: flex;
-    gap: 0.5rem;
-    align-items: baseline;
-    padding: 0.2rem 0.4rem;
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 4px;
-    font-size: 0.75rem;
-  }
-
-  .row-symbol { font-weight: 500; min-width: 2rem; color: var(--c-text); }
-  .row-value { color: var(--c-text-muted); }
-  .row-unit { color: var(--c-text-subtle); font-size: 0.65rem; text-transform: uppercase; }
 
   .field-label {
     display: flex;

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -59,6 +59,11 @@
   const formulaPreview = $derived(
     previewParse && "ok" in previewParse ? previewParse.ok : null,
   );
+  /** What the paste input displays — user's draft when dirty, otherwise the
+   *  canonical serialisation of the current rows (so edits to rows propagate
+   *  back into the text field). */
+  const displayText = $derived(textDirty ? textDraft : serialised);
+  let pasteError = $state<string | null>(null);
 
   const autoName = $derived(formulaPreview?.autoName ?? "");
   const autoDensity = $derived(formulaPreview?.density ?? null);
@@ -156,6 +161,44 @@
     });
   }
 
+  function onPasteInput(e: Event) {
+    textDraft = (e.target as HTMLInputElement).value;
+    textDirty = true;
+    pasteError = null;
+  }
+
+  function commitPastedText() {
+    if (!textDirty) return;
+    const trimmed = textDraft.trim();
+    if (!trimmed) {
+      // User cleared the field → clear rows.
+      rows = [];
+      textDirty = false;
+      pasteError = null;
+      return;
+    }
+    const parsed = parseMaterialInput(textDraft);
+    if (parsed && "ok" in parsed) {
+      rows = toRows(parsed.ok);
+      textDirty = false;
+      pasteError = null;
+    } else if (parsed && "error" in parsed) {
+      // Keep rows untouched; surface the error inline. textDirty stays true
+      // so the user's draft remains visible while they correct it.
+      pasteError = parsed.error;
+    } else {
+      // null result (whitespace-only after trim handled above; shouldn't reach)
+      pasteError = null;
+    }
+  }
+
+  function onPasteKeydown(e: KeyboardEvent) {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      commitPastedText();
+    }
+  }
+
   // Focus the first focusable inside the modal when it opens.
   $effect(() => {
     if (!elementPickerOpen) return;
@@ -183,6 +226,7 @@
       textDraft = "";
       textDirty = false;
       formError = null;
+      pasteError = null;
     } else {
       rows = [];
       defineOpen = false;
@@ -194,6 +238,7 @@
       textDraft = "";
       textDirty = false;
       formError = null;
+      pasteError = null;
     }
   });
 
@@ -272,6 +317,23 @@
           bind:this={addBtnRef}
           onclick={openPicker}
         >+ element</button>
+
+        <label class="field-label paste-field">
+          Or paste formula
+          <input
+            type="text"
+            class="field-input"
+            placeholder="Al2O3  or  Al 80%, Cu 5%, Zn %"
+            value={displayText}
+            oninput={onPasteInput}
+            onblur={commitPastedText}
+            onkeydown={onPasteKeydown}
+          />
+          <span class="field-hint">Stoichiometric formula or mass ratios. Cmd/Ctrl-Enter or blur to apply.</span>
+          {#if pasteError}
+            <span class="paste-error">{pasteError}</span>
+          {/if}
+        </label>
 
         {#if formulaPreview}
           <div class="preview">
@@ -506,6 +568,13 @@
     font-size: 0.6rem;
     color: var(--c-text-subtle);
     font-style: italic;
+  }
+
+  .paste-field { margin-top: 0.4rem; }
+
+  .paste-error {
+    color: var(--c-red);
+    font-size: 0.7rem;
   }
 
   .preview {

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -13,6 +13,7 @@
     updateCustomMaterial,
   } from "../../stores/custom-materials.svelte";
   import {
+    generateRowId,
     parseMaterialInput,
     serialise,
     toRows,
@@ -21,6 +22,7 @@
     type Row,
   } from "./define-form-rows";
   import DefineFormRow from "./DefineFormRow.svelte";
+  import PeriodicTable from "./PeriodicTable.svelte";
 
   interface Props {
     /** Set (reactively) to open the form in edit mode with these values.
@@ -99,6 +101,71 @@
   function removeRow(id: string) {
     rows = rows.filter((r) => r.id !== id);
   }
+
+  // --- "+ element" picker (PT in a focus-trapped modal) ---
+  let elementPickerOpen = $state(false);
+  let addBtnRef = $state<HTMLButtonElement | null>(null);
+  let modalRef = $state<HTMLDivElement | null>(null);
+
+  function openPicker() {
+    elementPickerOpen = true;
+  }
+
+  function closePicker() {
+    if (!elementPickerOpen) return;
+    elementPickerOpen = false;
+    // Return focus to the trigger after the modal unmounts.
+    requestAnimationFrame(() => addBtnRef?.focus());
+  }
+
+  function onPickerKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closePicker();
+      return;
+    }
+    if (e.key !== "Tab" || !modalRef) return;
+    const focusables = Array.from(
+      modalRef.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input:not([disabled]), [tabindex="0"]',
+      ),
+    ).filter((el) => !el.hasAttribute("hidden"));
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function handlePtSelect(symbol: string) {
+    const id = generateRowId();
+    rows = [...rows, { id, symbol, value: null, unit: "wt%", isBalance: false }];
+    closePicker();
+    // After the row mounts, focus its number input.
+    requestAnimationFrame(() => {
+      const el = document.querySelector<HTMLInputElement>(
+        `[data-row-id="${id}"] .value-input`,
+      );
+      el?.focus();
+    });
+  }
+
+  // Focus the first focusable inside the modal when it opens.
+  $effect(() => {
+    if (!elementPickerOpen) return;
+    requestAnimationFrame(() => {
+      const first = modalRef?.querySelector<HTMLElement>(
+        'button:not([disabled]), [tabindex="0"]',
+      );
+      first?.focus();
+    });
+  });
 
   // Seed/reset from the editInitial prop. This effect watches the prop, not
   // rows/textDraft, so it does not violate the "no $effect on rows or
@@ -186,7 +253,7 @@
       <div class="rows-section" role="grid" aria-label="Material composition rows">
         <span class="rows-heading">Composition</span>
         {#if rows.length === 0}
-          <p class="empty-hint">No elements yet — paste a formula or pick from the periodic table (coming soon).</p>
+          <p class="empty-hint">No elements yet — add one below.</p>
         {:else}
           {#each rows as r (r.id)}
             <DefineFormRow
@@ -198,6 +265,13 @@
             />
           {/each}
         {/if}
+
+        <button
+          type="button"
+          class="add-row-btn"
+          bind:this={addBtnRef}
+          onclick={openPicker}
+        >+ element</button>
 
         {#if formulaPreview}
           <div class="preview">
@@ -267,6 +341,29 @@
   {/if}
 </div>
 
+{#if elementPickerOpen}
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+  <div class="picker-overlay" onclick={(e) => { if (e.target === e.currentTarget) closePicker(); }}>
+    <div
+      class="picker-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick an element"
+      tabindex="-1"
+      bind:this={modalRef}
+      onkeydown={onPickerKeydown}
+    >
+      <div class="picker-header">
+        <h3>Pick an element</h3>
+        <button class="picker-close" aria-label="Close" onclick={closePicker}>×</button>
+      </div>
+      <div class="picker-body">
+        <PeriodicTable onselect={handlePtSelect} />
+      </div>
+    </div>
+  </div>
+{/if}
+
 <style>
   .define-section {
     border-top: 1px solid var(--c-border);
@@ -315,6 +412,75 @@
     color: var(--c-text-subtle);
     margin: 0;
     font-style: italic;
+  }
+
+  .add-row-btn {
+    align-self: flex-start;
+    background: var(--c-bg-muted);
+    border: 1px dashed var(--c-border);
+    border-radius: 4px;
+    color: var(--c-text-muted);
+    padding: 0.25rem 0.6rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    margin-top: 0.2rem;
+  }
+
+  .add-row-btn:hover { color: var(--c-accent); border-color: var(--c-accent); }
+  .add-row-btn:focus-visible { outline: 2px solid var(--c-accent); outline-offset: 1px; }
+
+  .picker-overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--c-overlay-heavy);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1100;
+    padding: 1rem;
+  }
+
+  .picker-modal {
+    background: var(--c-bg-subtle);
+    border: 1px solid var(--c-border);
+    border-radius: 8px;
+    max-width: 900px;
+    max-height: 90vh;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .picker-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.6rem 0.9rem;
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  .picker-header h3 { margin: 0; font-size: 0.95rem; color: var(--c-text); }
+
+  .picker-close {
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    font-size: 1.3rem;
+    cursor: pointer;
+    padding: 0.15rem 0.4rem;
+    border-radius: 4px;
+    line-height: 1;
+  }
+
+  .picker-close:hover { color: var(--c-text); background: var(--c-bg-muted); }
+  .picker-close:focus-visible { outline: 2px solid var(--c-accent); outline-offset: 1px; }
+
+  .picker-body {
+    padding: 0.75rem;
+    overflow: auto;
+    flex: 1;
+    min-height: 0;
   }
 
   .field-label {

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -12,7 +12,13 @@
     saveCustomMaterial,
     updateCustomMaterial,
   } from "../../stores/custom-materials.svelte";
-  import { ELEMENT_DENSITIES, COMPOUND_DENSITIES, parseFormula, SYMBOL_TO_Z, STANDARD_ATOMIC_WEIGHT } from "@hyrr/compute";
+  import {
+    parseMaterialInput,
+    serialise,
+    toRows,
+    validate,
+    type Row,
+  } from "./define-form-rows";
 
   interface Props {
     /** Set (reactively) to open the form in edit mode with these values.
@@ -26,185 +32,110 @@
 
   let { editInitial, currentEnrichment, onenrichment, oncommit }: Props = $props();
 
+  // --- Source-of-truth state per #64 §3.1 ---
+  let rows = $state<Row[]>([]);
+  let textDraft = $state("");
+  let textDirty = $state(false);
+
+  // Display-side state (not part of the rows↔text round-trip).
   let defineOpen = $state(false);
-  let newFormula = $state("");
-  let newName = $state("");
+  let nameDraft = $state("");
   let nameManuallySet = $state(false);
-  let newDensity = $state<number | null>(null);
-  let formulaError = $state<string | null>(null);
+  let densityDraft = $state<number | null>(null);
+  let densityManuallySet = $state(false);
+  let formError = $state<string | null>(null);
   let saving = $state(false);
   let editingCustomId = $state<string | null>(null);
 
-  // React to editInitial changes: seed + open when set, reset + collapse when null.
+  // Pure derivations off rows. NOTE: no $effect watches rows or textDraft —
+  // round-trips run inside event handlers (commitPastedText) only. (#64 §3.1)
+  const serialised = $derived(serialise(rows));
+  const validation = $derived(validate(rows));
+  const previewParse = $derived(parseMaterialInput(serialised));
+  const formulaPreview = $derived(
+    previewParse && "ok" in previewParse ? previewParse.ok : null,
+  );
+
+  const autoName = $derived(formulaPreview?.autoName ?? "");
+  const autoDensity = $derived(formulaPreview?.density ?? null);
+  const effectiveName = $derived(nameManuallySet ? nameDraft : autoName);
+  const effectiveDensity = $derived(densityManuallySet ? densityDraft : autoDensity);
+
+  const validationErrors = $derived(validation.filter((i) => i.level === "error"));
+  const canCommit = $derived(rows.length > 0 && validationErrors.length === 0 && !!formulaPreview);
+
+  // Seed/reset from the editInitial prop. This effect watches the prop, not
+  // rows/textDraft, so it does not violate the "no $effect on rows or
+  // textDraft" rule.
   $effect(() => {
     if (editInitial) {
+      const parsed = parseMaterialInput(editInitial.formula);
+      rows = parsed && "ok" in parsed ? toRows(parsed.ok) : [];
       defineOpen = true;
-      newFormula = editInitial.formula;
-      newName = editInitial.name;
+      nameDraft = editInitial.name;
       nameManuallySet = true;
-      newDensity = editInitial.density;
+      densityDraft = editInitial.density;
+      densityManuallySet = true;
       editingCustomId = editInitial.editingCustomId;
-      formulaError = null;
+      textDraft = "";
+      textDirty = false;
+      formError = null;
     } else {
+      rows = [];
       defineOpen = false;
-      newFormula = "";
-      newName = "";
+      nameDraft = "";
       nameManuallySet = false;
-      newDensity = null;
-      formulaError = null;
+      densityDraft = null;
+      densityManuallySet = false;
       editingCustomId = null;
-    }
-  });
-
-  interface ParsedMaterial {
-    type: "stoichiometric" | "mass-ratio";
-    formula: string;
-    elements: string[];
-    density: number | null;
-    autoName: string;
-    massFractions?: Record<string, number>;
-  }
-
-  type ParseResult = { ok: ParsedMaterial } | { error: string } | null;
-
-  function parseMaterialInput(input: string): ParseResult {
-    const trimmed = input.trim();
-    if (!trimmed) return null;
-
-    if (trimmed.includes("%")) {
-      return parseMassRatio(trimmed);
-    }
-
-    try {
-      const parsed = parseFormula(trimmed);
-      const elements = Object.keys(parsed);
-      if (elements.length === 0) return { error: "No elements found in formula" };
-      for (const el of elements) {
-        if (!SYMBOL_TO_Z[el]) return { error: `Unknown element: ${el}` };
-      }
-      let density: number | null = null;
-      if (COMPOUND_DENSITIES[trimmed]) {
-        density = COMPOUND_DENSITIES[trimmed];
-      } else if (elements.length === 1 && ELEMENT_DENSITIES[elements[0]]) {
-        density = ELEMENT_DENSITIES[elements[0]];
-      }
-      return { ok: { type: "stoichiometric", formula: trimmed, elements, density, autoName: trimmed } };
-    } catch {
-      return { error: "Invalid formula" };
-    }
-  }
-
-  function parseMassRatio(input: string): ParseResult {
-    const parts = input.split(",").map((s) => s.trim()).filter(Boolean);
-    const entries: { symbol: string; pct: number | null }[] = [];
-
-    for (const part of parts) {
-      const m = part.match(/^([A-Z][a-z]?)\s*(\d+(?:\.\d+)?)?\s*%$/);
-      if (!m) return { error: `Invalid: "${part}". Use "Al 80%, Cu 5%, Zn %"` };
-      const sym = m[1];
-      if (!SYMBOL_TO_Z[sym]) return { error: `Unknown element: ${sym}` };
-      entries.push({ symbol: sym, pct: m[2] ? parseFloat(m[2]) : null });
-    }
-
-    const specified = entries.filter((e) => e.pct !== null);
-    const remainder = entries.filter((e) => e.pct === null);
-    const specifiedSum = specified.reduce((s, e) => s + (e.pct ?? 0), 0);
-
-    if (remainder.length > 1) return { error: "Only one element can have unspecified %" };
-    if (remainder.length === 0 && Math.abs(specifiedSum - 100) > 0.5) {
-      return { error: `Sum is ${specifiedSum.toFixed(1)}%, needs 100%` };
-    }
-    if (remainder.length === 1) {
-      const rest = 100 - specifiedSum;
-      if (rest < 0) return { error: `Sum exceeds 100% (${specifiedSum.toFixed(1)}%)` };
-      remainder[0].pct = rest;
-    }
-
-    const massFractions: Record<string, number> = {};
-    const moles: Record<string, number> = {};
-    let totalMoles = 0;
-    let density = 0;
-    const nameParts: string[] = [];
-
-    for (const e of entries) {
-      const wt = (e.pct ?? 0) / 100;
-      massFractions[e.symbol] = wt;
-      const atomicWeight = STANDARD_ATOMIC_WEIGHT[e.symbol] ?? 1;
-      const mol = wt / atomicWeight;
-      moles[e.symbol] = mol;
-      totalMoles += mol;
-      density += wt * (ELEMENT_DENSITIES[e.symbol] ?? 5);
-      nameParts.push(`${e.symbol}${Math.round(e.pct ?? 0)}`);
-    }
-
-    const atomFracs = entries.map((e) => ({ symbol: e.symbol, frac: moles[e.symbol] / totalMoles }));
-    const minFrac = Math.min(...atomFracs.map((a) => a.frac));
-    const formula = atomFracs
-      .map((a) => {
-        const ratio = a.frac / minFrac;
-        const rounded = Math.round(ratio * 100) / 100;
-        return rounded === 1 ? a.symbol : `${a.symbol}${rounded}`;
-      })
-      .join("");
-
-    return { ok: { type: "mass-ratio", formula, elements: entries.map((e) => e.symbol), density, autoName: nameParts.join("-"), massFractions } };
-  }
-
-  let parseResult = $derived.by((): ParseResult => {
-    if (!newFormula.trim()) return null;
-    return parseMaterialInput(newFormula);
-  });
-
-  let formulaPreview = $derived<ParsedMaterial | null>(
-    parseResult && "ok" in parseResult ? parseResult.ok : null,
-  );
-
-  let parsedError = $derived<string | null>(
-    parseResult && "error" in parseResult ? parseResult.error : null,
-  );
-
-  $effect(() => {
-    const result = formulaPreview;
-    if (result && !nameManuallySet) {
-      newName = result.autoName;
-    }
-    if (result?.density && newDensity === null) {
-      newDensity = result.density;
+      textDraft = "";
+      textDirty = false;
+      formError = null;
     }
   });
 
   async function handleSave() {
-    const preview = formulaPreview;
-    if (!preview) return;
-
-    const nameVal = newName.trim() || preview.autoName;
-    const densityVal = newDensity;
-
+    if (!formulaPreview) return;
+    const nameVal = (effectiveName.trim() || formulaPreview.autoName);
+    const densityVal = effectiveDensity;
     if (densityVal === null || densityVal <= 0) {
-      formulaError = "Enter density (g/cm³)";
+      formError = "Enter density (g/cm³)";
       return;
     }
-
     saving = true;
-    formulaError = null;
+    formError = null;
     try {
       if (editingCustomId) {
-        await updateCustomMaterial(editingCustomId, nameVal, preview.formula, densityVal, preview.massFractions, newFormula.trim(), currentEnrichment);
+        await updateCustomMaterial(
+          editingCustomId,
+          nameVal,
+          formulaPreview.formula,
+          densityVal,
+          formulaPreview.massFractions,
+          serialised,
+          currentEnrichment,
+        );
       } else {
-        await saveCustomMaterial(nameVal, preview.formula, densityVal, preview.massFractions, newFormula.trim(), currentEnrichment);
+        await saveCustomMaterial(
+          nameVal,
+          formulaPreview.formula,
+          densityVal,
+          formulaPreview.massFractions,
+          serialised,
+          currentEnrichment,
+        );
       }
       oncommit(nameVal, currentEnrichment);
     } catch {
-      formulaError = "Failed to save";
+      formError = "Failed to save";
     } finally {
       saving = false;
     }
   }
 
   function useFormula() {
-    const preview = formulaPreview;
-    if (!preview) return;
-    oncommit(preview.formula);
+    if (!formulaPreview) return;
+    oncommit(formulaPreview.formula);
   }
 </script>
 
@@ -216,42 +147,47 @@
 
   {#if defineOpen}
     <div class="define-form">
-      <label class="field-label">
-        Composition
-        <input
-          type="text"
-          class="field-input"
-          placeholder="Al2O3  or  Al 80%, Cu 5%, Zn %"
-          bind:value={newFormula}
-          oninput={() => { formulaError = null; if (!editingCustomId) nameManuallySet = false; }}
-        />
-      </label>
-      <p class="hint">Stoichiometric formula or mass ratios (comma-separated with %)</p>
+      <div class="rows-section">
+        <span class="rows-heading">Composition</span>
+        {#if rows.length === 0}
+          <p class="empty-hint">No elements yet — paste a formula or pick from the periodic table (coming soon).</p>
+        {:else}
+          <ul class="rows-list">
+            {#each rows as r (r.id)}
+              <li class="row-item">
+                <span class="row-symbol">{r.symbol}</span>
+                <span class="row-value">{r.isBalance ? "balance" : (r.value ?? "—")}</span>
+                <span class="row-unit">{r.unit}</span>
+              </li>
+            {/each}
+          </ul>
+        {/if}
 
-      {#if formulaPreview}
-        <div class="preview">
-          <span class="preview-type">{formulaPreview.type}</span>
-          {#if formulaPreview.type === "mass-ratio"}
-            <span class="preview-formula">{formulaPreview.formula}</span>
-          {/if}
-          {#each formulaPreview.elements as el}
-            <button
-              class="el-badge"
-              class:enriched={!!currentEnrichment?.[el]}
-              onclick={() => onenrichment?.(el)}
-            >{el}</button>
-          {/each}
-        </div>
-      {/if}
+        {#if formulaPreview}
+          <div class="preview">
+            <span class="preview-type">{formulaPreview.type}</span>
+            {#if formulaPreview.type === "mass-ratio"}
+              <span class="preview-formula">{formulaPreview.formula}</span>
+            {/if}
+            {#each formulaPreview.elements as el}
+              <button
+                class="el-badge"
+                class:enriched={!!currentEnrichment?.[el]}
+                onclick={() => onenrichment?.(el)}
+              >{el}</button>
+            {/each}
+          </div>
+        {/if}
+      </div>
 
       <label class="field-label">
         Name
         <input
           type="text"
           class="field-input"
-          placeholder={formulaPreview?.autoName ?? "auto-filled from composition"}
-          bind:value={newName}
-          oninput={() => { nameManuallySet = true; }}
+          placeholder={autoName || "auto-filled from composition"}
+          value={effectiveName}
+          oninput={(e) => { nameDraft = (e.target as HTMLInputElement).value; nameManuallySet = true; }}
         />
         <span class="field-hint">Auto-filled — edit to override</span>
       </label>
@@ -262,25 +198,32 @@
           type="text"
           inputmode="decimal"
           class="field-input"
-          placeholder={formulaPreview?.density?.toFixed(2) ?? "e.g. 2.70"}
-          value={newDensity !== null ? String(newDensity) : ""}
-          oninput={(e) => { const v = parseFloat((e.target as HTMLInputElement).value); newDensity = Number.isFinite(v) ? v : null; }}
+          placeholder={autoDensity !== null ? autoDensity.toFixed(2) : "e.g. 2.70"}
+          value={effectiveDensity !== null ? String(effectiveDensity) : ""}
+          oninput={(e) => {
+            const v = parseFloat((e.target as HTMLInputElement).value);
+            densityDraft = Number.isFinite(v) ? v : null;
+            densityManuallySet = true;
+          }}
         />
       </label>
 
-      {#if parsedError || formulaError}
-        <p class="form-error">{parsedError ?? formulaError}</p>
+      {#if formError}
+        <p class="form-error">{formError}</p>
       {/if}
+      {#each validation as issue}
+        <p class="form-{issue.level}">{issue.message}</p>
+      {/each}
 
       <div class="form-actions">
         <button
           class="use-formula-btn"
-          disabled={!formulaPreview}
+          disabled={!canCommit}
           onclick={useFormula}
         >Use without saving</button>
         <button
           class="save-btn"
-          disabled={saving || !formulaPreview || newDensity === null || (newDensity ?? 0) <= 0}
+          disabled={saving || !canCommit || effectiveDensity === null || (effectiveDensity ?? 0) <= 0}
           onclick={handleSave}
         >{saving ? "Saving..." : editingCustomId ? "Update & Use" : "Save & Use"}</button>
       </div>
@@ -320,6 +263,48 @@
     border-radius: 4px;
   }
 
+  .rows-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .rows-heading {
+    font-size: 0.75rem;
+    color: var(--c-text-muted);
+  }
+
+  .empty-hint {
+    font-size: 0.7rem;
+    color: var(--c-text-subtle);
+    margin: 0;
+    font-style: italic;
+  }
+
+  .rows-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .row-item {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    padding: 0.2rem 0.4rem;
+    background: var(--c-bg-subtle);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    font-size: 0.75rem;
+  }
+
+  .row-symbol { font-weight: 500; min-width: 2rem; color: var(--c-text); }
+  .row-value { color: var(--c-text-muted); }
+  .row-unit { color: var(--c-text-subtle); font-size: 0.65rem; text-transform: uppercase; }
+
   .field-label {
     display: flex;
     flex-direction: column;
@@ -342,13 +327,6 @@
   .field-hint {
     font-size: 0.6rem;
     color: var(--c-text-subtle);
-    font-style: italic;
-  }
-
-  .hint {
-    font-size: 0.65rem;
-    color: var(--c-text-subtle);
-    margin: 0;
     font-style: italic;
   }
 
@@ -400,6 +378,12 @@
   .form-error {
     color: var(--c-red);
     font-size: 0.75rem;
+    margin: 0;
+  }
+
+  .form-warning {
+    color: var(--c-yellow, var(--c-text-muted));
+    font-size: 0.7rem;
     margin: 0;
   }
 

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -116,11 +116,19 @@
     elementPickerOpen = true;
   }
 
-  function closePicker() {
+  /** Close the picker. `returnFocus` defaults to true (Escape, ×, click-out
+   *  all want focus on the trigger). PT.onselect passes false because it
+   *  immediately focuses the new row's value input — keeping both branches
+   *  in this single function avoids a double-rAF race where the trigger
+   *  refocus would fight the row-input refocus for the next frame. */
+  function closePicker(returnFocus = true) {
     if (!elementPickerOpen) return;
     elementPickerOpen = false;
-    // Return focus to the trigger after the modal unmounts.
-    requestAnimationFrame(() => addBtnRef?.focus());
+    if (returnFocus) {
+      // addBtnRef may be null if the form was collapsed mid-flight; falling
+      // back to <body> is fine.
+      requestAnimationFrame(() => addBtnRef?.focus());
+    }
   }
 
   function onPickerKeydown(e: KeyboardEvent) {
@@ -151,8 +159,9 @@
   function handlePtSelect(symbol: string) {
     const id = generateRowId();
     rows = [...rows, { id, symbol, value: null, unit: "wt%", isBalance: false }];
-    closePicker();
-    // After the row mounts, focus its number input.
+    // closePicker(false) suppresses the trigger-refocus rAF; we focus the
+    // new row's number input instead.
+    closePicker(false);
     requestAnimationFrame(() => {
       const el = document.querySelector<HTMLInputElement>(
         `[data-row-id="${id}"] .value-input`,
@@ -210,9 +219,10 @@
     });
   });
 
-  // Seed/reset from the editInitial prop. This effect watches the prop, not
-  // rows/textDraft, so it does not violate the "no $effect on rows or
-  // textDraft" rule.
+  // Seed/reset from the editInitial prop. Svelte 5 read-tracking is per-rune
+  // *read*, not write — assigning to rows / textDraft inside this block does
+  // NOT add them to the effect's deps. The only tracked read is `editInitial`,
+  // so this respects the §3.1 "no $effect on rows or textDraft" rule.
   $effect(() => {
     if (editInitial) {
       const parsed = parseMaterialInput(editInitial.formula);
@@ -417,7 +427,7 @@
     >
       <div class="picker-header">
         <h3>Pick an element</h3>
-        <button class="picker-close" aria-label="Close" onclick={closePicker}>×</button>
+        <button class="picker-close" aria-label="Close" onclick={() => closePicker()}>×</button>
       </div>
       <div class="picker-body">
         <PeriodicTable onselect={handlePtSelect} />

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -1,0 +1,173 @@
+<script lang="ts">
+  import type { Issue, Row, Unit } from "./define-form-rows";
+
+  interface Props {
+    row: Row;
+    /** Shared name across all balance radios in this form so the browser
+     *  enforces single-selection within the radiogroup. */
+    radioName: string;
+    issues: Issue[];
+    /** Parent splices immutably. No bind: into nested $state per #64 §3.2. */
+    onchange: (patch: Partial<Row>) => void;
+    onremove: () => void;
+  }
+
+  let { row, radioName, issues, onchange, onremove }: Props = $props();
+
+  const UNIT_LABEL: Record<Unit, string> = {
+    "wt%": "wt%",
+    atomfrac: "atom frac",
+    stoich: "stoich",
+  };
+</script>
+
+<div class="row" role="row" data-row-id={row.id}>
+  <span class="symbol" role="gridcell">{row.symbol}</span>
+
+  <input
+    type="number"
+    class="value-input"
+    role="gridcell"
+    inputmode="decimal"
+    step="any"
+    min="0"
+    placeholder={row.isBalance ? "balance" : "0"}
+    aria-label={`Value for ${row.symbol}`}
+    disabled={row.isBalance}
+    value={row.value ?? ""}
+    oninput={(e) => {
+      const v = parseFloat((e.target as HTMLInputElement).value);
+      onchange({ value: Number.isFinite(v) ? v : null });
+    }}
+  />
+
+  <select
+    class="unit-select"
+    role="gridcell"
+    aria-label={`Unit for ${row.symbol}`}
+    value={row.unit}
+    onchange={(e) => onchange({ unit: (e.target as HTMLSelectElement).value as Unit })}
+  >
+    <option value="wt%">{UNIT_LABEL["wt%"]}</option>
+    <option value="atomfrac">{UNIT_LABEL.atomfrac}</option>
+    <option value="stoich">{UNIT_LABEL.stoich}</option>
+  </select>
+
+  <label class="balance-label" role="gridcell" title="Use this row to balance to 100%">
+    <input
+      type="radio"
+      name={radioName}
+      checked={row.isBalance}
+      onchange={(e) => {
+        const checked = (e.target as HTMLInputElement).checked;
+        onchange({ isBalance: checked, ...(checked ? { value: null } : {}) });
+      }}
+    />
+    <span class="balance-text">balance</span>
+  </label>
+
+  <button
+    type="button"
+    class="remove-btn"
+    role="gridcell"
+    aria-label={`Remove ${row.symbol}`}
+    onclick={onremove}
+  >×</button>
+</div>
+
+{#if issues.length > 0}
+  <div class="row-issues">
+    {#each issues as issue}
+      <p class="issue-{issue.level}">{issue.message}</p>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .row {
+    display: grid;
+    grid-template-columns: 2.2rem minmax(0, 1fr) 5rem auto 1.5rem;
+    gap: 0.4rem;
+    align-items: center;
+    padding: 0.25rem 0.4rem;
+    background: var(--c-bg-subtle);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    font-size: 0.75rem;
+  }
+
+  .symbol {
+    font-weight: 500;
+    color: var(--c-text);
+  }
+
+  .value-input,
+  .unit-select {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    color: var(--c-text);
+    padding: 0.15rem 0.3rem;
+    font-size: 0.75rem;
+    min-width: 0;
+  }
+
+  .value-input:focus,
+  .unit-select:focus {
+    outline: none;
+    border-color: var(--c-accent);
+  }
+
+  .value-input:disabled {
+    color: var(--c-text-subtle);
+    background: var(--c-bg-muted);
+  }
+
+  .balance-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    color: var(--c-text-muted);
+    font-size: 0.7rem;
+    cursor: pointer;
+  }
+
+  .balance-label input[type="radio"] {
+    accent-color: var(--c-accent);
+    cursor: pointer;
+  }
+
+  .balance-text {
+    user-select: none;
+  }
+
+  .remove-btn {
+    background: none;
+    border: none;
+    color: var(--c-text-subtle);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    border-radius: 3px;
+  }
+
+  .remove-btn:hover { color: var(--c-red); }
+  .remove-btn:focus-visible { outline: 2px solid var(--c-accent); outline-offset: 1px; }
+
+  .row-issues {
+    margin: 0.15rem 0 0.3rem 0.6rem;
+  }
+
+  .issue-error {
+    color: var(--c-red);
+    font-size: 0.7rem;
+    margin: 0;
+  }
+
+  .issue-warning {
+    color: var(--c-yellow, var(--c-text-muted));
+    font-size: 0.7rem;
+    margin: 0;
+  }
+</style>

--- a/frontend/src/lib/components/material/define-form-rows.test.ts
+++ b/frontend/src/lib/components/material/define-form-rows.test.ts
@@ -1,0 +1,365 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateRowId,
+  parseMaterialInput,
+  serialise,
+  toRows,
+  validate,
+  type Row,
+} from "./define-form-rows";
+
+function row(partial: Partial<Row> = {}): Row {
+  return {
+    id: partial.id ?? generateRowId(),
+    symbol: partial.symbol ?? "Cu",
+    value: "value" in partial ? (partial.value ?? null) : 100,
+    unit: partial.unit ?? "wt%",
+    isBalance: partial.isBalance ?? false,
+  };
+}
+
+describe("parseMaterialInput", () => {
+  it("returns null for empty input", () => {
+    expect(parseMaterialInput("")).toBeNull();
+    expect(parseMaterialInput("   ")).toBeNull();
+  });
+
+  it("parses a simple stoichiometric formula", () => {
+    const result = parseMaterialInput("Al2O3");
+    expect(result).toBeTruthy();
+    expect(result).toHaveProperty("ok");
+    if (result && "ok" in result) {
+      expect(result.ok.type).toBe("stoichiometric");
+      expect(result.ok.elements).toEqual(["Al", "O"]);
+      expect(result.ok.stoichCounts).toEqual({ Al: 2, O: 3 });
+    }
+  });
+
+  it("parses water with compound density", () => {
+    const result = parseMaterialInput("H2O");
+    if (result && "ok" in result) {
+      expect(result.ok.density).toBe(1.0);
+    } else {
+      throw new Error("expected ok");
+    }
+  });
+
+  it("parses mass-ratio with explicit balance", () => {
+    const result = parseMaterialInput("Al 80%, Cu 5%, Zn %");
+    if (!result || !("ok" in result)) throw new Error("expected ok");
+    expect(result.ok.type).toBe("mass-ratio");
+    expect(result.ok.balanceSymbol).toBe("Zn");
+    expect(result.ok.massFractions).toBeDefined();
+    expect(result.ok.massFractions!.Zn).toBeCloseTo(0.15, 4);
+  });
+
+  it("parses mass-ratio with all percentages explicit", () => {
+    const result = parseMaterialInput("Al 90%, Cu 10%");
+    if (!result || !("ok" in result)) throw new Error("expected ok");
+    expect(result.ok.balanceSymbol).toBeUndefined();
+    expect(result.ok.massFractions!.Al).toBeCloseTo(0.9);
+  });
+
+  it("rejects unknown element in formula", () => {
+    const result = parseMaterialInput("Xx2O3");
+    expect(result).toEqual({ error: expect.stringMatching(/Unknown element/) });
+  });
+
+  it("rejects unknown element in mass-ratio", () => {
+    const result = parseMaterialInput("Xx 50%, Cu 50%");
+    expect(result).toEqual({ error: expect.stringMatching(/Unknown element: Xx/) });
+  });
+
+  it("rejects mass-ratio with >1 balance", () => {
+    const result = parseMaterialInput("Al %, Cu %, Zn 50%");
+    expect(result).toEqual({ error: expect.stringMatching(/unspecified/) });
+  });
+
+  it("rejects mass-ratio with sum >100 + no balance", () => {
+    const result = parseMaterialInput("Al 70%, Cu 70%");
+    expect(result).toEqual({ error: expect.stringMatching(/100%/) });
+  });
+
+  it("rejects mass-ratio with sum exceeding 100 even with balance", () => {
+    const result = parseMaterialInput("Al 60%, Cu 60%, Zn %");
+    expect(result).toEqual({ error: expect.stringMatching(/Sum exceeds/) });
+  });
+
+  it("rejects malformed mass-ratio token", () => {
+    const result = parseMaterialInput("Al 80%, garbage, Cu 20%");
+    expect(result).toEqual({ error: expect.stringMatching(/Invalid/) });
+  });
+});
+
+describe("toRows", () => {
+  it("converts a stoichiometric parse to stoich rows", () => {
+    const parsed = parseMaterialInput("Al2O3");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const rows = toRows(parsed.ok);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({ symbol: "Al", unit: "stoich", value: 2, isBalance: false });
+    expect(rows[1]).toMatchObject({ symbol: "O", unit: "stoich", value: 3, isBalance: false });
+  });
+
+  it("converts a single-element stoichiometric parse", () => {
+    const parsed = parseMaterialInput("Cu");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const rows = toRows(parsed.ok);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ symbol: "Cu", unit: "stoich", value: 1, isBalance: false });
+  });
+
+  it("converts a mass-ratio parse to wt% rows with balance flag", () => {
+    const parsed = parseMaterialInput("Al 80%, Cu 5%, Zn %");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const rows = toRows(parsed.ok);
+    expect(rows.map((r) => r.symbol)).toEqual(["Al", "Cu", "Zn"]);
+    expect(rows.map((r) => r.unit)).toEqual(["wt%", "wt%", "wt%"]);
+    expect(rows.map((r) => r.isBalance)).toEqual([false, false, true]);
+    expect(rows[0].value).toBeCloseTo(80, 4);
+    expect(rows[1].value).toBeCloseTo(5, 4);
+    expect(rows[2].value).toBeCloseTo(15, 4);
+  });
+
+  it("assigns unique row IDs", () => {
+    const parsed = parseMaterialInput("FeCrNi");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const rows = toRows(parsed.ok);
+    const ids = new Set(rows.map((r) => r.id));
+    expect(ids.size).toBe(3);
+  });
+});
+
+describe("serialise", () => {
+  it("returns empty string for empty rows", () => {
+    expect(serialise([])).toBe("");
+  });
+
+  it("serialises stoichiometric rows as a chemical formula", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "stoich", value: 2 }),
+      row({ symbol: "O", unit: "stoich", value: 3 }),
+    ];
+    expect(serialise(rows)).toBe("Al2O3");
+  });
+
+  it("omits count of 1 in stoichiometric serialisation", () => {
+    const rows: Row[] = [
+      row({ symbol: "Fe", unit: "stoich", value: 1 }),
+      row({ symbol: "O", unit: "stoich", value: 2 }),
+    ];
+    expect(serialise(rows)).toBe("FeO2");
+  });
+
+  it("serialises wt% rows with explicit percentages", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
+      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
+      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
+    ];
+    expect(serialise(rows)).toBe("Al 80%, Cu 5%, Zn %");
+  });
+
+  it("serialises a single wt% row with balance as bare percentage", () => {
+    const rows: Row[] = [row({ symbol: "Cu", unit: "wt%", isBalance: true, value: null })];
+    expect(serialise(rows)).toBe("Cu %");
+  });
+
+  it("serialises mixed units as best-effort stoich form", () => {
+    const rows: Row[] = [
+      row({ symbol: "Fe", unit: "stoich", value: 1 }),
+      row({ symbol: "Cr", unit: "wt%", value: 18 }),
+    ];
+    expect(serialise(rows)).toBe("FeCr18");
+  });
+});
+
+describe("serialise round-trip", () => {
+  it("text → rows → text is canonical for stoichiometric input", () => {
+    const parsed = parseMaterialInput("Al2O3");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    expect(serialise(toRows(parsed.ok))).toBe("Al2O3");
+  });
+
+  it("text → rows → text is canonical for mass-ratio input with balance", () => {
+    const parsed = parseMaterialInput("Al 80%, Cu 5%, Zn %");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    expect(serialise(toRows(parsed.ok))).toBe("Al 80%, Cu 5%, Zn %");
+  });
+
+  it("text → rows → text is canonical for FeO2", () => {
+    const parsed = parseMaterialInput("FeO2");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    expect(serialise(toRows(parsed.ok))).toBe("FeO2");
+  });
+
+  it("text → rows → text for mass-ratio without balance preserves entries", () => {
+    const parsed = parseMaterialInput("Al 90%, Cu 10%");
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    expect(serialise(toRows(parsed.ok))).toBe("Al 90%, Cu 10%");
+  });
+});
+
+describe("validate", () => {
+  it("accepts a clean row list", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
+      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
+      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
+    ];
+    expect(validate(rows)).toEqual([]);
+  });
+
+  it("flags duplicate symbols as warnings", () => {
+    const rows: Row[] = [
+      row({ symbol: "Cu", unit: "wt%", value: 50 }),
+      row({ symbol: "Cu", unit: "wt%", value: 50 }),
+    ];
+    const issues = validate(rows);
+    const dup = issues.filter((i) => i.message.includes("Duplicate"));
+    expect(dup.length).toBe(1);
+    expect(dup[0].level).toBe("warning");
+  });
+
+  it("flags >1 balance row as form-level error", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", isBalance: true, value: null }),
+      row({ symbol: "Cu", unit: "wt%", isBalance: true, value: null }),
+    ];
+    const issues = validate(rows);
+    expect(issues.some((i) => i.level === "error" && i.message.includes("balance"))).toBe(true);
+  });
+
+  it("flags non-balance row with null value as row-scoped error", () => {
+    const rows: Row[] = [
+      row({ id: "r1", symbol: "Al", unit: "wt%", value: null, isBalance: false }),
+    ];
+    const issues = validate(rows);
+    const blank = issues.find((i) => i.rowId === "r1" && i.level === "error");
+    expect(blank).toBeDefined();
+    expect(blank!.message).toMatch(/value/i);
+  });
+
+  it("flags negative value as row-scoped error", () => {
+    const rows: Row[] = [
+      row({ id: "r1", symbol: "Al", unit: "wt%", value: -10, isBalance: false }),
+    ];
+    const issues = validate(rows);
+    expect(
+      issues.some((i) => i.rowId === "r1" && i.level === "error" && /non-negative/.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("flags wt% sum != 100 (no balance) as warning", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 50 }),
+      row({ symbol: "Cu", unit: "wt%", value: 30 }),
+    ];
+    const issues = validate(rows);
+    expect(
+      issues.some((i) => i.level === "warning" && /sum/i.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("does not flag wt% sum when balance row is present", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 50 }),
+      row({ symbol: "Cu", unit: "wt%", value: 30 }),
+      row({ symbol: "Zn", unit: "wt%", value: null, isBalance: true }),
+    ];
+    const issues = validate(rows);
+    expect(issues.some((i) => /sum/i.test(i.message))).toBe(false);
+  });
+
+  it("flags wt% sum > 100 with balance as error (negative balance)", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 60 }),
+      row({ symbol: "Cu", unit: "wt%", value: 60 }),
+      row({ symbol: "Zn", unit: "wt%", value: null, isBalance: true }),
+    ];
+    const issues = validate(rows);
+    expect(
+      issues.some((i) => i.level === "error" && /exceed/i.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("flags mixed units as form-level warning", () => {
+    const rows: Row[] = [
+      row({ symbol: "Fe", unit: "stoich", value: 1 }),
+      row({ symbol: "Cr", unit: "wt%", value: 18 }),
+    ];
+    const issues = validate(rows);
+    expect(
+      issues.some((i) => i.level === "warning" && /mixed units/i.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("flags unknown symbol as row-scoped error", () => {
+    const rows: Row[] = [row({ id: "r1", symbol: "Xx", unit: "wt%", value: 50 })];
+    const issues = validate(rows);
+    expect(
+      issues.some((i) => i.rowId === "r1" && i.level === "error" && /Unknown/.test(i.message)),
+    ).toBe(true);
+  });
+
+  it("returns empty issues for empty rows (form is empty, not invalid)", () => {
+    expect(validate([])).toEqual([]);
+  });
+
+  it("ignores blank symbol field (not a known element check)", () => {
+    const rows: Row[] = [row({ id: "r1", symbol: "", unit: "wt%", value: 50 })];
+    const issues = validate(rows);
+    // empty symbol isn't a known-element error; it's just a row in flux
+    expect(issues.some((i) => /Unknown/.test(i.message))).toBe(false);
+  });
+
+  it("treats stoich-only rows without sum check", () => {
+    const rows: Row[] = [
+      row({ symbol: "Al", unit: "stoich", value: 2 }),
+      row({ symbol: "O", unit: "stoich", value: 3 }),
+    ];
+    expect(validate(rows)).toEqual([]);
+  });
+
+  it("preserves error/warning ordering deterministically", () => {
+    const rows: Row[] = [
+      row({ id: "a", symbol: "Cu", unit: "wt%", value: null }),
+      row({ id: "b", symbol: "Cu", unit: "wt%", value: null }),
+    ];
+    const issues = validate(rows);
+    // Duplicate first (warning), then two missing-value errors
+    expect(issues.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("serialise → parseMaterialInput → toRows round-trip", () => {
+  it("survives stoichiometric round-trip", () => {
+    const original: Row[] = [
+      row({ symbol: "Al", unit: "stoich", value: 2 }),
+      row({ symbol: "O", unit: "stoich", value: 3 }),
+    ];
+    const text = serialise(original);
+    const parsed = parseMaterialInput(text);
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const round = toRows(parsed.ok);
+    expect(round.map((r) => ({ s: r.symbol, u: r.unit, v: r.value, b: r.isBalance }))).toEqual(
+      original.map((r) => ({ s: r.symbol, u: r.unit, v: r.value, b: r.isBalance })),
+    );
+  });
+
+  it("survives mass-ratio round-trip with balance", () => {
+    const original: Row[] = [
+      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
+      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
+      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
+    ];
+    const text = serialise(original);
+    const parsed = parseMaterialInput(text);
+    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
+    const round = toRows(parsed.ok);
+    expect(round.map((r) => r.symbol)).toEqual(["Al", "Cu", "Zn"]);
+    expect(round.map((r) => r.isBalance)).toEqual([false, false, true]);
+    expect(round[0].value).toBeCloseTo(80, 4);
+    expect(round[2].value).toBeCloseTo(15, 4);
+  });
+});

--- a/frontend/src/lib/components/material/define-form-rows.ts
+++ b/frontend/src/lib/components/material/define-form-rows.ts
@@ -1,0 +1,348 @@
+/**
+ * Pure helpers backing the rows-based DefineForm UI.
+ *
+ * Rows are the source of truth; the paste-formula text field is a derived
+ * view (when clean) or a draft (when dirty). All round-trips between rows
+ * and text are pure functions called from event handlers — no $effects.
+ *
+ * Refs: #64 §3.1
+ */
+import {
+  COMPOUND_DENSITIES,
+  ELEMENT_DENSITIES,
+  parseFormula,
+  STANDARD_ATOMIC_WEIGHT,
+  SYMBOL_TO_Z,
+} from "@hyrr/compute";
+
+export type Unit = "wt%" | "atomfrac" | "stoich";
+
+export interface Row {
+  id: string;
+  symbol: string;
+  value: number | null;
+  unit: Unit;
+  isBalance: boolean;
+}
+
+export interface ParsedMaterial {
+  type: "stoichiometric" | "mass-ratio";
+  formula: string;
+  elements: string[];
+  density: number | null;
+  autoName: string;
+  /** Mass fractions (0..1), only set for mass-ratio inputs. */
+  massFractions?: Record<string, number>;
+  /** Integer stoichiometric counts, only set for stoichiometric inputs. */
+  stoichCounts?: Record<string, number>;
+  /** Element symbol that supplied the balance ("Zn %"), only set when used. */
+  balanceSymbol?: string;
+}
+
+export type ParseResult =
+  | { ok: ParsedMaterial }
+  | { error: string }
+  | null;
+
+export interface Issue {
+  /** Row id when the issue is row-scoped; absent when it's form-level. */
+  rowId?: string;
+  level: "error" | "warning";
+  message: string;
+}
+
+export function parseMaterialInput(input: string): ParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.includes("%")) {
+    return parseMassRatio(trimmed);
+  }
+
+  try {
+    const counts = parseFormula(trimmed);
+    const elements = Object.keys(counts);
+    if (elements.length === 0) return { error: "No elements found in formula" };
+    for (const el of elements) {
+      if (!SYMBOL_TO_Z[el]) return { error: `Unknown element: ${el}` };
+    }
+    let density: number | null = null;
+    if (COMPOUND_DENSITIES[trimmed]) {
+      density = COMPOUND_DENSITIES[trimmed];
+    } else if (elements.length === 1 && ELEMENT_DENSITIES[elements[0]]) {
+      density = ELEMENT_DENSITIES[elements[0]];
+    }
+    return {
+      ok: {
+        type: "stoichiometric",
+        formula: trimmed,
+        elements,
+        density,
+        autoName: trimmed,
+        stoichCounts: counts,
+      },
+    };
+  } catch {
+    return { error: "Invalid formula" };
+  }
+}
+
+function parseMassRatio(input: string): ParseResult {
+  const parts = input.split(",").map((s) => s.trim()).filter(Boolean);
+  const entries: { symbol: string; pct: number | null }[] = [];
+
+  for (const part of parts) {
+    const m = part.match(/^([A-Z][a-z]?)\s*(\d+(?:\.\d+)?)?\s*%$/);
+    if (!m) return { error: `Invalid: "${part}". Use "Al 80%, Cu 5%, Zn %"` };
+    const sym = m[1];
+    if (!SYMBOL_TO_Z[sym]) return { error: `Unknown element: ${sym}` };
+    entries.push({ symbol: sym, pct: m[2] ? parseFloat(m[2]) : null });
+  }
+
+  const specified = entries.filter((e) => e.pct !== null);
+  const remainder = entries.filter((e) => e.pct === null);
+  const specifiedSum = specified.reduce((s, e) => s + (e.pct ?? 0), 0);
+
+  if (remainder.length > 1) return { error: "Only one element can have unspecified %" };
+  if (remainder.length === 0 && Math.abs(specifiedSum - 100) > 0.5) {
+    return { error: `Sum is ${specifiedSum.toFixed(1)}%, needs 100%` };
+  }
+  let balanceSymbol: string | undefined;
+  if (remainder.length === 1) {
+    const rest = 100 - specifiedSum;
+    if (rest < 0) return { error: `Sum exceeds 100% (${specifiedSum.toFixed(1)}%)` };
+    remainder[0].pct = rest;
+    balanceSymbol = remainder[0].symbol;
+  }
+
+  const massFractions: Record<string, number> = {};
+  const moles: Record<string, number> = {};
+  let totalMoles = 0;
+  let density = 0;
+  const nameParts: string[] = [];
+
+  for (const e of entries) {
+    const wt = (e.pct ?? 0) / 100;
+    massFractions[e.symbol] = wt;
+    const atomicWeight = STANDARD_ATOMIC_WEIGHT[e.symbol] ?? 1;
+    const mol = wt / atomicWeight;
+    moles[e.symbol] = mol;
+    totalMoles += mol;
+    density += wt * (ELEMENT_DENSITIES[e.symbol] ?? 5);
+    nameParts.push(`${e.symbol}${Math.round(e.pct ?? 0)}`);
+  }
+
+  const atomFracs = entries.map((e) => ({ symbol: e.symbol, frac: moles[e.symbol] / totalMoles }));
+  const minFrac = Math.min(...atomFracs.map((a) => a.frac));
+  const formula = atomFracs
+    .map((a) => {
+      const ratio = a.frac / minFrac;
+      const rounded = Math.round(ratio * 100) / 100;
+      return rounded === 1 ? a.symbol : `${a.symbol}${rounded}`;
+    })
+    .join("");
+
+  return {
+    ok: {
+      type: "mass-ratio",
+      formula,
+      elements: entries.map((e) => e.symbol),
+      density,
+      autoName: nameParts.join("-"),
+      massFractions,
+      balanceSymbol,
+    },
+  };
+}
+
+let __idCounter = 0;
+/** ID generator. Uses crypto.randomUUID when available; otherwise a counter
+ *  + timestamp suffix that's stable for the duration of one session. */
+export function generateRowId(): string {
+  const g = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (g?.randomUUID) return g.randomUUID();
+  __idCounter += 1;
+  return `row-${Date.now()}-${__idCounter}`;
+}
+
+/**
+ * Convert a successful ParsedMaterial into a Row[].
+ *
+ * - mass-ratio: one row per entry, unit="wt%", value=percentage,
+ *   balanceSymbol → isBalance=true (value retained for display).
+ * - stoichiometric: one row per element, unit="stoich", value=count.
+ */
+export function toRows(parsed: ParsedMaterial): Row[] {
+  if (parsed.type === "mass-ratio") {
+    const fractions = parsed.massFractions ?? {};
+    return parsed.elements.map((sym) => ({
+      id: generateRowId(),
+      symbol: sym,
+      value: (fractions[sym] ?? 0) * 100,
+      unit: "wt%" as const,
+      isBalance: parsed.balanceSymbol === sym,
+    }));
+  }
+  // stoichiometric
+  const counts = parsed.stoichCounts ?? {};
+  return parsed.elements.map((sym) => ({
+    id: generateRowId(),
+    symbol: sym,
+    value: counts[sym] ?? 1,
+    unit: "stoich" as const,
+    isBalance: false,
+  }));
+}
+
+/**
+ * Serialise rows back to a string the user could paste into the text field.
+ *
+ * - All wt% rows → "Al 80%, Cu 5%, Zn %" (balance row gets blank percentage).
+ * - All stoich rows → chemical formula "Al2O3" (count omitted when 1).
+ * - All atomfrac rows → "Al0.4Cu0.6"-style decimal-stoich (informational; the
+ *   parser cannot round-trip atomfrac, so callers should treat this as
+ *   display-only and prefer the stoich/wt% forms when possible).
+ * - Mixed units: stoich-priority chemical-formula form; round-trip is not
+ *   guaranteed (the validator surfaces a "mixed units" warning).
+ */
+export function serialise(rows: Row[]): string {
+  if (rows.length === 0) return "";
+  const units = new Set(rows.map((r) => r.unit));
+
+  if (units.size === 1 && units.has("wt%")) {
+    return rows
+      .map((r) => {
+        if (r.isBalance) return `${r.symbol} %`;
+        const val = r.value;
+        if (val === null || !Number.isFinite(val)) return `${r.symbol} %`;
+        const s = Number.isInteger(val) ? String(val) : String(val);
+        return `${r.symbol} ${s}%`;
+      })
+      .join(", ");
+  }
+
+  if (units.size === 1 && units.has("stoich")) {
+    return rows
+      .map((r) => {
+        const val = r.value;
+        if (val === null || val === 1) return r.symbol;
+        return `${r.symbol}${val}`;
+      })
+      .join("");
+  }
+
+  if (units.size === 1 && units.has("atomfrac")) {
+    return rows
+      .map((r) => {
+        const val = r.value;
+        if (val === null) return r.symbol;
+        return `${r.symbol}${val}`;
+      })
+      .join("");
+  }
+
+  // Mixed units: best-effort stoich-style serialisation. Validator will warn.
+  return rows
+    .map((r) => {
+      const val = r.value;
+      if (val === null || val === 1) return r.symbol;
+      return `${r.symbol}${val}`;
+    })
+    .join("");
+}
+
+/**
+ * Validate a Row[]. Returns a list of Issue records (errors and warnings).
+ * Empty array means the rows are clean.
+ */
+export function validate(rows: Row[]): Issue[] {
+  const issues: Issue[] = [];
+
+  // duplicate symbol → warning per duplicate row (after the first occurrence)
+  const seen = new Map<string, string>();
+  for (const r of rows) {
+    if (!r.symbol) continue;
+    const prev = seen.get(r.symbol);
+    if (prev !== undefined) {
+      issues.push({
+        rowId: r.id,
+        level: "warning",
+        message: `Duplicate element ${r.symbol}`,
+      });
+    } else {
+      seen.set(r.symbol, r.id);
+    }
+  }
+
+  // unknown symbol → error
+  for (const r of rows) {
+    if (r.symbol && !SYMBOL_TO_Z[r.symbol]) {
+      issues.push({
+        rowId: r.id,
+        level: "error",
+        message: `Unknown element: ${r.symbol}`,
+      });
+    }
+  }
+
+  // >1 balance row → error (form-level)
+  const balanceRows = rows.filter((r) => r.isBalance);
+  if (balanceRows.length > 1) {
+    issues.push({
+      level: "error",
+      message: "Only one row can be marked as balance",
+    });
+  }
+
+  // non-balance row with null value → error per row
+  for (const r of rows) {
+    if (r.isBalance) continue;
+    if (r.value === null || !Number.isFinite(r.value)) {
+      issues.push({
+        rowId: r.id,
+        level: "error",
+        message: "Enter a value",
+      });
+    } else if (r.value < 0) {
+      issues.push({
+        rowId: r.id,
+        level: "error",
+        message: "Value must be non-negative",
+      });
+    }
+  }
+
+  // mixed units → warning (form-level)
+  const units = new Set(rows.map((r) => r.unit));
+  if (units.size > 1) {
+    issues.push({
+      level: "warning",
+      message: "Mixed units — round-trip to text not guaranteed",
+    });
+  }
+
+  // wt% sum check (only when all rows are wt%, no balance):
+  const allWtPct = rows.length > 0 && units.size === 1 && units.has("wt%");
+  if (allWtPct) {
+    const hasBalance = balanceRows.length === 1;
+    const numericRows = rows.filter(
+      (r) => !r.isBalance && r.value !== null && Number.isFinite(r.value),
+    );
+    const sum = numericRows.reduce((s, r) => s + (r.value ?? 0), 0);
+    if (!hasBalance) {
+      if (Math.abs(sum - 100) > 0.5) {
+        issues.push({
+          level: "warning",
+          message: `Mass fractions sum to ${sum.toFixed(1)}%, expected 100%`,
+        });
+      }
+    } else if (sum > 100 + 0.5) {
+      issues.push({
+        level: "error",
+        message: `Mass fractions exceed 100% (${sum.toFixed(1)}%) — balance row would be negative`,
+      });
+    }
+  }
+
+  return issues;
+}


### PR DESCRIPTION
Phase 3 of #64 — replaces the single-text-input \`DefineForm.svelte\` with a rows-based UI where rows are the source of truth and the paste-formula text field is a derived view (clean) or draft (dirty).

## Summary

- Pure helpers (\`define-form-rows.ts\`): \`parseMaterialInput\`, \`toRows\`, \`serialise\`, \`validate\`. \`ParsedMaterial\` extended with \`stoichCounts\` + \`balanceSymbol\` so toRows can round-trip.
- Rows + textDraft + textDirty state shape per #64 §3.1; all rows↔text round-trips run inside event handlers (\`commitPastedText\`), never \$effects.
- Per-row controls in a new \`DefineFormRow.svelte\`: value input, unit dropdown (wt% / atom frac / stoich), balance radio in a shared radiogroup, × remove. Parent splices immutably via \`patchRow\` / \`removeRow\`; no \`bind:\` into nested \$state.
- \"+ element\" opens the standalone \`PeriodicTable\` in a \`role=\"dialog\" aria-modal=\"true\"\` overlay with Tab/Shift-Tab cycling, Escape close + trigger refocus. PT.onselect appends a row and focuses its number input.
- Persistent paste-formula input below the rows. Commits on Cmd/Ctrl-Enter or blur. Parse errors render inline; rows stay untouched.

## Verification

- \`svelte-check --threshold error\`: 2 baseline errors held (pre-existing in \`backend.ts\` and \`BugReportModal.svelte\`).
- \`vitest run\`: 297 → 338 (+41 cases for the rows helpers).
- \`playwright test --project=desktop-1280\`: 21/21 with the documented \`isotope-depth.spec.ts:30\` flake passing solo on retry (same baseline as Phase 2).

## Reviews

Two fresh-agent reviews both said ship:
- Impl-match against §3.1–§3.5: all 5 invariants pass.
- Svelte 5 runes specialist: 7-point mechanics check pass. They flagged a load-bearing double-rAF race in \`handlePtSelect\` (\`closePicker\` queued trigger refocus, \`handlePtSelect\` queued row-input refocus, second won by frame ordering) — addressed in the review-fix commit by giving \`closePicker\` an optional \`returnFocus\` flag so only one rAF fires per close path.

## Follow-up filed

- #87 — empty paste-formula on blur shouldn't silently nuke all rows. Same milestone.

## Out of scope (deferred per #64 handoff)

- §4.2 PT component DOM tests (needs jsdom + @testing-library/svelte infra)
- #76 PT polish (disabled-cell live-region, focus-ring halo doc)
- #85 PT integration polish (delete \`frontend/src/lib/compute/data-store.ts\` duplicate; custom-material-by-symbol routing)

Refs: #64