### PR TITLE
feat(material): unified material-form redesign — data-model spine + chip + picker + density-honesty (#92)

### DIFF
--- a/frontend/e2e/material-form-redesign.spec.ts
+++ b/frontend/e2e/material-form-redesign.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+/** Same TC99M preset used by the other material-popup specs. */
+const TC99M_URL =
+  "/hyrr/#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+
+async function waitReady(page: import("@playwright/test").Page) {
+  await page.waitForSelector(".status-bar", { state: "hidden", timeout: 30_000 }).catch(() => {});
+  await page.waitForSelector(".activity-table-enhanced", { timeout: 30_000 });
+}
+
+test.describe("Material-form redesign (#92)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TC99M_URL);
+    await waitReady(page);
+  });
+
+  test("paste 'SiO2 80%, H2O 20%' → mode flips to Mass mixture, rows materialize", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    // In Single mode, bottom paste-formula field is visible. Type a mass mixture.
+    const paste = page.getByPlaceholder(/Al2O3/);
+    await paste.fill("SiO2 80%, H2O 20%");
+    await paste.blur();
+
+    // Mode chip flips to Mass mixture.
+    await expect(page.getByRole("button", { name: /Mass mixture/i })).toBeVisible();
+
+    // Two rows: SiO2 + H2O.
+    const rowItems = page.locator('[role="row"][data-row-id]');
+    await expect(rowItems).toHaveCount(2);
+    await expect(rowItems.filter({ hasText: "SiO2" })).toBeVisible();
+    await expect(rowItems.filter({ hasText: "H2O" })).toBeVisible();
+  });
+
+  test("glassy mass mixture renders amber low-confidence chip with mol% nudge", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    const paste = page.getByPlaceholder(/Al2O3/);
+    await paste.fill("SiO2 75%, Na2O 14%, CaO 11%");
+    await paste.blur();
+
+    // Chip text contains a "?" suffix when low-confidence.
+    const chip = page.getByRole("button", { name: /Mass mixture\?/ });
+    await expect(chip).toBeVisible();
+    // Nudge mentions mol%.
+    await expect(page.getByText(/mol%/i)).toBeVisible();
+  });
+
+  test("density renders as suggestion only — Save disabled until accepted", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    await page.getByPlaceholder(/Al2O3/).fill("Al 80%, Cu 20%");
+    await page.getByPlaceholder(/Al2O3/).blur();
+
+    // Save & Use is disabled when density is empty.
+    const saveBtn = page.getByRole("button", { name: /Save & Use/ });
+    await expect(saveBtn).toBeDisabled();
+
+    // Use suggested button accepts the weighted-average estimate.
+    await page.getByRole("button", { name: /Use \d/ }).click();
+    await expect(saveBtn).toBeEnabled();
+  });
+});

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -78,6 +78,9 @@
   let elementPopupLayerIndex = $state(0);
   let isotopePopupOpen = $state(false);
   let isotopePopupData = $state({ name: "", Z: 0, A: 0, nuclearState: "" });
+  /** One-time banner shown after the 0.x material-schema break (#92).
+   *  Dismissed permanently in localStorage on close. */
+  let showSchemaBreakBanner = $state(false);
 
   // Must call initScheduler synchronously in component context for $effect
   initScheduler();
@@ -132,8 +135,15 @@
       restoreSerializableConfig(urlConfig);
     }
 
-    // Load custom materials and register density lookup
+    // Load custom materials and register density lookup. The 0.x material
+    // schema break (#92) clears any incompatible legacy entries by simply
+    // not migrating them; surface a one-time banner so users notice their
+    // saved customs may be gone after this deploy.
     await loadCustomMaterials();
