### PR TITLE
ci(release): drop macos-x86_64 from hyrr-mcp wheel matrix

### DIFF
--- a/.github/workflows/release-hyrr-mcp.yml
+++ b/.github/workflows/release-hyrr-mcp.yml
@@ -35,7 +35,8 @@ jobs:
         target:
           - { name: linux-x86_64,  runner: ubuntu-latest,  rust-target: x86_64-unknown-linux-gnu,    maturin-target: x86_64,  manylinux: "auto" }
           - { name: linux-aarch64, runner: ubuntu-latest,  rust-target: aarch64-unknown-linux-gnu,   maturin-target: aarch64, manylinux: "auto" }
-          - { name: macos-x86_64,  runner: macos-13,       rust-target: x86_64-apple-darwin,         maturin-target: x86_64,  manylinux: "" }
+          # macos-x86_64 dropped: Intel-mac runners on the free GitHub plan have
+          # multi-hour queues. Intel macs build from sdist instead.
           - { name: macos-arm64,   runner: macos-14,       rust-target: aarch64-apple-darwin,        maturin-target: aarch64, manylinux: "" }
           - { name: windows-x86_64, runner: windows-latest, rust-target: x86_64-pc-windows-msvc,     maturin-target: x64,     manylinux: "" }
     steps:


### PR DESCRIPTION
## Summary
- Intel-mac runners (`macos-13`) on the free GitHub plan have multi-hour queues — the first `hyrr-mcp-v0.1.0` tag (since deleted) sat 7+ hours waiting on a free runner while the other 5 builds finished in <5 min each.
- Drop `macos-x86_64` from the matrix. Intel-mac users build from sdist (still published).
- Re-tag once merged.

Refs: #71

## Test plan
- [x] YAML parses (only the matrix entry removed).
- [ ] After merge: re-tag `hyrr-mcp-v0.1.0`, watch the run finish, verify wheels appear on PyPI.