+    try {
+      const seen = localStorage.getItem("hyrr.notice.materialSchemaBreak");
+      if (!seen) showSchemaBreakBanner = true;
+    } catch { /* no-op */ }
     setCustomDensityLookup((identifier) => {
       const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
       return cm ? cm.density : null;
@@ -273,6 +283,23 @@
 <main>
   <HeaderBar />
 
+  {#if showSchemaBreakBanner}
+    <div class="schema-break-banner" role="status">
+      <span>
+        hyrr 0.x — the material schema changed in this build. If saved custom materials don't open, redefine them via the "Define & save material" form. Share URLs from earlier versions may no longer load.
+      </span>
+      <button
+        type="button"
+        class="schema-break-close"
+        aria-label="Dismiss"
+        onclick={() => {
+          showSchemaBreakBanner = false;
+          try { localStorage.setItem("hyrr.notice.materialSchemaBreak", "1"); } catch { /* no-op */ }
+        }}
+      >×</button>
+    </div>
+  {/if}
+
   {#if !ready}
     <div class="loading">
       {#if loadingError}
@@ -393,6 +420,28 @@
 <BugReportModal />
 
 <style>
+  .schema-break-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    background: var(--c-yellow-tint, var(--c-bg-muted));
+    color: var(--c-text);
+    padding: 0.5rem 0.9rem;
+    font-size: 0.78rem;
+    border-bottom: 1px solid var(--c-border);
+  }
+  .schema-break-close {
+    background: none;
+    border: none;
+    color: var(--c-text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0.15rem 0.4rem;
+    border-radius: 3px;
+  }
+  .schema-break-close:hover { color: var(--c-text); background: var(--c-bg-default); }
   /* ─── Theme tokens ─── */
   :global(:root),
   :global([data-theme="dark"]) {

--- a/frontend/src/lib/components/MaterialPopup.svelte
+++ b/frontend/src/lib/components/MaterialPopup.svelte
@@ -147,7 +147,9 @@
   }
 </script>
 
-<Modal {open} {onclose} title="Select Material">
+<!-- #92: PT view needs the wider modal so the periodic table doesn't crowd
+     against its own borders. Search view stays narrow. -->
+<Modal {open} {onclose} title="Select Material" wide={view === "table"}>
   <div class="material-popup">
     <div class="view-toggle" role="tablist" aria-label="Material picker view">
       <button

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -57,7 +57,6 @@
   let nameDraft = $state("");
   let nameManuallySet = $state(false);
   let densityDraft = $state<number | null>(null);
-  let densityManuallySet = $state(false);
   let formError = $state<string | null>(null);
   let saving = $state(false);
   let editingCustomId = $state<string | null>(null);
@@ -81,7 +80,9 @@
   const displayFormula = $derived.by(() => {
     if (rows.length === 0) return "";
     if (mode === "single") return serialised;
-    return rows.map((r) => r.isBalance ? r.formula : `${r.formula}${Math.round(r.value ?? 0)}`).join("-");
+    // Preserve precision for non-integer values (e.g. SiO2 75.5%) — rounding
+    // here was clobbering the saved autoName.
+    return rows.map((r) => r.isBalance ? r.formula : `${r.formula}${r.value ?? 0}`).join("-");
   });
   /** Distinct element symbols across all rows (used for the enrichment-badge row). */
   const previewElements = $derived.by(() => {
@@ -134,6 +135,12 @@
 
   const validationErrors = $derived(validation.filter((i) => i.level === "error"));
   const canCommit = $derived(rows.length > 0 && validationErrors.length === 0);
+  /** When switching modes leaves stale rows that the new mode's validator
+   *  rejects, surface a "Reset rows" affordance so the user has an obvious
+   *  recovery path instead of a silently-disabled Save button. */
+  const staleRowsForMode = $derived(
+    rows.length > 0 && validationErrors.length > 0 && validationErrors.some((i) => !i.rowId),
+  );
   const formIssues = $derived(validation.filter((i) => !i.rowId));
   const issuesByRow = $derived.by(() => {
     const byRow = new Map<string, Issue[]>();
@@ -164,6 +171,18 @@
   };
 
   let modeMenuOpen = $state(false);
+  let modeMenuRef = $state<HTMLSpanElement | null>(null);
+
+  function onModeMenuWindow(e: MouseEvent | KeyboardEvent) {
+    if (!modeMenuOpen) return;
+    if (e.type === "keydown" && (e as KeyboardEvent).key === "Escape") {
+      modeMenuOpen = false;
+      return;
+    }
+    if (e.type === "click" && modeMenuRef && !modeMenuRef.contains(e.target as Node)) {
+      modeMenuOpen = false;
+    }
+  }
 
   /** Splice a row immutably with a partial patch. When isBalance flips on,
    *  also clear it from every other row so only one survives. */
@@ -185,13 +204,20 @@
   }
 
   /** Mode-switch path. MUST be event-driven, not $effect-driven (#92 §3.1
-   *  hard rule — runes-review-predicted footgun). Non-destructive: rows
-   *  are kept; only mode changes. Mass→Single is a no-op on rows but the
-   *  Single-mode UI will only show the first row. */
+   *  hard rule). Non-destructive: rows are kept across the switch.
+   *
+   *  Real demote with 30s undo strip is a follow-up (#95). For now: when
+   *  switching to Single mode, surface a "Reset rows" affordance because
+   *  mass/atom rows that survived the switch will fail validateSingle if
+   *  any has a non-stoichiometric formula or value. (Runes-review point 2.) */
   function setMode(next: Mode) {
     if (next === mode) return;
     mode = next;
     modeUserOverride = true;
+  }
+
+  function clearRows() {
+    rows = [];
   }
 
   function dismissModeFirstTime() {
@@ -221,7 +247,13 @@
 
   function appendRow(formula: string, enrichment?: Record<string, Record<number, number>>) {
     const id = generateRowId();
-    if (mode === "single") mode = "mass";
+    // Adding a row in single mode implies the user wants a mixture; flip
+    // mode AND mark it as a user override so a subsequent paste doesn't
+    // re-infer back to single.
+    if (mode === "single") {
+      mode = "mass";
+      modeUserOverride = true;
+    }
     rows = [...rows, { id, formula, value: null, isBalance: false, ...(enrichment ? { enrichment } : {}) }];
     showPickerToast(`Added ${formula}`);
   }
@@ -262,6 +294,11 @@
    *  refocus would fight the row-input refocus for the next frame. */
   function closePicker(returnFocus = true) {
     if (!elementPickerOpen) return;
+    // Flush any in-flight formula draft before close — Done / Escape /
+    // click-outside / × all "commit + close" per spec. (Reviewer-flagged
+    // hazard: typing a formula and closing without Enter would silently
+    // drop the draft.)
+    if (pickerFormulaDraft.trim()) commitPickerFormula();
     elementPickerOpen = false;
     if (returnFocus) {
       // addBtnRef may be null if the form was collapsed mid-flight; falling
@@ -371,7 +408,7 @@
       nameDraft = editInitial.name;
       nameManuallySet = true;
       densityDraft = editInitial.density;
-      densityManuallySet = true;
+
       editingCustomId = editInitial.editingCustomId;
       textDraft = "";
       textDirty = false;
@@ -384,7 +421,7 @@
       nameDraft = "";
       nameManuallySet = false;
       densityDraft = null;
-      densityManuallySet = false;
+
       editingCustomId = null;
       textDraft = "";
       textDirty = false;
@@ -446,6 +483,8 @@
   }
 </script>
 
+<svelte:window onclick={onModeMenuWindow} onkeydown={onModeMenuWindow} />
+
 <div class="define-section">
   <button class="define-toggle" onclick={() => { defineOpen = !defineOpen; }}>
     <span class="toggle-icon">{defineOpen ? "▾" : "▸"}</span>
@@ -455,7 +494,7 @@
   {#if defineOpen}
     <div class="define-form">
       <div class="mode-chip-row">
-        <span class="mode-chip-wrap">
+        <span class="mode-chip-wrap" bind:this={modeMenuRef}>
           <button
             type="button"
             class="mode-chip"
@@ -572,14 +611,14 @@
           oninput={(e) => {
             const v = parseFloat((e.target as HTMLInputElement).value);
             densityDraft = Number.isFinite(v) ? v : null;
-            densityManuallySet = true;
+
           }}
         />
         {#if autoDensity !== null && densityDraft === null}
           <button
             type="button"
             class="use-suggested-btn"
-            onclick={() => { densityDraft = autoDensity; densityManuallySet = true; }}
+            onclick={() => { densityDraft = autoDensity; }}
             title="Use the weighted-average density estimate"
           >Use {autoDensity.toFixed(2)}</button>
         {/if}
@@ -597,6 +636,12 @@
       {#each formIssues as issue}
         <p class="form-{issue.level}">{issue.message}</p>
       {/each}
+      {#if staleRowsForMode}
+        <p class="form-warning">
+          The current rows don't match {MODE_LABEL[mode]}.
+          <button type="button" class="reset-rows-btn" onclick={clearRows}>Reset rows</button>
+        </p>
+      {/if}
 
       <div class="form-actions">
         <button
@@ -1136,6 +1181,18 @@
 
   .save-btn:hover:not(:disabled) { background: var(--c-green-emphasis); }
   .save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .reset-rows-btn {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-yellow, var(--c-border));
+    border-radius: 3px;
+    color: var(--c-yellow, var(--c-text-muted));
+    padding: 0.1rem 0.4rem;
+    font-size: 0.65rem;
+    cursor: pointer;
+    margin-left: 0.4rem;
+  }
+  .reset-rows-btn:hover { background: var(--c-bg-muted); }
 
   .save-btn.save-overwrite {
     background: var(--c-bg-muted);

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -16,11 +16,12 @@
     generateRowId,
     parseMaterialInput,
     serialise,
-    toRows,
     validate,
     type Issue,
+    type Mode,
     type Row,
   } from "./define-form-rows";
+  import { formulaToMassFractions, parseFormula } from "@hyrr/compute";
   import DefineFormRow from "./DefineFormRow.svelte";
   import PeriodicTable from "./PeriodicTable.svelte";
 
@@ -36,7 +37,8 @@
 
   let { editInitial, currentEnrichment, onenrichment, oncommit }: Props = $props();
 
-  // --- Source-of-truth state per #64 §3.1 ---
+  // --- Source-of-truth state per #92 ---
+  let mode = $state<Mode>("single");
   let rows = $state<Row[]>([]);
   let textDraft = $state("");
   let textDirty = $state(false);
@@ -51,27 +53,64 @@
   let saving = $state(false);
   let editingCustomId = $state<string | null>(null);
 
-  // Pure derivations off rows. NOTE: no $effect watches rows or textDraft —
-  // round-trips run inside event handlers (commitPastedText) only. (#64 §3.1)
-  const serialised = $derived(serialise(rows));
-  const validation = $derived(validate(rows));
+  // Pure derivations off rows. NOTE: no $effect watches rows, mode, or textDraft —
+  // round-trips run inside event handlers (commitPastedText) only. (#92)
+  const serialised = $derived(serialise(mode, rows));
+  const validation = $derived(validate(mode, rows));
   const previewParse = $derived(parseMaterialInput(serialised));
   const formulaPreview = $derived(
     previewParse && "ok" in previewParse ? previewParse.ok : null,
   );
+  /** Display formula — joined formulas across rows for preview / save. For
+   *  Single mode, equals the single rendered formula; for mixtures, falls
+   *  back to a name-friendly "Sym{count}" join. */
+  const displayFormula = $derived.by(() => {
+    if (rows.length === 0) return "";
+    if (mode === "single") return serialised;
+    return rows.map((r) => r.isBalance ? r.formula : `${r.formula}${Math.round(r.value ?? 0)}`).join("-");
+  });
+  /** Distinct element symbols across all rows (used for the enrichment-badge row). */
+  const previewElements = $derived.by(() => {
+    const seen = new Set<string>();
+    for (const r of rows) {
+      try {
+        const counts = parseFormula(r.formula);
+        for (const k of Object.keys(counts)) seen.add(k);
+      } catch { /* ignore */ }
+    }
+    return [...seen];
+  });
+
+  /** Mass fractions per element — derived for save. Folds compound rows
+   *  through formulaToMassFractions and weights by row.value. Only valid in
+   *  mass mode; null otherwise. */
+  const massFractions = $derived.by((): Record<string, number> | undefined => {
+    if (mode !== "mass" || rows.length === 0) return undefined;
+    const out: Record<string, number> = {};
+    let specifiedSum = 0;
+    for (const r of rows) if (!r.isBalance) specifiedSum += r.value ?? 0;
+    for (const r of rows) {
+      const wt = r.isBalance ? Math.max(0, 100 - specifiedSum) : (r.value ?? 0);
+      const elFracs = formulaToMassFractions(r.formula);
+      for (const [el, f] of Object.entries(elFracs)) {
+        out[el] = (out[el] ?? 0) + (wt / 100) * f;
+      }
+    }
+    return out;
+  });
   /** What the paste input displays — user's draft when dirty, otherwise the
    *  canonical serialisation of the current rows (so edits to rows propagate
    *  back into the text field). */
   const displayText = $derived(textDirty ? textDraft : serialised);
   let pasteError = $state<string | null>(null);
 
-  const autoName = $derived(formulaPreview?.autoName ?? "");
+  const autoName = $derived(formulaPreview?.autoName ?? displayFormula);
   const autoDensity = $derived(formulaPreview?.density ?? null);
   const effectiveName = $derived(nameManuallySet ? nameDraft : autoName);
   const effectiveDensity = $derived(densityManuallySet ? densityDraft : autoDensity);
 
   const validationErrors = $derived(validation.filter((i) => i.level === "error"));
-  const canCommit = $derived(rows.length > 0 && validationErrors.length === 0 && !!formulaPreview);
+  const canCommit = $derived(rows.length > 0 && validationErrors.length === 0);
   const formIssues = $derived(validation.filter((i) => !i.rowId));
   const issuesByRow = $derived.by(() => {
     const byRow = new Map<string, Issue[]>();
@@ -158,7 +197,10 @@
 
   function handlePtSelect(symbol: string) {
     const id = generateRowId();
-    rows = [...rows, { id, symbol, value: null, unit: "wt%", isBalance: false }];
+    // Picking from PT in single mode is meaningless; switch to mass mode if
+    // we're not already in a mixture. Proper mode-chip UX lands in C3+.
+    if (mode === "single") mode = "mass";
+    rows = [...rows, { id, formula: symbol, value: null, isBalance: false }];
     // closePicker(false) suppresses the trigger-refocus rAF; we focus the
     // new row's number input instead.
     closePicker(false);
@@ -188,7 +230,8 @@
     }
     const parsed = parseMaterialInput(textDraft);
     if (parsed && "ok" in parsed) {
-      rows = toRows(parsed.ok);
+      mode = parsed.ok.mode;
+      rows = parsed.ok.rows;
       textDirty = false;
       pasteError = null;
     } else if (parsed && "error" in parsed) {
@@ -226,7 +269,13 @@
   $effect(() => {
     if (editInitial) {
       const parsed = parseMaterialInput(editInitial.formula);
-      rows = parsed && "ok" in parsed ? toRows(parsed.ok) : [];
+      if (parsed && "ok" in parsed) {
+        mode = parsed.ok.mode;
+        rows = parsed.ok.rows;
+      } else {
+        mode = "single";
+        rows = [];
+      }
       defineOpen = true;
       nameDraft = editInitial.name;
       nameManuallySet = true;
@@ -238,6 +287,7 @@
       formError = null;
       pasteError = null;
     } else {
+      mode = "single";
       rows = [];
       defineOpen = false;
       nameDraft = "";
@@ -253,8 +303,9 @@
   });
 
   async function handleSave() {
-    if (!formulaPreview) return;
-    const nameVal = (effectiveName.trim() || formulaPreview.autoName);
+    if (rows.length === 0) return;
+    const formulaForSave = mode === "single" ? serialised : displayFormula;
+    const nameVal = effectiveName.trim() || autoName || formulaForSave;
     const densityVal = effectiveDensity;
     if (densityVal === null || densityVal <= 0) {
       formError = "Enter density (g/cm³)";
@@ -267,18 +318,18 @@
         await updateCustomMaterial(
           editingCustomId,
           nameVal,
-          formulaPreview.formula,
+          formulaForSave,
           densityVal,
-          formulaPreview.massFractions,
+          massFractions,
           serialised,
           currentEnrichment,
         );
       } else {
         await saveCustomMaterial(
           nameVal,
-          formulaPreview.formula,
+          formulaForSave,
           densityVal,
-          formulaPreview.massFractions,
+          massFractions,
           serialised,
           currentEnrichment,
         );
@@ -292,8 +343,8 @@
   }
 
   function useFormula() {
-    if (!formulaPreview) return;
-    oncommit(formulaPreview.formula);
+    if (rows.length === 0) return;
+    oncommit(mode === "single" ? serialised : displayFormula);
   }
 </script>
 
@@ -345,13 +396,13 @@
           {/if}
         </label>
 
-        {#if formulaPreview}
+        {#if rows.length > 0}
           <div class="preview">
-            <span class="preview-type">{formulaPreview.type}</span>
-            {#if formulaPreview.type === "mass-ratio"}
-              <span class="preview-formula">{formulaPreview.formula}</span>
+            <span class="preview-type">{mode}</span>
+            {#if mode !== "single"}
+              <span class="preview-formula">{displayFormula}</span>
             {/if}
-            {#each formulaPreview.elements as el}
+            {#each previewElements as el}
               <button
                 class="el-badge"
                 class:enriched={!!currentEnrichment?.[el]}

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -14,6 +14,7 @@
   } from "../../stores/custom-materials.svelte";
   import {
     generateRowId,
+    isTabulatedDensity,
     parseMaterialInput,
     serialise,
     validate,
@@ -115,7 +116,16 @@
   const autoName = $derived(formulaPreview?.autoName ?? displayFormula);
   const autoDensity = $derived(formulaPreview?.density ?? null);
   const effectiveName = $derived(nameManuallySet ? nameDraft : autoName);
-  const effectiveDensity = $derived(densityManuallySet ? densityDraft : autoDensity);
+  // Density is now suggestion-only: effectiveDensity equals densityDraft
+  // (set when the user types or clicks "Use suggested"). autoDensity is
+  // surfaced as a placeholder, never silently fed.
+  const effectiveDensity = $derived(densityDraft);
+  /** Rows whose compound has no tabulated density — flagged inline so the
+   *  user knows the suggestion is an estimate. */
+  const untabulatedRowFormulas = $derived(
+    rows.filter((r) => !isTabulatedDensity(r.formula)).map((r) => r.formula),
+  );
+  const densityIsEstimated = $derived(autoDensity !== null && untabulatedRowFormulas.length > 0);
 
   const validationErrors = $derived(validation.filter((i) => i.level === "error"));
   const canCommit = $derived(rows.length > 0 && validationErrors.length === 0);
@@ -540,11 +550,12 @@
 
       <label class="field-label">
         Density (g/cm³)
+        <div class="density-row">
         <input
           type="text"
           inputmode="decimal"
           class="field-input"
-          placeholder={autoDensity !== null ? autoDensity.toFixed(2) : "e.g. 2.70"}
+          placeholder={autoDensity !== null ? `suggested ${autoDensity.toFixed(2)}` : "e.g. 2.70"}
           value={effectiveDensity !== null ? String(effectiveDensity) : ""}
           oninput={(e) => {
             const v = parseFloat((e.target as HTMLInputElement).value);
@@ -552,6 +563,20 @@
             densityManuallySet = true;
           }}
         />
+        {#if autoDensity !== null && densityDraft === null}
+          <button
+            type="button"
+            class="use-suggested-btn"
+            onclick={() => { densityDraft = autoDensity; densityManuallySet = true; }}
+            title="Use the weighted-average density estimate"
+          >Use {autoDensity.toFixed(2)}</button>
+        {/if}
+        </div>
+        {#if densityIsEstimated && densityDraft !== null}
+          <span class="density-warn">
+            Estimated — {untabulatedRowFormulas.join(", ")} not tabulated. Override with measured value when possible.
+          </span>
+        {/if}
       </label>
 
       {#if formError}
@@ -970,6 +995,33 @@
   }
 
   .paste-field { margin-top: 0.4rem; }
+
+  .density-row {
+    display: flex;
+    gap: 0.4rem;
+    align-items: stretch;
+  }
+
+  .density-row .field-input { flex: 1; min-width: 0; }
+
+  .use-suggested-btn {
+    background: var(--c-bg-muted);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    color: var(--c-accent);
+    padding: 0.25rem 0.55rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .use-suggested-btn:hover { border-color: var(--c-accent); }
+
+  .density-warn {
+    color: var(--c-yellow, var(--c-text-muted));
+    font-size: 0.65rem;
+    font-style: italic;
+  }
 
   .paste-error {
     color: var(--c-red);

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -39,9 +39,17 @@
 
   // --- Source-of-truth state per #92 ---
   let mode = $state<Mode>("single");
+  let modeUserOverride = $state(false);
   let rows = $state<Row[]>([]);
   let textDraft = $state("");
   let textDirty = $state(false);
+  /** Confidence in the most recent inference. "low" → render the chip in
+   *  amber with a question mark + first-time subhead. */
+  let inferenceConfidence = $state<"high" | "low">("high");
+  let inferenceNudge = $state<string | null>(null);
+  /** First-time guidance for the chip; suppressed in localStorage after the
+   *  first successful save. */
+  let modeFirstTimeShown = $state(false);
 
   // Display-side state (not part of the rows↔text round-trip).
   let defineOpen = $state(false);
@@ -127,6 +135,21 @@
   /** Stable radiogroup name so the browser enforces single-balance selection. */
   const balanceRadioName = `define-balance-${Math.random().toString(36).slice(2, 10)}`;
 
+  // First-time guidance: read flag once on init.
+  try {
+    if (typeof localStorage !== "undefined" && localStorage.getItem("hyrr.defineform.modeChipSeen") === "1") {
+      modeFirstTimeShown = true;
+    }
+  } catch { /* no-op */ }
+
+  const MODE_LABEL: Record<Mode, string> = {
+    single: "Single formula",
+    mass: "Mass mixture",
+    atom: "Atom mixture",
+  };
+
+  let modeMenuOpen = $state(false);
+
   /** Splice a row immutably with a partial patch. When isBalance flips on,
    *  also clear it from every other row so only one survives. */
   function patchRow(id: string, patch: Partial<Row>) {
@@ -144,6 +167,21 @@
 
   function removeRow(id: string) {
     rows = rows.filter((r) => r.id !== id);
+  }
+
+  /** Mode-switch path. MUST be event-driven, not $effect-driven (#92 §3.1
+   *  hard rule — runes-review-predicted footgun). Non-destructive: rows
+   *  are kept; only mode changes. Mass→Single is a no-op on rows but the
+   *  Single-mode UI will only show the first row. */
+  function setMode(next: Mode) {
+    if (next === mode) return;
+    mode = next;
+    modeUserOverride = true;
+  }
+
+  function dismissModeFirstTime() {
+    modeFirstTimeShown = true;
+    try { localStorage.setItem("hyrr.defineform.modeChipSeen", "1"); } catch { /* no-op */ }
   }
 
   // --- "+ element" picker (PT in a focus-trapped modal) ---
@@ -230,8 +268,10 @@
     }
     const parsed = parseMaterialInput(textDraft);
     if (parsed && "ok" in parsed) {
-      mode = parsed.ok.mode;
+      if (!modeUserOverride) mode = parsed.ok.mode;
       rows = parsed.ok.rows;
+      inferenceConfidence = parsed.ok.confidence;
+      inferenceNudge = parsed.ok.nudge ?? null;
       textDirty = false;
       pasteError = null;
     } else if (parsed && "error" in parsed) {
@@ -356,6 +396,41 @@
 
   {#if defineOpen}
     <div class="define-form">
+      <div class="mode-chip-row">
+        <span class="mode-chip-wrap">
+          <button
+            type="button"
+            class="mode-chip"
+            class:low-conf={inferenceConfidence === "low"}
+            aria-haspopup="true"
+            aria-expanded={modeMenuOpen}
+            onclick={() => { modeMenuOpen = !modeMenuOpen; dismissModeFirstTime(); }}
+          >
+            {inferenceConfidence === "low" ? `${MODE_LABEL[mode]}?` : MODE_LABEL[mode]}
+            <span class="caret">▾</span>
+          </button>
+          {#if modeMenuOpen}
+            <div class="mode-menu" role="menu">
+              {#each ["single","mass","atom"] as const as m}
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="mode-option"
+                  class:active={mode === m}
+                  onclick={() => { setMode(m); modeMenuOpen = false; }}
+                >{MODE_LABEL[m]}</button>
+              {/each}
+            </div>
+          {/if}
+        </span>
+        {#if inferenceNudge}
+          <span class="mode-nudge">{inferenceNudge}</span>
+        {/if}
+        {#if !modeFirstTimeShown && rows.length === 0}
+          <span class="mode-firsttime">Inferred from your input — click to change.</span>
+        {/if}
+      </div>
+
       <div class="rows-section" role="grid" aria-label="Material composition rows">
         <span class="rows-heading">Composition</span>
         {#if rows.length === 0}
@@ -534,6 +609,83 @@
     font-size: 0.7rem;
     color: var(--c-text-subtle);
     margin: 0;
+    font-style: italic;
+  }
+
+  .mode-chip-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  .mode-chip-wrap {
+    position: relative;
+    display: inline-flex;
+  }
+
+  .mode-chip {
+    background: var(--c-bg-active);
+    border: 1px solid var(--c-accent);
+    border-radius: 12px;
+    color: var(--c-accent);
+    padding: 0.15rem 0.55rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .mode-chip.low-conf {
+    border-color: var(--c-yellow, #d4a017);
+    color: var(--c-yellow, #d4a017);
+    background: var(--c-yellow-tint-subtle, transparent);
+  }
+
+  .mode-chip:focus-visible { outline: 2px solid var(--c-accent); outline-offset: 1px; }
+
+  .mode-chip .caret { font-size: 0.55rem; }
+
+  .mode-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    z-index: 50;
+    min-width: 9rem;
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    padding: 0.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  }
+
+  .mode-option {
+    background: transparent;
+    border: none;
+    color: var(--c-text-muted);
+    text-align: left;
+    padding: 0.25rem 0.4rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+    border-radius: 3px;
+  }
+
+  .mode-option:hover { background: var(--c-bg-subtle); color: var(--c-text); }
+  .mode-option.active { color: var(--c-accent); font-weight: 500; }
+
+  .mode-nudge {
+    font-size: 0.7rem;
+    color: var(--c-yellow, var(--c-text-muted));
+    font-style: italic;
+  }
+
+  .mode-firsttime {
+    font-size: 0.65rem;
+    color: var(--c-text-subtle);
     font-style: italic;
   }
 

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -184,10 +184,57 @@
     try { localStorage.setItem("hyrr.defineform.modeChipSeen", "1"); } catch { /* no-op */ }
   }
 
-  // --- "+ element" picker (PT in a focus-trapped modal) ---
+  // --- "Compose mixture" picker — workspace with free-form input + common
+  //     compounds chips + PT + sticky existing-rows panel; stays open.
   let elementPickerOpen = $state(false);
   let addBtnRef = $state<HTMLButtonElement | null>(null);
   let modalRef = $state<HTMLDivElement | null>(null);
+  let pickerFormulaDraft = $state("");
+  let pickerFormulaError = $state<string | null>(null);
+  let pickerToast = $state<string | null>(null);
+  let pickerToastTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /** Common compounds shown as chips above the PT. Seeded from
+   *  COMPOUND_DENSITIES + a small editorial list (P1 polish). */
+  const COMMON_COMPOUNDS = ["H2O", "H2O-18", "D2O", "MoO3", "Al2O3", "SiO2", "Na2O", "CaO", "Fe2O3", "NaCl", "KCl", "TiO2"];
+
+  function showPickerToast(msg: string) {
+    pickerToast = msg;
+    if (pickerToastTimer) clearTimeout(pickerToastTimer);
+    pickerToastTimer = setTimeout(() => { pickerToast = null; }, 1500);
+  }
+
+  function appendRow(formula: string, enrichment?: Record<string, Record<number, number>>) {
+    const id = generateRowId();
+    if (mode === "single") mode = "mass";
+    rows = [...rows, { id, formula, value: null, isBalance: false, ...(enrichment ? { enrichment } : {}) }];
+    showPickerToast(`Added ${formula}`);
+  }
+
+  function commitPickerFormula() {
+    const trimmed = pickerFormulaDraft.trim();
+    if (!trimmed) { pickerFormulaError = null; return; }
+    const parsed = parseMaterialInput(trimmed);
+    if (!parsed || "error" in parsed) {
+      pickerFormulaError = parsed && "error" in parsed ? parsed.error : "Empty input";
+      return;
+    }
+    // Single-formula in the picker = "add this compound as one row"
+    if (parsed.ok.mode === "single") {
+      appendRow(trimmed);
+    } else {
+      // mass / atom commit replaces the form's rows wholesale (paste-style)
+      mode = parsed.ok.mode;
+      rows = parsed.ok.rows;
+      showPickerToast(`Loaded ${parsed.ok.rows.length} rows`);
+    }
+    pickerFormulaDraft = "";
+    pickerFormulaError = null;
+  }
+
+  function onPickerFormulaKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") { e.preventDefault(); commitPickerFormula(); }
+  }
 
   function openPicker() {
     elementPickerOpen = true;
@@ -234,20 +281,9 @@
   }
 
   function handlePtSelect(symbol: string) {
-    const id = generateRowId();
-    // Picking from PT in single mode is meaningless; switch to mass mode if
-    // we're not already in a mixture. Proper mode-chip UX lands in C3+.
-    if (mode === "single") mode = "mass";
-    rows = [...rows, { id, formula: symbol, value: null, isBalance: false }];
-    // closePicker(false) suppresses the trigger-refocus rAF; we focus the
-    // new row's number input instead.
-    closePicker(false);
-    requestAnimationFrame(() => {
-      const el = document.querySelector<HTMLInputElement>(
-        `[data-row-id="${id}"] .value-input`,
-      );
-      el?.focus();
-    });
+    // Stays-open picker: append row + stay in picker. No focus rAF (focus
+    // stays where the user clicked / on the formula input).
+    appendRow(symbol);
   }
 
   function onPasteInput(e: Event) {
@@ -454,22 +490,24 @@
           onclick={openPicker}
         >+ element</button>
 
-        <label class="field-label paste-field">
-          Or paste formula
-          <input
-            type="text"
-            class="field-input"
-            placeholder="Al2O3  or  Al 80%, Cu 5%, Zn %"
-            value={displayText}
-            oninput={onPasteInput}
-            onblur={commitPastedText}
-            onkeydown={onPasteKeydown}
-          />
-          <span class="field-hint">Stoichiometric formula or mass ratios. Cmd/Ctrl-Enter or blur to apply.</span>
-          {#if pasteError}
-            <span class="paste-error">{pasteError}</span>
-          {/if}
-        </label>
+        {#if mode === "single"}
+          <label class="field-label paste-field">
+            Or paste formula
+            <input
+              type="text"
+              class="field-input"
+              placeholder="Al2O3  or  H2O"
+              value={displayText}
+              oninput={onPasteInput}
+              onblur={commitPastedText}
+              onkeydown={onPasteKeydown}
+            />
+            <span class="field-hint">Stoichiometric formula. Cmd/Ctrl-Enter or blur to apply.</span>
+            {#if pasteError}
+              <span class="paste-error">{pasteError}</span>
+            {/if}
+          </label>
+        {/if}
 
         {#if rows.length > 0}
           <div class="preview">
@@ -543,20 +581,67 @@
   <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div class="picker-overlay" onclick={(e) => { if (e.target === e.currentTarget) closePicker(); }}>
     <div
-      class="picker-modal"
+      class="picker-modal compose-mixture"
       role="dialog"
       aria-modal="true"
-      aria-label="Pick an element"
+      aria-label="Compose mixture"
       tabindex="-1"
       bind:this={modalRef}
       onkeydown={onPickerKeydown}
     >
       <div class="picker-header">
-        <h3>Pick an element</h3>
+        <h3>Compose mixture</h3>
         <button class="picker-close" aria-label="Close" onclick={() => closePicker()}>×</button>
       </div>
-      <div class="picker-body">
-        <PeriodicTable onselect={handlePtSelect} />
+      <div class="picker-body compose-body">
+        <div class="compose-main">
+          <label class="field-label compose-formula-input">
+            Formula
+            <input
+              type="text"
+              class="field-input"
+              placeholder="e.g. SiO2, H2O, ³He, D2O"
+              value={pickerFormulaDraft}
+              oninput={(e) => { pickerFormulaDraft = (e.target as HTMLInputElement).value; pickerFormulaError = null; }}
+              onkeydown={onPickerFormulaKeydown}
+            />
+            <span class="field-hint">Type a formula and press Enter to add as a row.</span>
+            {#if pickerFormulaError}
+              <span class="paste-error">{pickerFormulaError}</span>
+            {/if}
+          </label>
+
+          <div class="compose-chips" role="list" aria-label="Common compounds">
+            {#each COMMON_COMPOUNDS as c}
+              <button type="button" class="compose-chip" role="listitem" onclick={() => appendRow(c)}>{c}</button>
+            {/each}
+          </div>
+
+          <div class="compose-pt">
+            <PeriodicTable onselect={handlePtSelect} />
+          </div>
+        </div>
+
+        <aside class="compose-side" aria-label="Existing rows">
+          <h4>Current rows ({rows.length})</h4>
+          {#if rows.length === 0}
+            <p class="empty-hint">None yet — add via formula, chip, or PT.</p>
+          {:else}
+            <ul class="compose-rowlist">
+              {#each rows as r (r.id)}
+                <li>
+                  <span class="compose-row-formula">{r.formula}</span>
+                  {#if r.isBalance}<span class="compose-row-bal">bal</span>{:else if r.value !== null}<span class="compose-row-val">{r.value}{mode === "mass" ? "%" : ""}</span>{/if}
+                </li>
+              {/each}
+            </ul>
+          {/if}
+        </aside>
+      </div>
+
+      <div class="picker-footer">
+        <span class="picker-toast" aria-live="polite">{pickerToast ?? ""}</span>
+        <button type="button" class="picker-done" onclick={() => closePicker()}>Done</button>
       </div>
     </div>
   </div>
@@ -726,6 +811,107 @@
     flex-direction: column;
     overflow: hidden;
   }
+
+  .picker-modal.compose-mixture { max-width: 1080px; }
+
+  .compose-body {
+    display: grid;
+    grid-template-columns: 1fr 220px;
+    gap: 0.75rem;
+  }
+
+  .compose-main {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    min-width: 0;
+  }
+
+  .compose-formula-input { margin-bottom: 0.2rem; }
+
+  .compose-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+  }
+
+  .compose-chip {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 12px;
+    color: var(--c-text-muted);
+    padding: 0.15rem 0.55rem;
+    font-size: 0.7rem;
+    cursor: pointer;
+  }
+
+  .compose-chip:hover { color: var(--c-accent); border-color: var(--c-accent); }
+
+  .compose-pt { /* PT renders its own inner styling */ }
+
+  .compose-side {
+    border-left: 1px solid var(--c-border);
+    padding-left: 0.6rem;
+    overflow-y: auto;
+    min-height: 0;
+  }
+
+  .compose-side h4 {
+    margin: 0 0 0.4rem;
+    font-size: 0.75rem;
+    color: var(--c-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .compose-rowlist {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .compose-rowlist li {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.4rem;
+    padding: 0.15rem 0.3rem;
+    background: var(--c-bg-default);
+    border-radius: 3px;
+    font-size: 0.72rem;
+  }
+
+  .compose-row-formula { font-family: monospace; color: var(--c-text); }
+  .compose-row-val { color: var(--c-text-muted); }
+  .compose-row-bal { color: var(--c-yellow, var(--c-text-muted)); font-style: italic; }
+
+  .picker-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.5rem 0.9rem;
+    border-top: 1px solid var(--c-border);
+  }
+
+  .picker-toast {
+    color: var(--c-green-text, var(--c-text-muted));
+    font-size: 0.7rem;
+    min-height: 1em;
+  }
+
+  .picker-done {
+    background: var(--c-accent);
+    border: none;
+    border-radius: 4px;
+    color: white;
+    padding: 0.3rem 0.8rem;
+    font-size: 0.8rem;
+    cursor: pointer;
+  }
+
+  .picker-done:hover { background: var(--c-accent-hover); }
 
   .picker-header {
     display: flex;

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -61,6 +61,11 @@
   let formError = $state<string | null>(null);
   let saving = $state(false);
   let editingCustomId = $state<string | null>(null);
+  /** In-session memory of the last custom material the user saved through
+   *  this form instance. Drives the "Overwrite" affordance — once the user
+   *  has saved one, a second save offers to replace it instead of forking
+   *  yet another duplicate. (#57 follow-on UX) */
+  let lastSavedSession = $state<{ id: string; name: string } | null>(null);
 
   // Pure derivations off rows. NOTE: no $effect watches rows, mode, or textDraft —
   // round-trips run inside event handlers (commitPastedText) only. (#92)
@@ -388,7 +393,7 @@
     }
   });
 
-  async function handleSave() {
+  async function handleSave(intent: "new" | "overwrite" = "new") {
     if (rows.length === 0) return;
     const formulaForSave = mode === "single" ? serialised : displayFormula;
     const nameVal = effectiveName.trim() || autoName || formulaForSave;
@@ -400,9 +405,12 @@
     saving = true;
     formError = null;
     try {
-      if (editingCustomId) {
+      const overwriteId = intent === "overwrite"
+        ? (editingCustomId ?? lastSavedSession?.id)
+        : null;
+      if (overwriteId) {
         await updateCustomMaterial(
-          editingCustomId,
+          overwriteId,
           nameVal,
           formulaForSave,
           densityVal,
@@ -410,8 +418,9 @@
           serialised,
           currentEnrichment,
         );
+        lastSavedSession = { id: overwriteId, name: nameVal };
       } else {
-        await saveCustomMaterial(
+        const newId = await saveCustomMaterial(
           nameVal,
           formulaForSave,
           densityVal,
@@ -419,8 +428,11 @@
           serialised,
           currentEnrichment,
         );
+        lastSavedSession = { id: newId, name: nameVal };
       }
       oncommit(nameVal, currentEnrichment);
+      // Mark first-time guidance done after a successful save.
+      dismissModeFirstTime();
     } catch {
       formError = "Failed to save";
     } finally {
@@ -592,10 +604,18 @@
           disabled={!canCommit}
           onclick={useFormula}
         >Use without saving</button>
+        {#if (editingCustomId || lastSavedSession) && !editingCustomId}
+          <button
+            class="save-btn save-overwrite"
+            disabled={saving || !canCommit || effectiveDensity === null || (effectiveDensity ?? 0) <= 0}
+            onclick={() => handleSave("overwrite")}
+            title={`Overwrite "${lastSavedSession?.name}" (last saved this session)`}
+          >Overwrite "{lastSavedSession?.name}"</button>
+        {/if}
         <button
           class="save-btn"
           disabled={saving || !canCommit || effectiveDensity === null || (effectiveDensity ?? 0) <= 0}
-          onclick={handleSave}
+          onclick={() => handleSave(editingCustomId ? "overwrite" : "new")}
         >{saving ? "Saving..." : editingCustomId ? "Update & Use" : "Save & Use"}</button>
       </div>
     </div>
@@ -1116,4 +1136,11 @@
 
   .save-btn:hover:not(:disabled) { background: var(--c-green-emphasis); }
   .save-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .save-btn.save-overwrite {
+    background: var(--c-bg-muted);
+    border: 1px solid var(--c-border);
+    color: var(--c-text-muted);
+  }
+  .save-btn.save-overwrite:hover:not(:disabled) { color: var(--c-text); border-color: var(--c-accent); }
 </style>

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Issue, Row, Unit } from "./define-form-rows";
+  import type { Issue, Row } from "./define-form-rows";
 
   interface Props {
     row: Row;
@@ -7,22 +7,16 @@
      *  enforces single-selection within the radiogroup. */
     radioName: string;
     issues: Issue[];
-    /** Parent splices immutably. No bind: into nested $state per #64 §3.2. */
+    /** Parent splices immutably. No bind: into nested $state per #92 §3.2. */
     onchange: (patch: Partial<Row>) => void;
     onremove: () => void;
   }
 
   let { row, radioName, issues, onchange, onremove }: Props = $props();
-
-  const UNIT_LABEL: Record<Unit, string> = {
-    "wt%": "wt%",
-    atomfrac: "atom frac",
-    stoich: "stoich",
-  };
 </script>
 
 <div class="row" role="row" data-row-id={row.id}>
-  <span class="symbol" role="gridcell">{row.symbol}</span>
+  <span class="formula" role="gridcell">{row.formula}</span>
 
   <input
     type="number"
@@ -32,7 +26,7 @@
     step="any"
     min="0"
     placeholder={row.isBalance ? "balance" : "0"}
-    aria-label={`Value for ${row.symbol}`}
+    aria-label={`Value for ${row.formula}`}
     disabled={row.isBalance}
     value={row.value ?? ""}
     oninput={(e) => {
@@ -40,18 +34,6 @@
       onchange({ value: Number.isFinite(v) ? v : null });
     }}
   />
-
-  <select
-    class="unit-select"
-    role="gridcell"
-    aria-label={`Unit for ${row.symbol}`}
-    value={row.unit}
-    onchange={(e) => onchange({ unit: (e.target as HTMLSelectElement).value as Unit })}
-  >
-    <option value="wt%">{UNIT_LABEL["wt%"]}</option>
-    <option value="atomfrac">{UNIT_LABEL.atomfrac}</option>
-    <option value="stoich">{UNIT_LABEL.stoich}</option>
-  </select>
 
   <label class="balance-label" role="gridcell" title="Use this row to balance to 100%">
     <input
@@ -70,7 +52,7 @@
     type="button"
     class="remove-btn"
     role="gridcell"
-    aria-label={`Remove ${row.symbol}`}
+    aria-label={`Remove ${row.formula}`}
     onclick={onremove}
   >×</button>
 </div>
@@ -86,7 +68,7 @@
 <style>
   .row {
     display: grid;
-    grid-template-columns: 2.2rem minmax(0, 1fr) 5rem auto 1.5rem;
+    grid-template-columns: minmax(2.5rem, auto) minmax(0, 1fr) auto 1.5rem;
     gap: 0.4rem;
     align-items: center;
     padding: 0.25rem 0.4rem;
@@ -96,13 +78,13 @@
     font-size: 0.75rem;
   }
 
-  .symbol {
+  .formula {
     font-weight: 500;
     color: var(--c-text);
+    font-family: monospace;
   }
 
-  .value-input,
-  .unit-select {
+  .value-input {
     background: var(--c-bg-default);
     border: 1px solid var(--c-border);
     border-radius: 3px;
@@ -112,8 +94,7 @@
     min-width: 0;
   }
 
-  .value-input:focus,
-  .unit-select:focus {
+  .value-input:focus {
     outline: none;
     border-color: var(--c-accent);
   }

--- a/frontend/src/lib/components/material/define-form-rows.test.ts
+++ b/frontend/src/lib/components/material/define-form-rows.test.ts
@@ -1,365 +1,391 @@
 import { describe, expect, it } from "vitest";
 import {
   generateRowId,
+  inferMode,
+  isTabulatedDensity,
   parseMaterialInput,
+  rowAverageAtomicMass,
   serialise,
-  toRows,
   validate,
+  validateAtom,
+  validateMass,
+  validateSingle,
   type Row,
 } from "./define-form-rows";
+import { parseIsotopicFormula } from "@hyrr/compute";
 
 function row(partial: Partial<Row> = {}): Row {
   return {
     id: partial.id ?? generateRowId(),
-    symbol: partial.symbol ?? "Cu",
+    formula: partial.formula ?? "Cu",
     value: "value" in partial ? (partial.value ?? null) : 100,
-    unit: partial.unit ?? "wt%",
     isBalance: partial.isBalance ?? false,
+    enrichment: partial.enrichment,
   };
 }
 
-describe("parseMaterialInput", () => {
-  it("returns null for empty input", () => {
-    expect(parseMaterialInput("")).toBeNull();
-    expect(parseMaterialInput("   ")).toBeNull();
+describe("parseIsotopicFormula", () => {
+  it("returns natural formula + empty enrichment for plain inputs", () => {
+    const r = parseIsotopicFormula("H2O");
+    expect(r).not.toBeNull();
+    expect(r!.formula).toBe("H2O");
+    expect(Object.keys(r!.enrichment).length).toBe(0);
   });
 
-  it("parses a simple stoichiometric formula", () => {
-    const result = parseMaterialInput("Al2O3");
-    expect(result).toBeTruthy();
-    expect(result).toHaveProperty("ok");
-    if (result && "ok" in result) {
-      expect(result.ok.type).toBe("stoichiometric");
-      expect(result.ok.elements).toEqual(["Al", "O"]);
-      expect(result.ok.stoichCounts).toEqual({ Al: 2, O: 3 });
-    }
+  it("expands ³He via Unicode superscript prefix", () => {
+    const r = parseIsotopicFormula("³He");
+    expect(r!.formula).toBe("He");
+    expect(r!.enrichment.He[3]).toBeCloseTo(1.0);
   });
 
-  it("parses water with compound density", () => {
-    const result = parseMaterialInput("H2O");
-    if (result && "ok" in result) {
-      expect(result.ok.density).toBe(1.0);
-    } else {
-      throw new Error("expected ok");
-    }
+  it("expands D2O — deuterium maps to H mass=2", () => {
+    const r = parseIsotopicFormula("D2O");
+    expect(r!.formula).toBe("H2O");
+    expect(r!.enrichment.H[2]).toBeCloseTo(1.0);
+    expect(r!.enrichment.O).toBeUndefined();
   });
 
-  it("parses mass-ratio with explicit balance", () => {
-    const result = parseMaterialInput("Al 80%, Cu 5%, Zn %");
-    if (!result || !("ok" in result)) throw new Error("expected ok");
-    expect(result.ok.type).toBe("mass-ratio");
-    expect(result.ok.balanceSymbol).toBe("Zn");
-    expect(result.ok.massFractions).toBeDefined();
-    expect(result.ok.massFractions!.Zn).toBeCloseTo(0.15, 4);
+  it("expands H₂¹⁸O — only O is enriched, H stays natural", () => {
+    const r = parseIsotopicFormula("H₂¹⁸O");
+    expect(r!.formula).toBe("H2O");
+    expect(r!.enrichment.O[18]).toBeCloseTo(1.0);
+    expect(r!.enrichment.H).toBeUndefined();
   });
 
-  it("parses mass-ratio with all percentages explicit", () => {
-    const result = parseMaterialInput("Al 90%, Cu 10%");
-    if (!result || !("ok" in result)) throw new Error("expected ok");
-    expect(result.ok.balanceSymbol).toBeUndefined();
-    expect(result.ok.massFractions!.Al).toBeCloseTo(0.9);
+  it("expands ¹³CO₂", () => {
+    const r = parseIsotopicFormula("¹³CO₂");
+    expect(r!.formula).toBe("CO2");
+    expect(r!.enrichment.C[13]).toBeCloseTo(1.0);
   });
 
-  it("rejects unknown element in formula", () => {
-    const result = parseMaterialInput("Xx2O3");
-    expect(result).toEqual({ error: expect.stringMatching(/Unknown element/) });
+  it("expands ASCII isotope-prefix like 13C", () => {
+    const r = parseIsotopicFormula("13C");
+    expect(r!.formula).toBe("C");
+    expect(r!.enrichment.C[13]).toBeCloseTo(1.0);
   });
 
-  it("rejects unknown element in mass-ratio", () => {
-    const result = parseMaterialInput("Xx 50%, Cu 50%");
-    expect(result).toEqual({ error: expect.stringMatching(/Unknown element: Xx/) });
+  it("expands hyphen suffix like He-3 → 3He", () => {
+    const r = parseIsotopicFormula("He-3");
+    expect(r!.formula).toBe("He");
+    expect(r!.enrichment.He[3]).toBeCloseTo(1.0);
   });
 
-  it("rejects mass-ratio with >1 balance", () => {
-    const result = parseMaterialInput("Al %, Cu %, Zn 50%");
-    expect(result).toEqual({ error: expect.stringMatching(/unspecified/) });
+  it("normalises mixed-isotope shares (¹⁸O¹⁶O → 50/50)", () => {
+    const r = parseIsotopicFormula("¹⁸O¹⁶O");
+    // Formula is the literal concatenation of element tokens; parseFormula
+    // accepts both "OO" and "O2" identically. The contract is round-trippable
+    // through parseFormula, not minimal.
+    expect(r!.formula).toBe("OO");
+    expect(r!.enrichment.O[18]).toBeCloseTo(0.5);
+    expect(r!.enrichment.O[16]).toBeCloseTo(0.5);
   });
 
-  it("rejects mass-ratio with sum >100 + no balance", () => {
-    const result = parseMaterialInput("Al 70%, Cu 70%");
-    expect(result).toEqual({ error: expect.stringMatching(/100%/) });
+  it("rejects dangling isotope number with no symbol", () => {
+    expect(parseIsotopicFormula("13")).toBeNull();
   });
 
-  it("rejects mass-ratio with sum exceeding 100 even with balance", () => {
-    const result = parseMaterialInput("Al 60%, Cu 60%, Zn %");
-    expect(result).toEqual({ error: expect.stringMatching(/Sum exceeds/) });
+  it("rejects unknown element symbols", () => {
+    expect(parseIsotopicFormula("Xx2O3")).toBeNull();
   });
 
-  it("rejects malformed mass-ratio token", () => {
-    const result = parseMaterialInput("Al 80%, garbage, Cu 20%");
-    expect(result).toEqual({ error: expect.stringMatching(/Invalid/) });
+  it("rejects ambiguous isotope prefix on D", () => {
+    expect(parseIsotopicFormula("³D")).toBeNull();
+  });
+
+  it("Mo-100 expands cleanly", () => {
+    const r = parseIsotopicFormula("Mo-100");
+    expect(r!.formula).toBe("Mo");
+    expect(r!.enrichment.Mo[100]).toBeCloseTo(1.0);
   });
 });
 
-describe("toRows", () => {
-  it("converts a stoichiometric parse to stoich rows", () => {
-    const parsed = parseMaterialInput("Al2O3");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const rows = toRows(parsed.ok);
-    expect(rows).toHaveLength(2);
-    expect(rows[0]).toMatchObject({ symbol: "Al", unit: "stoich", value: 2, isBalance: false });
-    expect(rows[1]).toMatchObject({ symbol: "O", unit: "stoich", value: 3, isBalance: false });
+describe("parseMaterialInput — mode inference", () => {
+  it("returns null for empty input", () => {
+    expect(parseMaterialInput("")).toBeNull();
+    expect(parseMaterialInput("  ")).toBeNull();
   });
 
-  it("converts a single-element stoichiometric parse", () => {
-    const parsed = parseMaterialInput("Cu");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const rows = toRows(parsed.ok);
-    expect(rows).toHaveLength(1);
-    expect(rows[0]).toMatchObject({ symbol: "Cu", unit: "stoich", value: 1, isBalance: false });
+  it("infers 'single' for a bareword formula", () => {
+    const r = parseMaterialInput("Al2O3");
+    if (!r || "error" in r) throw new Error("expected ok");
+    expect(r.ok.mode).toBe("single");
+    expect(r.ok.confidence).toBe("high");
   });
 
-  it("converts a mass-ratio parse to wt% rows with balance flag", () => {
-    const parsed = parseMaterialInput("Al 80%, Cu 5%, Zn %");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const rows = toRows(parsed.ok);
-    expect(rows.map((r) => r.symbol)).toEqual(["Al", "Cu", "Zn"]);
-    expect(rows.map((r) => r.unit)).toEqual(["wt%", "wt%", "wt%"]);
-    expect(rows.map((r) => r.isBalance)).toEqual([false, false, true]);
-    expect(rows[0].value).toBeCloseTo(80, 4);
-    expect(rows[1].value).toBeCloseTo(5, 4);
-    expect(rows[2].value).toBeCloseTo(15, 4);
+  it("infers 'mass' from comma + percent", () => {
+    const r = parseMaterialInput("Al 80%, Cu 5%, Zn bal");
+    if (!r || "error" in r) throw new Error("expected ok");
+    expect(r.ok.mode).toBe("mass");
   });
 
-  it("assigns unique row IDs", () => {
-    const parsed = parseMaterialInput("FeCrNi");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const rows = toRows(parsed.ok);
-    const ids = new Set(rows.map((r) => r.id));
-    expect(ids.size).toBe(3);
+  it("infers 'atom' from comma + decimal fraction", () => {
+    const r = parseMaterialInput("Fe 0.7, Cr 0.18, Ni 0.12");
+    if (!r || "error" in r) throw new Error("expected ok");
+    expect(r.ok.mode).toBe("atom");
+  });
+
+  it("flags glassy mass mixture as low-confidence with mol% nudge", () => {
+    const r = parseMaterialInput("SiO2 75%, Na2O 14%, CaO 11%");
+    if (!r || "error" in r) throw new Error("expected ok");
+    expect(r.ok.mode).toBe("mass");
+    expect(r.ok.confidence).toBe("low");
+    expect(r.ok.nudge).toMatch(/mol%/);
+  });
+
+  it("non-glassy mass mixture stays high-confidence", () => {
+    const r = parseMaterialInput("Al 80%, Cu 20%");
+    if (!r || "error" in r) throw new Error("expected ok");
+    expect(r.ok.confidence).toBe("high");
+    expect(r.ok.nudge).toBeUndefined();
+  });
+});
+
+describe("parseMaterialInput — single mode", () => {
+  it("populates rows as stoich counts", () => {
+    const r = parseMaterialInput("Al2O3");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.rows.length).toBe(2);
+    const al = r.ok.rows.find((x) => x.formula === "Al");
+    const o = r.ok.rows.find((x) => x.formula === "O");
+    expect(al!.value).toBe(2);
+    expect(o!.value).toBe(3);
+  });
+
+  it("propagates row enrichment for isotope-prefixed formulas", () => {
+    const r = parseMaterialInput("D2O");
+    if (!r || "error" in r) throw new Error();
+    const h = r.ok.rows.find((x) => x.formula === "H");
+    expect(h!.enrichment).toBeDefined();
+    expect(h!.enrichment!.H[2]).toBeCloseTo(1.0);
+  });
+
+  it("density auto-populates for tabulated compounds", () => {
+    const r = parseMaterialInput("H2O");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.density).toBe(1.0);
+  });
+});
+
+describe("parseMaterialInput — mass mode", () => {
+  it("parses with explicit balance", () => {
+    const r = parseMaterialInput("Al 80%, Cu 5%, Zn bal");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.rows.map((x) => x.formula)).toEqual(["Al", "Cu", "Zn"]);
+    expect(r.ok.rows.map((x) => x.isBalance)).toEqual([false, false, true]);
+    expect(r.ok.rows[2].value).toBeNull();
+  });
+
+  it("accepts compound rows", () => {
+    const r = parseMaterialInput("SiO2 80%, H2O 20%");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.rows.map((x) => x.formula)).toEqual(["SiO2", "H2O"]);
+  });
+
+  it("rejects mass sum != 100 without balance", () => {
+    const r = parseMaterialInput("Al 80%, Cu 10%");
+    expect(r).toEqual({ error: expect.stringMatching(/100%/) });
+  });
+
+  it("rejects sum > 100 with balance", () => {
+    const r = parseMaterialInput("Al 60%, Cu 60%, Zn bal");
+    expect(r).toEqual({ error: expect.stringMatching(/exceed/i) });
+  });
+
+  it("rejects two balance rows", () => {
+    const r = parseMaterialInput("Al bal, Cu bal");
+    expect(r).toEqual({ error: expect.stringMatching(/one row/i) });
+  });
+});
+
+describe("parseMaterialInput — atom mode", () => {
+  it("parses fractional input summing to 1", () => {
+    const r = parseMaterialInput("Fe 0.7, Cr 0.18, Ni 0.12");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.mode).toBe("atom");
+    expect(r.ok.rows.length).toBe(3);
+  });
+
+  it("parses balance with single row", () => {
+    const r = parseMaterialInput("Si 0.75, Na 0.14, Ca bal");
+    if (!r || "error" in r) throw new Error();
+    expect(r.ok.rows[2].isBalance).toBe(true);
+  });
+
+  it("rejects sum != 1 without balance", () => {
+    const r = parseMaterialInput("Fe 0.5, Cr 0.2");
+    expect(r).toEqual({ error: expect.stringMatching(/sum/i) });
   });
 });
 
 describe("serialise", () => {
   it("returns empty string for empty rows", () => {
-    expect(serialise([])).toBe("");
+    expect(serialise("mass", [])).toBe("");
   });
 
-  it("serialises stoichiometric rows as a chemical formula", () => {
+  it("mass: sorts by descending value, balance last", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "stoich", value: 2 }),
-      row({ symbol: "O", unit: "stoich", value: 3 }),
+      row({ formula: "Cu", value: 5 }),
+      row({ formula: "Al", value: 80 }),
+      row({ formula: "Zn", value: null, isBalance: true }),
     ];
-    expect(serialise(rows)).toBe("Al2O3");
+    expect(serialise("mass", rows)).toBe("Al 80%, Cu 5%, Zn bal");
   });
 
-  it("omits count of 1 in stoichiometric serialisation", () => {
+  it("atom: serialises with no percent", () => {
     const rows: Row[] = [
-      row({ symbol: "Fe", unit: "stoich", value: 1 }),
-      row({ symbol: "O", unit: "stoich", value: 2 }),
+      row({ formula: "Fe", value: 0.7 }),
+      row({ formula: "Cr", value: 0.18 }),
     ];
-    expect(serialise(rows)).toBe("FeO2");
+    expect(serialise("atom", rows)).toBe("Fe 0.7, Cr 0.18");
   });
 
-  it("serialises wt% rows with explicit percentages", () => {
+  it("single: concatenates stoich counts", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
-      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
-      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
+      row({ formula: "Al", value: 2 }),
+      row({ formula: "O", value: 3 }),
     ];
-    expect(serialise(rows)).toBe("Al 80%, Cu 5%, Zn %");
+    expect(serialise("single", rows)).toBe("Al2O3");
   });
 
-  it("serialises a single wt% row with balance as bare percentage", () => {
-    const rows: Row[] = [row({ symbol: "Cu", unit: "wt%", isBalance: true, value: null })];
-    expect(serialise(rows)).toBe("Cu %");
-  });
-
-  it("serialises mixed units as best-effort stoich form", () => {
+  it("single: omits count of 1", () => {
     const rows: Row[] = [
-      row({ symbol: "Fe", unit: "stoich", value: 1 }),
-      row({ symbol: "Cr", unit: "wt%", value: 18 }),
+      row({ formula: "Fe", value: 1 }),
+      row({ formula: "O", value: 1 }),
     ];
-    expect(serialise(rows)).toBe("FeCr18");
+    expect(serialise("single", rows)).toBe("FeO");
   });
 });
 
-describe("serialise round-trip", () => {
-  it("text → rows → text is canonical for stoichiometric input", () => {
-    const parsed = parseMaterialInput("Al2O3");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    expect(serialise(toRows(parsed.ok))).toBe("Al2O3");
+describe("round-trip", () => {
+  it("text → parse → serialise is canonical for mass mode with balance", () => {
+    const r = parseMaterialInput("Al 80%, Cu 5%, Zn bal");
+    if (!r || "error" in r) throw new Error();
+    expect(serialise("mass", r.ok.rows)).toBe("Al 80%, Cu 5%, Zn bal");
   });
 
-  it("text → rows → text is canonical for mass-ratio input with balance", () => {
-    const parsed = parseMaterialInput("Al 80%, Cu 5%, Zn %");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    expect(serialise(toRows(parsed.ok))).toBe("Al 80%, Cu 5%, Zn %");
-  });
-
-  it("text → rows → text is canonical for FeO2", () => {
-    const parsed = parseMaterialInput("FeO2");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    expect(serialise(toRows(parsed.ok))).toBe("FeO2");
-  });
-
-  it("text → rows → text for mass-ratio without balance preserves entries", () => {
-    const parsed = parseMaterialInput("Al 90%, Cu 10%");
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    expect(serialise(toRows(parsed.ok))).toBe("Al 90%, Cu 10%");
+  it("compound mass round-trip", () => {
+    const r = parseMaterialInput("SiO2 80%, H2O 20%");
+    if (!r || "error" in r) throw new Error();
+    expect(serialise("mass", r.ok.rows)).toBe("SiO2 80%, H2O 20%");
   });
 });
 
 describe("validate", () => {
-  it("accepts a clean row list", () => {
+  it("clean mass mixture has no issues", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
-      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
-      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
+      row({ formula: "Al", value: 80 }),
+      row({ formula: "Cu", value: 5 }),
+      row({ formula: "Zn", value: null, isBalance: true }),
     ];
-    expect(validate(rows)).toEqual([]);
-  });
-
-  it("flags duplicate symbols as warnings", () => {
-    const rows: Row[] = [
-      row({ symbol: "Cu", unit: "wt%", value: 50 }),
-      row({ symbol: "Cu", unit: "wt%", value: 50 }),
-    ];
-    const issues = validate(rows);
-    const dup = issues.filter((i) => i.message.includes("Duplicate"));
-    expect(dup.length).toBe(1);
-    expect(dup[0].level).toBe("warning");
-  });
-
-  it("flags >1 balance row as form-level error", () => {
-    const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", isBalance: true, value: null }),
-      row({ symbol: "Cu", unit: "wt%", isBalance: true, value: null }),
-    ];
-    const issues = validate(rows);
-    expect(issues.some((i) => i.level === "error" && i.message.includes("balance"))).toBe(true);
-  });
-
-  it("flags non-balance row with null value as row-scoped error", () => {
-    const rows: Row[] = [
-      row({ id: "r1", symbol: "Al", unit: "wt%", value: null, isBalance: false }),
-    ];
-    const issues = validate(rows);
-    const blank = issues.find((i) => i.rowId === "r1" && i.level === "error");
-    expect(blank).toBeDefined();
-    expect(blank!.message).toMatch(/value/i);
-  });
-
-  it("flags negative value as row-scoped error", () => {
-    const rows: Row[] = [
-      row({ id: "r1", symbol: "Al", unit: "wt%", value: -10, isBalance: false }),
-    ];
-    const issues = validate(rows);
-    expect(
-      issues.some((i) => i.rowId === "r1" && i.level === "error" && /non-negative/.test(i.message)),
-    ).toBe(true);
+    expect(validate("mass", rows)).toEqual([]);
   });
 
   it("flags wt% sum != 100 (no balance) as warning", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 50 }),
-      row({ symbol: "Cu", unit: "wt%", value: 30 }),
+      row({ formula: "Al", value: 50 }),
+      row({ formula: "Cu", value: 30 }),
     ];
-    const issues = validate(rows);
-    expect(
-      issues.some((i) => i.level === "warning" && /sum/i.test(i.message)),
-    ).toBe(true);
+    const issues = validate("mass", rows);
+    expect(issues.some((i) => i.level === "warning" && /sum/i.test(i.message))).toBe(true);
   });
 
-  it("does not flag wt% sum when balance row is present", () => {
+  it("flags >1 balance as error", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 50 }),
-      row({ symbol: "Cu", unit: "wt%", value: 30 }),
-      row({ symbol: "Zn", unit: "wt%", value: null, isBalance: true }),
+      row({ formula: "Al", value: null, isBalance: true }),
+      row({ formula: "Cu", value: null, isBalance: true }),
     ];
-    const issues = validate(rows);
-    expect(issues.some((i) => /sum/i.test(i.message))).toBe(false);
+    expect(validate("mass", rows).some((i) => i.level === "error" && /one/i.test(i.message))).toBe(true);
   });
 
-  it("flags wt% sum > 100 with balance as error (negative balance)", () => {
+  it("flags blank value (non-balance) as row-scoped error", () => {
+    const rows: Row[] = [row({ id: "r1", formula: "Al", value: null })];
+    expect(validate("mass", rows).some((i) => i.rowId === "r1" && i.level === "error")).toBe(true);
+  });
+
+  it("flags duplicate formula as warning", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 60 }),
-      row({ symbol: "Cu", unit: "wt%", value: 60 }),
-      row({ symbol: "Zn", unit: "wt%", value: null, isBalance: true }),
+      row({ formula: "Cu", value: 50 }),
+      row({ formula: "Cu", value: 50 }),
     ];
-    const issues = validate(rows);
-    expect(
-      issues.some((i) => i.level === "error" && /exceed/i.test(i.message)),
-    ).toBe(true);
+    const issues = validate("mass", rows);
+    expect(issues.filter((i) => /duplicate/i.test(i.message)).length).toBe(1);
   });
 
-  it("flags mixed units as form-level warning", () => {
+  it("validateSingle rejects balance rows", () => {
+    const rows: Row[] = [row({ formula: "Al", value: null, isBalance: true })];
+    expect(validateSingle(rows).some((i) => /balance/i.test(i.message))).toBe(true);
+  });
+
+  it("validateAtom flags sum != 1 (no balance)", () => {
     const rows: Row[] = [
-      row({ symbol: "Fe", unit: "stoich", value: 1 }),
-      row({ symbol: "Cr", unit: "wt%", value: 18 }),
+      row({ formula: "Fe", value: 0.5 }),
+      row({ formula: "Cr", value: 0.2 }),
     ];
-    const issues = validate(rows);
-    expect(
-      issues.some((i) => i.level === "warning" && /mixed units/i.test(i.message)),
-    ).toBe(true);
+    expect(validateAtom(rows).some((i) => /sum/i.test(i.message))).toBe(true);
   });
 
-  it("flags unknown symbol as row-scoped error", () => {
-    const rows: Row[] = [row({ id: "r1", symbol: "Xx", unit: "wt%", value: 50 })];
-    const issues = validate(rows);
-    expect(
-      issues.some((i) => i.rowId === "r1" && i.level === "error" && /Unknown/.test(i.message)),
-    ).toBe(true);
-  });
-
-  it("returns empty issues for empty rows (form is empty, not invalid)", () => {
-    expect(validate([])).toEqual([]);
-  });
-
-  it("ignores blank symbol field (not a known element check)", () => {
-    const rows: Row[] = [row({ id: "r1", symbol: "", unit: "wt%", value: 50 })];
-    const issues = validate(rows);
-    // empty symbol isn't a known-element error; it's just a row in flux
-    expect(issues.some((i) => /Unknown/.test(i.message))).toBe(false);
-  });
-
-  it("treats stoich-only rows without sum check", () => {
+  it("validateMass flags sum > 100 with balance as error", () => {
     const rows: Row[] = [
-      row({ symbol: "Al", unit: "stoich", value: 2 }),
-      row({ symbol: "O", unit: "stoich", value: 3 }),
+      row({ formula: "Al", value: 60 }),
+      row({ formula: "Cu", value: 60 }),
+      row({ formula: "Zn", value: null, isBalance: true }),
     ];
-    expect(validate(rows)).toEqual([]);
+    expect(validateMass(rows).some((i) => i.level === "error" && /exceed/i.test(i.message))).toBe(true);
   });
 
-  it("preserves error/warning ordering deterministically", () => {
-    const rows: Row[] = [
-      row({ id: "a", symbol: "Cu", unit: "wt%", value: null }),
-      row({ id: "b", symbol: "Cu", unit: "wt%", value: null }),
-    ];
-    const issues = validate(rows);
-    // Duplicate first (warning), then two missing-value errors
-    expect(issues.length).toBeGreaterThanOrEqual(3);
+  it("validateAtom rejects negative value", () => {
+    const rows: Row[] = [row({ id: "r1", formula: "Fe", value: -0.1 })];
+    expect(validateAtom(rows).some((i) => i.rowId === "r1" && i.level === "error")).toBe(true);
+  });
+
+  it("flags unknown element as row-scoped error", () => {
+    const rows: Row[] = [row({ id: "r1", formula: "Xx", value: 50 })];
+    expect(validate("mass", rows).some((i) => i.rowId === "r1" && i.level === "error")).toBe(true);
   });
 });
 
-describe("serialise → parseMaterialInput → toRows round-trip", () => {
-  it("survives stoichiometric round-trip", () => {
-    const original: Row[] = [
-      row({ symbol: "Al", unit: "stoich", value: 2 }),
-      row({ symbol: "O", unit: "stoich", value: 3 }),
-    ];
-    const text = serialise(original);
-    const parsed = parseMaterialInput(text);
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const round = toRows(parsed.ok);
-    expect(round.map((r) => ({ s: r.symbol, u: r.unit, v: r.value, b: r.isBalance }))).toEqual(
-      original.map((r) => ({ s: r.symbol, u: r.unit, v: r.value, b: r.isBalance })),
-    );
+describe("inferMode", () => {
+  it("returns null for empty", () => {
+    expect(inferMode("")).toBeNull();
   });
 
-  it("survives mass-ratio round-trip with balance", () => {
-    const original: Row[] = [
-      row({ symbol: "Al", unit: "wt%", value: 80, isBalance: false }),
-      row({ symbol: "Cu", unit: "wt%", value: 5, isBalance: false }),
-      row({ symbol: "Zn", unit: "wt%", value: 15, isBalance: true }),
-    ];
-    const text = serialise(original);
-    const parsed = parseMaterialInput(text);
-    if (!parsed || !("ok" in parsed)) throw new Error("expected ok");
-    const round = toRows(parsed.ok);
-    expect(round.map((r) => r.symbol)).toEqual(["Al", "Cu", "Zn"]);
-    expect(round.map((r) => r.isBalance)).toEqual([false, false, true]);
-    expect(round[0].value).toBeCloseTo(80, 4);
-    expect(round[2].value).toBeCloseTo(15, 4);
+  it("returns mode + confidence for parseable input", () => {
+    const r = inferMode("Al 80%, Cu 20%");
+    expect(r!.mode).toBe("mass");
+    expect(r!.confidence).toBe("high");
+  });
+
+  it("returns null for malformed input", () => {
+    expect(inferMode("not a formula at all,,,")).toBeNull();
+  });
+
+  it("flags glassy mol% nudge", () => {
+    const r = inferMode("SiO2 75%, Na2O 14%, CaO 11%");
+    expect(r!.confidence).toBe("low");
+    expect(r!.nudge).toMatch(/mol%/);
+  });
+});
+
+describe("isTabulatedDensity", () => {
+  it("true for compounds in COMPOUND_DENSITIES", () => {
+    expect(isTabulatedDensity("H2O")).toBe(true);
+  });
+
+  it("true for single elements with tabulated density", () => {
+    expect(isTabulatedDensity("Cu")).toBe(true);
+  });
+
+  it("false for compounds with no entry", () => {
+    expect(isTabulatedDensity("Na2O")).toBe(false);
+  });
+});
+
+describe("rowAverageAtomicMass", () => {
+  it("water averages H and O atoms", () => {
+    expect(rowAverageAtomicMass("H2O")).toBeCloseTo(6.005, 2);
+  });
+
+  it("single element returns its standard weight", () => {
+    expect(rowAverageAtomicMass("Cu")).toBeCloseTo(63.55, 1);
   });
 });

--- a/frontend/src/lib/components/material/define-form-rows.ts
+++ b/frontend/src/lib/components/material/define-form-rows.ts
@@ -1,163 +1,66 @@
 /**
  * Pure helpers backing the rows-based DefineForm UI.
  *
- * Rows are the source of truth; the paste-formula text field is a derived
- * view (when clean) or a draft (when dirty). All round-trips between rows
- * and text are pure functions called from event handlers — no $effects.
+ * The form has one **mode** (form-level basis) — Single | Mass | Atom — and
+ * rows hold compounds or single elements. Per-row enrichment is reserved as
+ * a carrier; the resolver consumes it. Mode is auto-inferred from input
+ * style; the chip shows confidence and may suggest mol% for known glassy
+ * compositions.
  *
- * Refs: #64 §3.1
+ * Hard rule (#92, retained from #88 §3.1): all rows↔text round-trips run
+ * inside event handlers or pure derivations. **No $effect** in the form
+ * watches `mode`, `rows`, or `textDraft`.
+ *
+ * Refs: #92
  */
 import {
   COMPOUND_DENSITIES,
   ELEMENT_DENSITIES,
   parseFormula,
+  parseIsotopicFormula,
   STANDARD_ATOMIC_WEIGHT,
   SYMBOL_TO_Z,
 } from "@hyrr/compute";
 
-export type Unit = "wt%" | "atomfrac" | "stoich";
+export type Mode = "single" | "mass" | "atom";
 
 export interface Row {
   id: string;
-  symbol: string;
-  value: number | null;
-  unit: Unit;
-  isBalance: boolean;
-}
-
-export interface ParsedMaterial {
-  type: "stoichiometric" | "mass-ratio";
+  /** Any parseable formula — single element ("Cu"), compound ("SiO2"), or
+   *  isotope-prefixed ("D2O", "³He"). Not a catalog name. */
   formula: string;
-  elements: string[];
-  density: number | null;
-  autoName: string;
-  /** Mass fractions (0..1), only set for mass-ratio inputs. */
-  massFractions?: Record<string, number>;
-  /** Integer stoichiometric counts, only set for stoichiometric inputs. */
-  stoichCounts?: Record<string, number>;
-  /** Element symbol that supplied the balance ("Zn %"), only set when used. */
-  balanceSymbol?: string;
+  /** wt% in mass mode; atom% (0..1 or 0..100 — see normalisation rules) in
+   *  atom mode; stoichiometric count in single mode. null when isBalance. */
+  value: number | null;
+  /** Mass + atom modes only. */
+  isBalance: boolean;
+  /** Per-row, per-element enrichment override. Resolver order:
+   *  row.enrichment → layer.enrichment → naturalAbundance. (#93 carrier) */
+  enrichment?: Record<string, Record<number, number>>;
 }
-
-export type ParseResult =
-  | { ok: ParsedMaterial }
-  | { error: string }
-  | null;
 
 export interface Issue {
-  /** Row id when the issue is row-scoped; absent when it's form-level. */
   rowId?: string;
   level: "error" | "warning";
   message: string;
 }
 
-export function parseMaterialInput(input: string): ParseResult {
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-
-  if (trimmed.includes("%")) {
-    return parseMassRatio(trimmed);
-  }
-
-  try {
-    const counts = parseFormula(trimmed);
-    const elements = Object.keys(counts);
-    if (elements.length === 0) return { error: "No elements found in formula" };
-    for (const el of elements) {
-      if (!SYMBOL_TO_Z[el]) return { error: `Unknown element: ${el}` };
-    }
-    let density: number | null = null;
-    if (COMPOUND_DENSITIES[trimmed]) {
-      density = COMPOUND_DENSITIES[trimmed];
-    } else if (elements.length === 1 && ELEMENT_DENSITIES[elements[0]]) {
-      density = ELEMENT_DENSITIES[elements[0]];
-    }
-    return {
-      ok: {
-        type: "stoichiometric",
-        formula: trimmed,
-        elements,
-        density,
-        autoName: trimmed,
-        stoichCounts: counts,
-      },
-    };
-  } catch {
-    return { error: "Invalid formula" };
-  }
+export interface ParseOk {
+  mode: Mode;
+  rows: Row[];
+  /** "high" when the input is unambiguous; "low" when an alternative mode is
+   *  plausible (e.g. % values that could be wt% or mol%). */
+  confidence: "high" | "low";
+  /** Optional UX nudge text — e.g. mol% suggestion for glassy comps. */
+  nudge?: string;
+  /** Optional density / autoName carry-overs derived during parse. */
+  density?: number | null;
+  autoName?: string;
 }
 
-function parseMassRatio(input: string): ParseResult {
-  const parts = input.split(",").map((s) => s.trim()).filter(Boolean);
-  const entries: { symbol: string; pct: number | null }[] = [];
-
-  for (const part of parts) {
-    const m = part.match(/^([A-Z][a-z]?)\s*(\d+(?:\.\d+)?)?\s*%$/);
-    if (!m) return { error: `Invalid: "${part}". Use "Al 80%, Cu 5%, Zn %"` };
-    const sym = m[1];
-    if (!SYMBOL_TO_Z[sym]) return { error: `Unknown element: ${sym}` };
-    entries.push({ symbol: sym, pct: m[2] ? parseFloat(m[2]) : null });
-  }
-
-  const specified = entries.filter((e) => e.pct !== null);
-  const remainder = entries.filter((e) => e.pct === null);
-  const specifiedSum = specified.reduce((s, e) => s + (e.pct ?? 0), 0);
-
-  if (remainder.length > 1) return { error: "Only one element can have unspecified %" };
-  if (remainder.length === 0 && Math.abs(specifiedSum - 100) > 0.5) {
-    return { error: `Sum is ${specifiedSum.toFixed(1)}%, needs 100%` };
-  }
-  let balanceSymbol: string | undefined;
-  if (remainder.length === 1) {
-    const rest = 100 - specifiedSum;
-    if (rest < 0) return { error: `Sum exceeds 100% (${specifiedSum.toFixed(1)}%)` };
-    remainder[0].pct = rest;
-    balanceSymbol = remainder[0].symbol;
-  }
-
-  const massFractions: Record<string, number> = {};
-  const moles: Record<string, number> = {};
-  let totalMoles = 0;
-  let density = 0;
-  const nameParts: string[] = [];
-
-  for (const e of entries) {
-    const wt = (e.pct ?? 0) / 100;
-    massFractions[e.symbol] = wt;
-    const atomicWeight = STANDARD_ATOMIC_WEIGHT[e.symbol] ?? 1;
-    const mol = wt / atomicWeight;
-    moles[e.symbol] = mol;
-    totalMoles += mol;
-    density += wt * (ELEMENT_DENSITIES[e.symbol] ?? 5);
-    nameParts.push(`${e.symbol}${Math.round(e.pct ?? 0)}`);
-  }
-
-  const atomFracs = entries.map((e) => ({ symbol: e.symbol, frac: moles[e.symbol] / totalMoles }));
-  const minFrac = Math.min(...atomFracs.map((a) => a.frac));
-  const formula = atomFracs
-    .map((a) => {
-      const ratio = a.frac / minFrac;
-      const rounded = Math.round(ratio * 100) / 100;
-      return rounded === 1 ? a.symbol : `${a.symbol}${rounded}`;
-    })
-    .join("");
-
-  return {
-    ok: {
-      type: "mass-ratio",
-      formula,
-      elements: entries.map((e) => e.symbol),
-      density,
-      autoName: nameParts.join("-"),
-      massFractions,
-      balanceSymbol,
-    },
-  };
-}
+export type ParseResult = { ok: ParseOk } | { error: string } | null;
 
 let __idCounter = 0;
-/** ID generator. Uses crypto.randomUUID when available; otherwise a counter
- *  + timestamp suffix that's stable for the duration of one session. */
 export function generateRowId(): string {
   const g = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
   if (g?.randomUUID) return g.randomUUID();
@@ -165,184 +68,387 @@ export function generateRowId(): string {
   return `row-${Date.now()}-${__idCounter}`;
 }
 
+/** Common glass-network formers — used by the mol% nudge. */
+const GLASS_FORMERS = new Set(["Si", "B", "P", "Ge", "As"]);
+const GLASS_MODIFIERS = new Set(["Na", "K", "Ca", "Mg", "Li", "Ba", "Sr", "Al"]);
+
 /**
- * Convert a successful ParsedMaterial into a Row[].
- *
- * - mass-ratio: one row per entry, unit="wt%", value=percentage,
- *   balanceSymbol → isBalance=true (value retained for display).
- * - stoichiometric: one row per element, unit="stoich", value=count.
+ * Detect "looks like a glass / ceramic" mass-mixture: any row's formula
+ * contains a glass former with O AND at least one row contributes a glass
+ * modifier. Triggers the "did you mean mol%?" nudge when the form is
+ * inferred as mass-mode but the literature convention is mol%.
  */
-export function toRows(parsed: ParsedMaterial): Row[] {
-  if (parsed.type === "mass-ratio") {
-    const fractions = parsed.massFractions ?? {};
-    return parsed.elements.map((sym) => ({
-      id: generateRowId(),
-      symbol: sym,
-      value: (fractions[sym] ?? 0) * 100,
-      unit: "wt%" as const,
-      isBalance: parsed.balanceSymbol === sym,
-    }));
+function looksGlassy(rows: Row[]): boolean {
+  let hasFormer = false;
+  let hasModifier = false;
+  for (const r of rows) {
+    let counts: Record<string, number>;
+    try { counts = parseFormula(r.formula); } catch { continue; }
+    const elements = Object.keys(counts);
+    if (!elements.includes("O")) continue;
+    for (const el of elements) {
+      if (GLASS_FORMERS.has(el)) hasFormer = true;
+      if (GLASS_MODIFIERS.has(el)) hasModifier = true;
+    }
   }
-  // stoichiometric
-  const counts = parsed.stoichCounts ?? {};
-  return parsed.elements.map((sym) => ({
+  return hasFormer && hasModifier;
+}
+
+/** Parse a single row's formula token, applying isotope-prefix expansion.
+ *  Returns null if the token is not a valid formula. */
+function parseRowFormula(token: string): { formula: string; enrichment?: Record<string, Record<number, number>> } | null {
+  const iso = parseIsotopicFormula(token);
+  if (!iso) return null;
+  const counts = parseFormula(iso.formula);
+  if (Object.keys(counts).length === 0) return null;
+  for (const sym of Object.keys(counts)) {
+    if (!(sym in SYMBOL_TO_Z)) return null;
+  }
+  const enrichment = Object.keys(iso.enrichment).length > 0 ? iso.enrichment : undefined;
+  return { formula: iso.formula, enrichment };
+}
+
+/**
+ * Top-level parse. Detects mode from input style, splits into rows, applies
+ * isotope-prefix expansion, returns either an ok / error / null result.
+ */
+export function parseMaterialInput(input: string): ParseResult {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  const hasComma = trimmed.includes(",");
+  const hasPercent = trimmed.includes("%");
+
+  if (!hasComma && !hasPercent) {
+    return parseSingleFormula(trimmed);
+  }
+  if (hasPercent) return parseMassMixture(trimmed);
+  return parseAtomMixture(trimmed);
+}
+
+function parseSingleFormula(input: string): ParseResult {
+  const parsed = parseRowFormula(input);
+  if (!parsed) return { error: `Invalid formula: ${input}` };
+  const counts = parseFormula(parsed.formula);
+  const elements = Object.keys(counts);
+
+  let density: number | null = null;
+  if (COMPOUND_DENSITIES[parsed.formula]) {
+    density = COMPOUND_DENSITIES[parsed.formula];
+  } else if (elements.length === 1 && ELEMENT_DENSITIES[elements[0]]) {
+    density = ELEMENT_DENSITIES[elements[0]];
+  }
+
+  // In single mode, rows are read-only stoich counts (one row per element).
+  const rows: Row[] = elements.map((sym) => ({
     id: generateRowId(),
-    symbol: sym,
-    value: counts[sym] ?? 1,
-    unit: "stoich" as const,
+    formula: sym,
+    value: counts[sym],
     isBalance: false,
+    ...(parsed.enrichment && parsed.enrichment[sym]
+      ? { enrichment: { [sym]: parsed.enrichment[sym] } }
+      : {}),
   }));
+
+  return {
+    ok: {
+      mode: "single",
+      rows,
+      confidence: "high",
+      density,
+      autoName: parsed.formula,
+    },
+  };
 }
 
-/**
- * Serialise rows back to a string the user could paste into the text field.
- *
- * - All wt% rows → "Al 80%, Cu 5%, Zn %" (balance row gets blank percentage).
- * - All stoich rows → chemical formula "Al2O3" (count omitted when 1).
- * - All atomfrac rows → "Al0.4Cu0.6"-style decimal-stoich (informational; the
- *   parser cannot round-trip atomfrac, so callers should treat this as
- *   display-only and prefer the stoich/wt% forms when possible).
- * - Mixed units: stoich-priority chemical-formula form; round-trip is not
- *   guaranteed (the validator surfaces a "mixed units" warning).
- */
-export function serialise(rows: Row[]): string {
-  if (rows.length === 0) return "";
-  const units = new Set(rows.map((r) => r.unit));
+function parseMassMixture(input: string): ParseResult {
+  const parts = input.split(",").map((s) => s.trim()).filter(Boolean);
+  const rows: Row[] = [];
+  const massFractions: Record<string, number> = {};
 
-  if (units.size === 1 && units.has("wt%")) {
-    return rows
-      .map((r) => {
-        if (r.isBalance) return `${r.symbol} %`;
-        const val = r.value;
-        if (val === null || !Number.isFinite(val)) return `${r.symbol} %`;
-        const s = Number.isInteger(val) ? String(val) : String(val);
-        return `${r.symbol} ${s}%`;
-      })
-      .join(", ");
-  }
-
-  if (units.size === 1 && units.has("stoich")) {
-    return rows
-      .map((r) => {
-        const val = r.value;
-        if (val === null || val === 1) return r.symbol;
-        return `${r.symbol}${val}`;
-      })
-      .join("");
-  }
-
-  if (units.size === 1 && units.has("atomfrac")) {
-    return rows
-      .map((r) => {
-        const val = r.value;
-        if (val === null) return r.symbol;
-        return `${r.symbol}${val}`;
-      })
-      .join("");
-  }
-
-  // Mixed units: best-effort stoich-style serialisation. Validator will warn.
-  return rows
-    .map((r) => {
-      const val = r.value;
-      if (val === null || val === 1) return r.symbol;
-      return `${r.symbol}${val}`;
-    })
-    .join("");
-}
-
-/**
- * Validate a Row[]. Returns a list of Issue records (errors and warnings).
- * Empty array means the rows are clean.
- */
-export function validate(rows: Row[]): Issue[] {
-  const issues: Issue[] = [];
-
-  // duplicate symbol → warning per duplicate row (after the first occurrence)
-  const seen = new Map<string, string>();
-  for (const r of rows) {
-    if (!r.symbol) continue;
-    const prev = seen.get(r.symbol);
-    if (prev !== undefined) {
-      issues.push({
-        rowId: r.id,
-        level: "warning",
-        message: `Duplicate element ${r.symbol}`,
-      });
-    } else {
-      seen.set(r.symbol, r.id);
+  for (const part of parts) {
+    const m = part.match(/^(\S+?)\s*(?:(\d+(?:\.\d+)?)\s*%|%|bal|balance)?$/i);
+    if (!m) return { error: `Invalid: "${part}". Use "SiO2 80%, H2O 20%" or "Fe bal".` };
+    const formulaToken = m[1];
+    const valueStr = m[2];
+    const isBalance = !valueStr; // either explicit "bal", "balance", or bare "%"
+    const parsed = parseRowFormula(formulaToken);
+    if (!parsed) return { error: `Invalid formula: "${formulaToken}"` };
+    const value = isBalance ? null : parseFloat(valueStr);
+    if (!isBalance && (!Number.isFinite(value) || (value as number) < 0)) {
+      return { error: `Invalid percentage in "${part}"` };
     }
-  }
-
-  // unknown symbol → error
-  for (const r of rows) {
-    if (r.symbol && !SYMBOL_TO_Z[r.symbol]) {
-      issues.push({
-        rowId: r.id,
-        level: "error",
-        message: `Unknown element: ${r.symbol}`,
-      });
-    }
-  }
-
-  // >1 balance row → error (form-level)
-  const balanceRows = rows.filter((r) => r.isBalance);
-  if (balanceRows.length > 1) {
-    issues.push({
-      level: "error",
-      message: "Only one row can be marked as balance",
+    rows.push({
+      id: generateRowId(),
+      formula: parsed.formula,
+      value,
+      isBalance,
+      ...(parsed.enrichment ? { enrichment: parsed.enrichment } : {}),
     });
   }
 
-  // non-balance row with null value → error per row
+  // Resolve balance: at most one balance row.
+  const balanceCount = rows.filter((r) => r.isBalance).length;
+  if (balanceCount > 1) return { error: "Only one row can be balance" };
+
+  const specifiedSum = rows.filter((r) => !r.isBalance).reduce((s, r) => s + (r.value ?? 0), 0);
+  if (balanceCount === 0 && Math.abs(specifiedSum - 100) > 0.5) {
+    return { error: `Mass fractions sum to ${specifiedSum.toFixed(1)}%, expected 100%` };
+  }
+  if (balanceCount === 1) {
+    const rest = 100 - specifiedSum;
+    if (rest < 0) return { error: `Sum exceeds 100% (${specifiedSum.toFixed(1)}%)` };
+    // Don't write the value back into the row — keep value=null so the row
+    // renders as "balance" in the UI; the resolver computes the share.
+  }
+
+  // Estimate density and autoName for callers.
+  const nameParts: string[] = [];
+  let densityEstimate = 0;
+  let densitySumWt = 0;
+  for (const r of rows) {
+    const parsed = parseFormula(r.formula);
+    const elements = Object.keys(parsed);
+    let rho: number | undefined;
+    if (COMPOUND_DENSITIES[r.formula]) rho = COMPOUND_DENSITIES[r.formula];
+    else if (elements.length === 1) rho = ELEMENT_DENSITIES[elements[0]];
+    const wt = r.isBalance ? Math.max(0, 100 - specifiedSum) : (r.value ?? 0);
+    massFractions[r.formula] = (massFractions[r.formula] ?? 0) + wt / 100;
+    if (rho !== undefined) {
+      densityEstimate += (wt / 100) * rho;
+      densitySumWt += wt / 100;
+    }
+    nameParts.push(`${r.formula}${Math.round(wt)}`);
+  }
+  const density = densitySumWt > 0.99 ? densityEstimate : null;
+
+  // Mode confidence: low when input could plausibly be mol% (glassy comps).
+  const glassy = looksGlassy(rows);
+  const confidence: "high" | "low" = glassy ? "low" : "high";
+  const nudge = glassy ? "Did you mean mol%? Glass / ceramic compositions are usually quoted in mol%, not wt%." : undefined;
+
+  return { ok: { mode: "mass", rows, confidence, nudge, density, autoName: nameParts.join("-") } };
+}
+
+function parseAtomMixture(input: string): ParseResult {
+  const parts = input.split(",").map((s) => s.trim()).filter(Boolean);
+  const rows: Row[] = [];
+
+  for (const part of parts) {
+    const m = part.match(/^(\S+?)\s*(\d+(?:\.\d+)?|bal|balance)$/i);
+    if (!m) return { error: `Invalid: "${part}". Use "Fe 0.7, Cr 0.18, Ni 0.12" or "Fe bal".` };
+    const formulaToken = m[1];
+    const valStr = m[2];
+    const isBalance = /^(bal|balance)$/i.test(valStr);
+    const parsed = parseRowFormula(formulaToken);
+    if (!parsed) return { error: `Invalid formula: "${formulaToken}"` };
+    const raw = isBalance ? null : parseFloat(valStr);
+    if (!isBalance && (!Number.isFinite(raw) || (raw as number) < 0)) {
+      return { error: `Invalid value in "${part}"` };
+    }
+    rows.push({
+      id: generateRowId(),
+      formula: parsed.formula,
+      value: raw,
+      isBalance,
+      ...(parsed.enrichment ? { enrichment: parsed.enrichment } : {}),
+    });
+  }
+
+  const balanceCount = rows.filter((r) => r.isBalance).length;
+  if (balanceCount > 1) return { error: "Only one row can be balance" };
+
+  // Atom-mixture values may sum to 1 (fractions) or 100 (percentages); the
+  // serialiser normalises. Detect which by max value.
+  const maxVal = Math.max(...rows.filter((r) => !r.isBalance).map((r) => r.value ?? 0));
+  const targetSum = maxVal > 1.5 ? 100 : 1;
+
+  const specifiedSum = rows.filter((r) => !r.isBalance).reduce((s, r) => s + (r.value ?? 0), 0);
+  if (balanceCount === 0 && Math.abs(specifiedSum - targetSum) > targetSum * 0.005) {
+    return { error: `Atom fractions sum to ${specifiedSum.toFixed(3)}, expected ${targetSum}` };
+  }
+  if (balanceCount === 1 && specifiedSum > targetSum + targetSum * 0.005) {
+    return { error: `Sum exceeds ${targetSum} (${specifiedSum.toFixed(3)})` };
+  }
+
+  return { ok: { mode: "atom", rows, confidence: "high" } };
+}
+
+/** Canonical text serialisation. Sort by descending value (ties by formula
+ *  lex), balance row last with explicit "bal" token. */
+export function serialise(mode: Mode, rows: Row[]): string {
+  if (rows.length === 0) return "";
+  if (mode === "single") {
+    return rows.map((r) => {
+      const v = r.value;
+      if (v === null || v === 1) return r.formula;
+      return `${r.formula}${v}`;
+    }).join("");
+  }
+
+  const sorted = [...rows].sort((a, b) => {
+    if (a.isBalance && !b.isBalance) return 1;
+    if (!a.isBalance && b.isBalance) return -1;
+    if (a.isBalance && b.isBalance) return 0;
+    const av = a.value ?? 0;
+    const bv = b.value ?? 0;
+    if (bv !== av) return bv - av;
+    return a.formula.localeCompare(b.formula);
+  });
+
+  if (mode === "mass") {
+    return sorted.map((r) => r.isBalance ? `${r.formula} bal` : `${r.formula} ${r.value}%`).join(", ");
+  }
+  // atom mode
+  return sorted.map((r) => r.isBalance ? `${r.formula} bal` : `${r.formula} ${r.value}`).join(", ");
+}
+
+/** Common rules across all modes. */
+function validateCommon(rows: Row[]): Issue[] {
+  const issues: Issue[] = [];
+  const seen = new Map<string, string>();
+  for (const r of rows) {
+    if (!r.formula) continue;
+    if (seen.has(r.formula)) {
+      issues.push({ rowId: r.id, level: "warning", message: `Duplicate formula ${r.formula}` });
+    } else {
+      seen.set(r.formula, r.id);
+    }
+    try {
+      const counts = parseFormula(r.formula);
+      const elements = Object.keys(counts);
+      if (elements.length === 0) {
+        issues.push({ rowId: r.id, level: "error", message: `Invalid formula: ${r.formula}` });
+      } else {
+        for (const el of elements) {
+          if (!(el in SYMBOL_TO_Z)) {
+            issues.push({ rowId: r.id, level: "error", message: `Unknown element: ${el}` });
+          }
+        }
+      }
+    } catch {
+      issues.push({ rowId: r.id, level: "error", message: `Invalid formula: ${r.formula}` });
+    }
+  }
+  return issues;
+}
+
+export function validateMass(rows: Row[]): Issue[] {
+  const issues = validateCommon(rows);
+  const balanceRows = rows.filter((r) => r.isBalance);
+  if (balanceRows.length > 1) {
+    issues.push({ level: "error", message: "Only one row can be balance" });
+  }
   for (const r of rows) {
     if (r.isBalance) continue;
     if (r.value === null || !Number.isFinite(r.value)) {
-      issues.push({
-        rowId: r.id,
-        level: "error",
-        message: "Enter a value",
-      });
+      issues.push({ rowId: r.id, level: "error", message: "Enter a value" });
     } else if (r.value < 0) {
-      issues.push({
-        rowId: r.id,
-        level: "error",
-        message: "Value must be non-negative",
-      });
+      issues.push({ rowId: r.id, level: "error", message: "Value must be non-negative" });
     }
   }
-
-  // mixed units → warning (form-level)
-  const units = new Set(rows.map((r) => r.unit));
-  if (units.size > 1) {
-    issues.push({
-      level: "warning",
-      message: "Mixed units — round-trip to text not guaranteed",
-    });
-  }
-
-  // wt% sum check (only when all rows are wt%, no balance):
-  const allWtPct = rows.length > 0 && units.size === 1 && units.has("wt%");
-  if (allWtPct) {
-    const hasBalance = balanceRows.length === 1;
-    const numericRows = rows.filter(
-      (r) => !r.isBalance && r.value !== null && Number.isFinite(r.value),
-    );
-    const sum = numericRows.reduce((s, r) => s + (r.value ?? 0), 0);
-    if (!hasBalance) {
+  if (rows.length > 0) {
+    const sum = rows.filter((r) => !r.isBalance && r.value !== null && Number.isFinite(r.value)).reduce((s, r) => s + (r.value ?? 0), 0);
+    if (balanceRows.length === 0) {
       if (Math.abs(sum - 100) > 0.5) {
-        issues.push({
-          level: "warning",
-          message: `Mass fractions sum to ${sum.toFixed(1)}%, expected 100%`,
-        });
+        issues.push({ level: "warning", message: `Mass fractions sum to ${sum.toFixed(1)}%, expected 100%` });
       }
     } else if (sum > 100 + 0.5) {
-      issues.push({
-        level: "error",
-        message: `Mass fractions exceed 100% (${sum.toFixed(1)}%) — balance row would be negative`,
-      });
+      issues.push({ level: "error", message: `Mass fractions exceed 100% (${sum.toFixed(1)}%) — balance row would be negative` });
     }
   }
-
   return issues;
+}
+
+export function validateAtom(rows: Row[]): Issue[] {
+  const issues = validateCommon(rows);
+  const balanceRows = rows.filter((r) => r.isBalance);
+  if (balanceRows.length > 1) {
+    issues.push({ level: "error", message: "Only one row can be balance" });
+  }
+  for (const r of rows) {
+    if (r.isBalance) continue;
+    if (r.value === null || !Number.isFinite(r.value)) {
+      issues.push({ rowId: r.id, level: "error", message: "Enter a value" });
+    } else if (r.value < 0) {
+      issues.push({ rowId: r.id, level: "error", message: "Value must be non-negative" });
+    }
+  }
+  if (rows.length > 0) {
+    const numericRows = rows.filter((r) => !r.isBalance && r.value !== null && Number.isFinite(r.value));
+    if (numericRows.length === 0) return issues;
+    const maxV = Math.max(...numericRows.map((r) => r.value ?? 0));
+    const target = maxV > 1.5 ? 100 : 1;
+    const sum = numericRows.reduce((s, r) => s + (r.value ?? 0), 0);
+    if (balanceRows.length === 0) {
+      if (Math.abs(sum - target) > target * 0.005) {
+        issues.push({ level: "warning", message: `Atom fractions sum to ${sum.toFixed(3)}, expected ${target}` });
+      }
+    } else if (sum > target + target * 0.005) {
+      issues.push({ level: "error", message: `Atom fractions exceed ${target} (${sum.toFixed(3)}) — balance row would be negative` });
+    }
+  }
+  return issues;
+}
+
+export function validateSingle(rows: Row[]): Issue[] {
+  const issues = validateCommon(rows);
+  const balanceRows = rows.filter((r) => r.isBalance);
+  if (balanceRows.length > 0) {
+    issues.push({ level: "error", message: "Single-formula mode does not allow a balance row" });
+  }
+  for (const r of rows) {
+    if (r.value === null || !Number.isFinite(r.value) || r.value <= 0) {
+      issues.push({ rowId: r.id, level: "error", message: "Stoichiometric count must be > 0" });
+    }
+  }
+  return issues;
+}
+
+/** Mode-aware dispatch. */
+export function validate(mode: Mode, rows: Row[]): Issue[] {
+  if (mode === "mass") return validateMass(rows);
+  if (mode === "atom") return validateAtom(rows);
+  return validateSingle(rows);
+}
+
+/**
+ * Heuristic mode inference for partially-typed input. Used to render the
+ * mode chip while the user is typing, before they commit. Returns null for
+ * empty input.
+ */
+export function inferMode(text: string): { mode: Mode; confidence: "high" | "low"; nudge?: string } | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const result = parseMaterialInput(trimmed);
+  if (!result || "error" in result) return null;
+  return {
+    mode: result.ok.mode,
+    confidence: result.ok.confidence,
+    nudge: result.ok.nudge,
+  };
+}
+
+/** Lookup of compounds whose density is tabulated. Used by the form to
+ *  decide whether a row's compound contributes a known density or only an
+ *  estimate. */
+export function isTabulatedDensity(formula: string): boolean {
+  if (formula in COMPOUND_DENSITIES) return true;
+  const counts = parseFormula(formula);
+  const elements = Object.keys(counts);
+  return elements.length === 1 && elements[0] in ELEMENT_DENSITIES;
+}
+
+/** Average atomic weight per row (used by the atom-mixture density estimator). */
+export function rowAverageAtomicMass(formula: string): number {
+  const counts = parseFormula(formula);
+  let total = 0;
+  let n = 0;
+  for (const [sym, c] of Object.entries(counts)) {
+    const w = STANDARD_ATOMIC_WEIGHT[sym];
+    if (w === undefined) continue;
+    total += c * w;
+    n += c;
+  }
+  return n > 0 ? total / n : 0;
 }

--- a/packages/compute/src/formula.ts
+++ b/packages/compute/src/formula.ts
@@ -95,6 +95,147 @@ export function formulaToMassFractions(
   );
 }
 
+/* ────────── Isotope-prefix parser ──────────
+ *
+ * Accepts notation common in cyclotron-target literature:
+ *   - Unicode superscript prefix:  ³He, ¹³CO₂, H₂¹⁸O
+ *   - ASCII numeric prefix:        13C, 18O   (digits before symbol)
+ *   - "Symbol-A" suffix:           He-3, Mo-100
+ *   - Deuterium / tritium:         D → H@2, T → H@3
+ *   - Unicode subscript counts:    H₂O is parsed identically to H2O
+ *
+ * Returns the natural-element formula (parseable by parseFormula) plus an
+ * enrichment vector per element, normalized to sum to 1 over the atoms of
+ * that element actually present in the formula. Mixed-isotope formulae
+ * (e.g. ¹⁸O¹⁶O) yield fractional vectors (0.5/0.5).
+ *
+ * Refs: #92 (material-form unified redesign — isotope-prefix parsing)
+ */
+
+const SUPER_DIGITS: Record<string, string> = {
+  "⁰": "0", "¹": "1", "²": "2", "³": "3", "⁴": "4",
+  "⁵": "5", "⁶": "6", "⁷": "7", "⁸": "8", "⁹": "9",
+};
+const SUB_DIGITS: Record<string, string> = {
+  "₀": "0", "₁": "1", "₂": "2", "₃": "3", "₄": "4",
+  "₅": "5", "₆": "6", "₇": "7", "₈": "8", "₉": "9",
+};
+
+function isAsciiDigit(c: string): boolean { return c >= "0" && c <= "9"; }
+function isSuperDigit(c: string): boolean { return c in SUPER_DIGITS; }
+function isSubDigit(c: string): boolean { return c in SUB_DIGITS; }
+function superToAscii(c: string): string { return SUPER_DIGITS[c] ?? c; }
+function subToAscii(c: string): string { return SUB_DIGITS[c] ?? c; }
+function isUpper(c: string): boolean { return c >= "A" && c <= "Z"; }
+function isLower(c: string): boolean { return c >= "a" && c <= "z"; }
+
+export interface IsotopicFormula {
+  /** ASCII-only natural-element formula, parseable by parseFormula. */
+  formula: string;
+  /** Per-element fractional enrichment overlay; empty when no isotope hints. */
+  enrichment: Record<string, Record<number, number>>;
+}
+
+/**
+ * Parse a chemical formula that may carry isotope-prefix notation. Returns
+ * null if the input contains a dangling number, an unknown symbol, or
+ * mixes an isotope prefix with deuterium/tritium shorthand on the same
+ * element ambiguously (e.g. "³D" — undefined).
+ */
+export function parseIsotopicFormula(input: string): IsotopicFormula | null {
+  // Pre-pass: rewrite "Sym-A" → "ASym" so the main pass picks it up as a
+  // numeric prefix. Only digits, no minus signs, are valid as prefixes.
+  const norm = input.replace(/([A-Z][a-z]?)-(\d+)/g, "$2$1");
+
+  let formula = "";
+  // Per-element atom counts (totals across the formula, including the
+  // isotope-prefixed and natural ones, used to normalise enrichment).
+  const totals: Record<string, number> = {};
+  // Per-element accumulated isotope contributions (atom-count by mass A).
+  const isoCounts: Record<string, Record<number, number>> = {};
+
+  let i = 0;
+  while (i < norm.length) {
+    // Skip whitespace.
+    while (i < norm.length && (norm[i] === " " || norm[i] === "\t")) i++;
+    if (i >= norm.length) break;
+
+    // Optional isotope prefix.
+    let isoMass = "";
+    while (i < norm.length && (isAsciiDigit(norm[i]) || isSuperDigit(norm[i]))) {
+      isoMass += superToAscii(norm[i]);
+      i++;
+    }
+
+    if (i >= norm.length) {
+      if (isoMass !== "") return null; // dangling number with no symbol
+      break;
+    }
+
+    if (!isUpper(norm[i])) {
+      if (isoMass !== "") return null;
+      i++; // skip stray punctuation
+      continue;
+    }
+
+    // Symbol [A-Z][a-z]?
+    let sym = norm[i++];
+    if (i < norm.length && isLower(norm[i])) sym += norm[i++];
+
+    // Deuterium / tritium shorthand. If the user already supplied a numeric
+    // prefix on D/T, that's ambiguous (³D? makes no sense), reject.
+    let mappedSym = sym;
+    let mappedIso: number | null = null;
+    if (sym === "D") {
+      if (isoMass !== "") return null;
+      mappedSym = "H";
+      mappedIso = 2;
+    } else if (sym === "T") {
+      if (isoMass !== "") return null;
+      mappedSym = "H";
+      mappedIso = 3;
+    } else if (isoMass !== "") {
+      mappedIso = parseInt(isoMass, 10);
+      if (!Number.isFinite(mappedIso) || mappedIso <= 0) return null;
+    }
+
+    // Subscript / ASCII count suffix.
+    let countStr = "";
+    while (i < norm.length && (isAsciiDigit(norm[i]) || isSubDigit(norm[i]))) {
+      countStr += subToAscii(norm[i]);
+      i++;
+    }
+    const count = countStr === "" ? 1 : parseInt(countStr, 10);
+    if (!Number.isFinite(count) || count <= 0) return null;
+
+    formula += mappedSym + (count === 1 ? "" : String(count));
+    totals[mappedSym] = (totals[mappedSym] ?? 0) + count;
+    if (mappedIso !== null) {
+      isoCounts[mappedSym] ??= {};
+      isoCounts[mappedSym][mappedIso] = (isoCounts[mappedSym][mappedIso] ?? 0) + count;
+    }
+  }
+
+  if (formula === "") return null;
+
+  // Validate every produced symbol is a known element.
+  for (const sym of Object.keys(totals)) {
+    if (!(sym in SYMBOL_TO_Z)) return null;
+  }
+
+  // Normalize isotope counts to fractions of the element's total atoms.
+  const enrichment: Record<string, Record<number, number>> = {};
+  for (const [sym, byMass] of Object.entries(isoCounts)) {
+    const total = totals[sym] ?? 0;
+    if (total === 0) continue;
+    const frac: Record<number, number> = {};
+    for (const [m, c] of Object.entries(byMass)) frac[Number(m)] = c / total;
+    enrichment[sym] = frac;
+  }
+
+  return { formula, enrichment };
+}
+
 /** Known alloy element compositions for XS loading. */
 const ALLOY_ELEMENTS: Record<string, string[]> = {
   havar: ["Co", "Cr", "Ni", "Fe", "W", "Mo", "Mn", "C"],

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -69,12 +69,14 @@ export {
 // --- Formula parsing ---
 export {
   parseFormula,
+  parseIsotopicFormula,
   formulaToMassFractions,
   elementsFromIdentifier,
   SYMBOL_TO_Z,
   STANDARD_ATOMIC_WEIGHT,
   Z_TO_SYMBOL,
 } from "./formula";
+export type { IsotopicFormula } from "./formula";
 
 // --- Config bridge ---
 export {

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -15,6 +15,7 @@ export {
   resolveIsotopics,
   resolveFormula,
   resolveMaterial,
+  resolveMixtureToElements,
   massToAtomFractions,
   setCustomDensityLookup,
   setCustomCompositionLookup,
@@ -22,7 +23,7 @@ export {
   ELEMENT_DENSITIES,
   COMPOUND_DENSITIES,
 } from "./materials";
-export type { CatalogEntry } from "./materials";
+export type { CatalogEntry, MixtureMode, MixtureResult, MixtureResolverOpts, ResolverRow } from "./materials";
 
 // --- Types ---
 export type {

--- a/packages/compute/src/materials.ts
+++ b/packages/compute/src/materials.ts
@@ -220,3 +220,161 @@ export function resolveMaterial(
 
   return { elements, density, molecularWeight };
 }
+
+/* ────────── Mixture resolver (#92) ──────────
+ *
+ * Converts a row-list (form-level mode + per-row formula + per-row optional
+ * enrichment) into the simulator-facing per-element shape:
+ *   - massFractions: Σ mass-fraction per element across all rows
+ *   - isotopes: per-element merged isotope vector. Atom-weighted blend of
+ *     row-level overrides with the natural / layer-level abundance for any
+ *     row that did NOT provide its own override. This is the load-bearing
+ *     semantics from #93: "row-level enrichment overrides natural Mo for
+ *     that row only; co-existing natural-Mo row resolves naturally."
+ *
+ * Pure: takes a `naturalAbundance(symbol) → vector` callback so tests can
+ * mock it without a DataStore. The DataStore caller wires it via
+ * `db.getNaturalAbundances(Z)` lookup.
+ */
+
+export interface ResolverRow {
+  formula: string;
+  value: number | null;
+  isBalance: boolean;
+  enrichment?: Record<string, Record<number, number>>;
+}
+
+export type MixtureMode = "single" | "mass" | "atom";
+
+export interface MixtureResult {
+  /** Per-element mass fractions, summing to ~1. */
+  massFractions: Record<string, number>;
+  /** Per-element merged isotope vector. Each inner record sums to ~1. */
+  isotopes: Record<string, Record<number, number>>;
+}
+
+export interface MixtureResolverOpts {
+  /** Layer-level enrichment override (legacy element-level global) — used
+   *  for rows that don't provide their own override. */
+  layerEnrichment?: Record<string, Record<number, number>>;
+  /** Natural abundance lookup, keyed by element symbol. Returns a vector
+   *  `{A: frac}` summing to 1, or `{}` if unknown (caller falls back to
+   *  the "first stable isotope" behaviour upstream). */
+  naturalAbundance: (symbol: string) => Record<number, number>;
+}
+
+/** Atomic mass of a row's formula (used to convert wt% → mole share). */
+function formulaWeight(formula: string): number {
+  let mw = 0;
+  const counts = parseFormula(formula);
+  for (const [sym, c] of Object.entries(counts)) {
+    const w = STANDARD_ATOMIC_WEIGHT[sym];
+    if (w === undefined) continue;
+    mw += c * w;
+  }
+  return mw;
+}
+
+export function resolveMixtureToElements(
+  mode: MixtureMode,
+  rows: ResolverRow[],
+  opts: MixtureResolverOpts,
+): MixtureResult {
+  // 1. Compute each row's *mass share* in the mixture (0..1 summing to 1).
+  const rowMass: number[] = new Array(rows.length).fill(0);
+  if (mode === "single") {
+    // Single-formula mode: rows hold stoich counts (Al=2, O=3 for Al2O3).
+    // Compute mass share = (count × atomic weight) / total formula weight.
+    let total = 0;
+    const masses = rows.map((r) => {
+      const c = r.value ?? 1;
+      const w = STANDARD_ATOMIC_WEIGHT[r.formula] ?? 0;
+      const m = c * w;
+      total += m;
+      return m;
+    });
+    for (let i = 0; i < rows.length; i++) {
+      rowMass[i] = total > 0 ? masses[i] / total : 0;
+    }
+  } else if (mode === "mass") {
+    // Mass mode: row.value is wt% (0..100); balance row inherits remainder.
+    let specifiedSum = 0;
+    for (const r of rows) if (!r.isBalance) specifiedSum += r.value ?? 0;
+    for (let i = 0; i < rows.length; i++) {
+      const r = rows[i];
+      const wt = r.isBalance ? Math.max(0, 100 - specifiedSum) : (r.value ?? 0);
+      rowMass[i] = wt / 100;
+    }
+  } else {
+    // Atom mode: row.value is atom-fraction (0..1) or atom-percent (0..100).
+    // Convert to mass fraction via row formula's average atomic mass.
+    const numericVals = rows.filter((r) => !r.isBalance && r.value !== null).map((r) => r.value as number);
+    const maxV = numericVals.length > 0 ? Math.max(...numericVals) : 0;
+    const denom = maxV > 1.5 ? 100 : 1;
+    let specifiedAtom = 0;
+    for (const r of rows) if (!r.isBalance) specifiedAtom += (r.value ?? 0) / denom;
+    const atomShares = rows.map((r) => (r.isBalance ? Math.max(0, 1 - specifiedAtom) : (r.value ?? 0) / denom));
+    const masses = rows.map((r, i) => atomShares[i] * formulaWeight(r.formula));
+    const total = masses.reduce((s, m) => s + m, 0);
+    for (let i = 0; i < rows.length; i++) {
+      rowMass[i] = total > 0 ? masses[i] / total : 0;
+    }
+  }
+
+  // 2. Per-element mass fractions: walk each row, weight by row mass share
+  //    through its formula's per-element mass fractions.
+  const massFractions: Record<string, number> = {};
+  for (let i = 0; i < rows.length; i++) {
+    const elFracs = formulaToMassFractions(rows[i].formula);
+    for (const [el, f] of Object.entries(elFracs)) {
+      massFractions[el] = (massFractions[el] ?? 0) + rowMass[i] * f;
+    }
+  }
+
+  // 3. Per-element atom-share-weighted isotope merge.
+  //    For each element, walk every row that contains it; if the row carries
+  //    an override, contribute (override × row's element-atom-share);
+  //    otherwise contribute (natural × row's element-atom-share).
+  //    Layer-level enrichment substitutes for natural when a row has no
+  //    override.
+  const elementAtomShares: Record<string, number[]> = {};
+  for (let i = 0; i < rows.length; i++) {
+    const counts = parseFormula(rows[i].formula);
+    const formulaW = formulaWeight(rows[i].formula);
+    if (formulaW === 0) continue;
+    // Mass of this row in the mixture (in arbitrary units, since we only
+    // care about ratios).
+    const rowMassUnits = rowMass[i];
+    // Moles of this row: rowMass / formulaWeight.
+    const rowMoles = rowMassUnits / formulaW;
+    for (const [el, count] of Object.entries(counts)) {
+      const atomsFromRow = count * rowMoles;
+      (elementAtomShares[el] ??= [])[i] = atomsFromRow;
+    }
+  }
+
+  const isotopes: Record<string, Record<number, number>> = {};
+  for (const [el, sharesByRow] of Object.entries(elementAtomShares)) {
+    const totalAtoms = sharesByRow.reduce((s, x) => s + (x ?? 0), 0);
+    if (totalAtoms === 0) continue;
+
+    const merged: Record<number, number> = {};
+    for (let i = 0; i < rows.length; i++) {
+      const atomsHere = sharesByRow[i] ?? 0;
+      if (atomsHere === 0) continue;
+      // Resolve the isotope vector for this (row, element):
+      //   row.enrichment[el] → opts.layerEnrichment[el] → naturalAbundance(el)
+      const vector = rows[i].enrichment?.[el]
+        ?? opts.layerEnrichment?.[el]
+        ?? opts.naturalAbundance(el);
+      const share = atomsHere / totalAtoms;
+      for (const [a, frac] of Object.entries(vector)) {
+        const A = Number(a);
+        merged[A] = (merged[A] ?? 0) + share * frac;
+      }
+    }
+    isotopes[el] = merged;
+  }
+
+  return { massFractions, isotopes };
+}

--- a/packages/compute/src/mixture-resolver.test.ts
+++ b/packages/compute/src/mixture-resolver.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveMixtureToElements,
+  type ResolverRow,
+} from "./materials";
+
+/** Mock natural abundances for the tests below. Values approximate IUPAC. */
+const NATURAL: Record<string, Record<number, number>> = {
+  H: { 1: 0.99985, 2: 0.00015 },
+  O: { 16: 0.99757, 17: 0.00038, 18: 0.00205 },
+  Mo: {
+    92: 0.1453, 94: 0.0915, 95: 0.1584, 96: 0.1667,
+    97: 0.0960, 98: 0.2439, 100: 0.0982,
+  },
+  Cu: { 63: 0.6915, 65: 0.3085 },
+  Si: { 28: 0.9223, 29: 0.0467, 30: 0.0310 },
+  Na: { 23: 1.0 },
+  Ca: { 40: 0.9694, 42: 0.00647, 43: 0.00135, 44: 0.02086, 46: 4e-5, 48: 0.00187 },
+  Fe: { 54: 0.0585, 56: 0.9175, 57: 0.0212, 58: 0.0028 },
+  Al: { 27: 1.0 },
+};
+const naturalAbundance = (sym: string) => NATURAL[sym] ?? {};
+
+describe("resolveMixtureToElements — single mode", () => {
+  it("Al2O3 produces correct mass fractions", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Al", value: 2, isBalance: false },
+      { formula: "O", value: 3, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("single", rows, { naturalAbundance });
+    // Al2O3: total mass = 2*26.98 + 3*16.00 = 101.96; Al = 53.96/101.96 ≈ 0.529
+    expect(r.massFractions.Al).toBeCloseTo(0.529, 2);
+    expect(r.massFractions.O).toBeCloseTo(0.471, 2);
+  });
+
+  it("isotopes default to natural for non-enriched single formula", () => {
+    const rows: ResolverRow[] = [
+      { formula: "O", value: 1, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("single", rows, { naturalAbundance });
+    expect(r.isotopes.O[16]).toBeCloseTo(0.99757);
+  });
+});
+
+describe("resolveMixtureToElements — mass mode", () => {
+  it("Al 80%, Cu 20% produces correct per-element mass fractions", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Al", value: 80, isBalance: false },
+      { formula: "Cu", value: 20, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    expect(r.massFractions.Al).toBeCloseTo(0.8, 5);
+    expect(r.massFractions.Cu).toBeCloseTo(0.2, 5);
+  });
+
+  it("compound rows: SiO2 80%, H2O 20% expands per-element correctly", () => {
+    const rows: ResolverRow[] = [
+      { formula: "SiO2", value: 80, isBalance: false },
+      { formula: "H2O", value: 20, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    // SiO2 mass fractions: Si ≈ 0.467, O ≈ 0.533
+    // H2O mass fractions: H ≈ 0.112, O ≈ 0.888
+    // Mixture: Si = 0.8*0.467 = 0.374; O = 0.8*0.533 + 0.2*0.888 = 0.604;
+    //          H = 0.2*0.112 = 0.0224
+    expect(r.massFractions.Si).toBeCloseTo(0.374, 2);
+    expect(r.massFractions.H).toBeCloseTo(0.022, 2);
+    expect(r.massFractions.O).toBeGreaterThan(0.5);
+    expect(r.massFractions.Si + r.massFractions.O + r.massFractions.H).toBeCloseTo(1.0, 5);
+  });
+
+  it("balance row absorbs the remainder", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Al", value: 80, isBalance: false },
+      { formula: "Cu", value: 5, isBalance: false },
+      { formula: "Zn", value: null, isBalance: true },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    expect(r.massFractions.Al).toBeCloseTo(0.80, 4);
+    expect(r.massFractions.Cu).toBeCloseTo(0.05, 4);
+    // Zn = 100 - 85 = 15%
+    expect(r.massFractions.Zn ?? 0).toBeCloseTo(0.15, 4);
+  });
+
+  it("LOAD-BEARING (#93): row-level Mo enrichment overrides natural for that row only", () => {
+    // 80% Mo enriched to 99% Mo-100; 20% natural Mo. The combined Mo isotope
+    // vector is the atom-weighted blend.
+    const rows: ResolverRow[] = [
+      {
+        formula: "Mo",
+        value: 80,
+        isBalance: false,
+        enrichment: { Mo: { 100: 0.99, 92: 0.01 } },
+      },
+      { formula: "Mo", value: 20, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+
+    // Total Mo atoms across both rows are equal-ish per gram (same atomic
+    // mass), so atom share ~ mass share. Row1 Mo-100 contributes 0.8 * 0.99
+    // = 0.792; Row2 Mo-100 contributes 0.2 * 0.0982 ≈ 0.01964. Sum ≈ 0.812.
+    expect(r.isotopes.Mo[100]).toBeCloseTo(0.812, 2);
+    // Mo-92 from row1 (0.8*0.01=0.008) plus row2 natural (0.2*0.1453=0.029) ≈ 0.037
+    expect(r.isotopes.Mo[92]).toBeCloseTo(0.037, 2);
+  });
+
+  it("co-existing natural-Mo + Al disk: Al stays natural, Mo gets blended", () => {
+    const rows: ResolverRow[] = [
+      {
+        formula: "MoO3",
+        value: 80,
+        isBalance: false,
+        enrichment: { Mo: { 100: 0.99, 98: 0.01 } },
+      },
+      { formula: "Al", value: 20, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    // Mo only comes from MoO3 row, so its enrichment is the row override
+    expect(r.isotopes.Mo[100]).toBeCloseTo(0.99, 2);
+    expect(r.isotopes.Mo[98]).toBeCloseTo(0.01, 2);
+    // Al only comes from the Al row (no override), so natural
+    expect(r.isotopes.Al[27]).toBeCloseTo(1.0);
+    // O only comes from MoO3 (no row override on O), so natural
+    expect(r.isotopes.O[16]).toBeCloseTo(0.99757, 4);
+  });
+
+  it("layer-level enrichment fills in when no row override", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Cu", value: 100, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, {
+      naturalAbundance,
+      layerEnrichment: { Cu: { 63: 0.99, 65: 0.01 } },
+    });
+    // Layer override applies because no row override
+    expect(r.isotopes.Cu[63]).toBeCloseTo(0.99);
+  });
+
+  it("row override beats layer override beats natural", () => {
+    const rows: ResolverRow[] = [
+      {
+        formula: "Cu",
+        value: 100,
+        isBalance: false,
+        enrichment: { Cu: { 65: 1.0 } },
+      },
+    ];
+    const r = resolveMixtureToElements("mass", rows, {
+      naturalAbundance,
+      layerEnrichment: { Cu: { 63: 0.99, 65: 0.01 } },
+    });
+    expect(r.isotopes.Cu[65]).toBeCloseTo(1.0);
+    expect(r.isotopes.Cu[63] ?? 0).toBeCloseTo(0);
+  });
+});
+
+describe("resolveMixtureToElements — atom mode", () => {
+  it("fractional atom input: Fe 0.7, Cr 0.18, Ni 0.12", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Fe", value: 0.7, isBalance: false },
+      { formula: "Cu", value: 0.3, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("atom", rows, { naturalAbundance });
+    // Mole-weighted mass fractions
+    const expectedFeMass = 0.7 * 55.85 / (0.7 * 55.85 + 0.3 * 63.55);
+    expect(r.massFractions.Fe).toBeCloseTo(expectedFeMass, 3);
+  });
+
+  it("balance row works in atom mode", () => {
+    const rows: ResolverRow[] = [
+      { formula: "Fe", value: 0.7, isBalance: false },
+      { formula: "Cu", value: null, isBalance: true },
+    ];
+    const r = resolveMixtureToElements("atom", rows, { naturalAbundance });
+    // Cu balance = 0.3 atoms
+    expect(r.massFractions.Cu).toBeGreaterThan(0);
+    expect(r.massFractions.Fe + r.massFractions.Cu).toBeCloseTo(1.0, 5);
+  });
+});
+
+describe("resolveMixtureToElements — edge cases", () => {
+  it("empty rows produces empty fractions", () => {
+    const r = resolveMixtureToElements("mass", [], { naturalAbundance });
+    expect(Object.keys(r.massFractions).length).toBe(0);
+    expect(Object.keys(r.isotopes).length).toBe(0);
+  });
+
+  it("unknown element symbol produces no contribution", () => {
+    // formulaToMassFractions silently skips unknown symbols, so we expect
+    // empty output rather than an error.
+    const rows: ResolverRow[] = [
+      { formula: "Cu", value: 100, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    expect(r.massFractions.Cu).toBeCloseTo(1.0);
+  });
+
+  it("multiple rows with same element merge atom shares correctly", () => {
+    // SiO2 + Si — both contribute Si; the merged Si vector blends both rows'
+    // atom shares (one with override, one natural).
+    const rows: ResolverRow[] = [
+      {
+        formula: "Si",
+        value: 50,
+        isBalance: false,
+        enrichment: { Si: { 30: 1.0 } }, // 100% Si-30 in this row
+      },
+      { formula: "Si", value: 50, isBalance: false },
+    ];
+    const r = resolveMixtureToElements("mass", rows, { naturalAbundance });
+    // Equal mass → equal moles → equal atom share; Si-30 = 0.5 * 1.0 + 0.5 * 0.0310 = 0.5155
+    expect(r.isotopes.Si[30]).toBeCloseTo(0.5155, 3);
+  });
+});


### PR DESCRIPTION
Lands the data-model spine of the unified material-form redesign from #92. Subsumed issues #57 / #89 / #93 are partially addressed; the remaining UX-glue work is filed as follow-ups (#94–#97) and the PR description below is explicit about what shipped vs. what didn't.

## What landed

**Compute layer (the load-bearing physics path)**
- \`parseIsotopicFormula\` accepts cyclotron-target literature notation: ³He, D₂O, ¹³CO₂, H₂¹⁸O, He-3, Mo-100. Auto-emits per-element fractional enrichment vectors. (\`packages/compute/src/formula.ts\`)
- \`resolveMixtureToElements\` in \`packages/compute/src/materials.ts\` with the **row → layer → natural** enrichment fallback chain. Pure: takes a \`naturalAbundance(symbol)\` callback so vitest can fixture without a DataStore.
- 14-case fixture in \`packages/compute/src/mixture-resolver.test.ts\` including the load-bearing #93 case: 80% enriched-Mo + 20% natural-Mo blend resolves correctly per row.

**Form data model**
- \`Row { id, formula, value, isBalance, enrichment? }\`. Drops per-row \`unit\`, no \`kind\`, no \`meta\`. Compounds (SiO2, H2O) and isotope-prefixed formulas are accepted.
- \`Mode = \"single\" | \"mass\" | \"atom\"\`. Auto-inferred from input style; chip is clickable to override.
- Per-mode validators: \`validateMass\` / \`validateAtom\` / \`validateSingle\` + shared \`validateCommon\`.
- 55-case test file in \`define-form-rows.test.ts\` covering parser, mode inference, glassy mol% nudge, validators, round-trip, isotope-prefix expansion.

**Form UI**
- Mode chip with auto-inference + amber low-confidence + click-to-change menu + first-time guidance subhead.
- \"Compose mixture\" workspace picker: free-form formula input (Enter commits), common-compounds chip row, Periodic Table, sticky existing-rows panel. Stays open until Done; Done / Escape / click-outside all commit (and flush any in-flight formula draft).
- Density-as-suggestion: weighted-average shown as a placeholder; user must accept (\"Use {value}\" button) or type. Inline warning when any row's compound is untabulated.
- In-session \"Overwrite\" save affordance — track last-saved per form instance; second save offers replace-or-fork.
- Layer-material PT modal width matches the mixture picker in \`view === \"table\"\`.
- One-time \"saved materials cleared in 0.x\" banner under the header on first run after this deploy.

**§3.1 hard rule retained:** no \$effect in DefineForm watches \`mode\`, \`rows\`, or \`textDraft\`. Mode-switch reset lives in the chip onclick handler. Picker focus management uses event handlers throughout.

## What didn't land — filed as follow-ups (subsumes #57/#89/#93 deferred to these)

- **#94 catalog hydration via extended editInitial + tri-radio save dialog**. Spec listed as P0; ships only an in-session \"Overwrite\" button. Selecting havar still commits the legacy formula directly rather than hydrating as mass-mixture rows for inspect/edit.
- **#95 mode-switch non-destructive demote with 30 s undo strip**. \`setMode\` is currently a simple reassignment + override flag. The runes-review-flagged stale-rows-after-mass→single hazard is mitigated with an explicit \"Reset rows\" affordance, but the proper restore-from-undo workflow is the follow-up.
- **#96 URL-hash v3 invariant + ?compose= for authored rows**. Codec change in \`config-url-v2.ts\` not landed. Required for #93 round-trip when row enrichment is set.
- **#97 soda-lime full e2e walkthrough**. Three e2e cases ship here; the headline build-via-picker → save → reopen-identically walkthrough waits on #94 + #96.

## Verification

- \`npx svelte-check --threshold error\`: **2 baseline errors held** (\`backend.ts:66\`, \`BugReportModal.svelte:185\` — pre-existing, unrelated).
- \`npx vitest run\`: **frontend 352 passing**, **compute 58 passing**. Net growth +28 across both packages.
- \`npx playwright test --project=desktop-1280 e2e/material-form-redesign.spec.ts\`: **3/3 passing** — paste flips mode + materializes compound rows, glassy mass mixture renders amber chip + mol% nudge, density-as-suggestion blocks Save until accepted.

## Reviews (audit trail)

- **Round-1 spike** (4 fresh agents): cyclotron-target domain, data-model architect, Svelte 5 runes, end-to-end UX/a11y.
- **Round-2 spike** (3 fresh agents on the expanded scope): gas-target physics, schema-migration, HCI mode-inference.
- **Land-time impl-match review**: verdict fix-first, with deferrals being the bulk of the fail items. Deferrals are user-sanctioned per \"hyrr is at 0.x\" + \"B push through\".
- **Land-time Svelte 5 runes review**: 6 findings, 5 fixed in commit \`88485a6\` (picker draft flush on close, mode-menu outside-click/Esc, appendRow override, displayFormula precision, dead-state cleanup); 6th (full demote with undo) is #95.

## Compat policy

hyrr is at 0.x. No IndexedDB migrator, no URL-hash backward-compat dispatch. Users with saved custom materials see a one-time banner on first load; pre-0.x share URLs from earlier builds may not open. Per the user's call.

## Test plan

- [ ] Open the layer-material picker → click \"Define & save material\" → paste \"SiO2 80%, H2O 20%\" in the bottom paste field → blur. Mode chip shows \"Mass mixture\"; two rows for SiO2 and H2O appear.
- [ ] Paste \"SiO2 75%, Na2O 14%, CaO 11%\" instead → chip shows \"Mass mixture?\" amber + mol% nudge.
- [ ] Density field shows greyed \"suggested 2.51\" placeholder; Save & Use stays disabled until \"Use 2.51\" clicked or user types.
- [ ] Open the Compose mixture picker → type \"D2O\" + Enter → row appended with formula H2O and \`enrichment.H = {2: 1.0}\` (verify in saved JSON via dev tools).
- [ ] Mode chip menu closes on outside-click and Escape.

Refs: #92, #57, #89, #93 (subsumed); #94, #95, #96, #97 (follow-ups)