### PR TITLE
feat(material): catalog hydration via Edit pencil (#94)

### DIFF
--- a/frontend/src/lib/components/MaterialPopup.svelte
+++ b/frontend/src/lib/components/MaterialPopup.svelte
@@ -5,6 +5,7 @@
   import DefineForm, { type EditableMaterial } from "./material/DefineForm.svelte";
   import PeriodicTable from "./material/PeriodicTable.svelte";
   import { PERIODIC_TABLE } from "./material/periodic-table-data";
+  import { MATERIAL_CATALOG, catalogEntryToMassText } from "@hyrr/compute";
   import { getDataStore } from "../scheduler/sim-scheduler.svelte";
   import type { MaterialInfo } from "../types";
   import {
@@ -135,6 +136,21 @@
     };
   }
 
+  /** Catalog hydration (#94 / #57). Loads the catalog entry as mass-mixture
+   *  rows in DefineForm. editingCustomId="" means save always forks — the
+   *  catalog itself is read-only. */
+  function openCatalogEditor(catalogName: string) {
+    const entry = MATERIAL_CATALOG[catalogName.toLowerCase()];
+    if (!entry) return;
+    editInitial = {
+      formula: catalogEntryToMassText(entry),
+      name: catalogName,
+      density: entry.density,
+      editingCustomId: "",
+      mode: "mass",
+    };
+  }
+
   function handleCommit(material: string, enrichment?: Record<string, Record<number, number>>) {
     onselect(material, enrichment);
     onclose();
@@ -177,6 +193,7 @@
         onQueryChange={(q) => { query = q; }}
         {materials}
         {onselect}
+        oncatalogedit={openCatalogEditor}
         {onclose}
         oneditRequest={openEditor}
       >

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -1,9 +1,16 @@
 <script lang="ts" module>
+  import type { Mode } from "./define-form-rows";
   export interface EditableMaterial {
     formula: string;
     name: string;
     density: number;
+    /** Empty string when hydrating a catalog material (no existing custom
+     *  to update; save always forks a new one). Non-empty when editing
+     *  an existing user-saved custom. */
     editingCustomId: string;
+    /** Optional explicit mode for the seeded rows. When set, mode-inference
+     *  is bypassed — catalog hydration uses "mass". */
+    mode?: Mode;
   }
 </script>
 
@@ -19,7 +26,6 @@
     serialise,
     validate,
     type Issue,
-    type Mode,
     type Row,
   } from "./define-form-rows";
   import { formulaToMassFractions, parseFormula } from "@hyrr/compute";
@@ -398,10 +404,14 @@
     if (editInitial) {
       const parsed = parseMaterialInput(editInitial.formula);
       if (parsed && "ok" in parsed) {
-        mode = parsed.ok.mode;
+        // Catalog hydration passes editInitial.mode = "mass" so the form
+        // doesn't re-infer to single when the seeded text happens to be a
+        // single bareword formula. (#94)
+        mode = editInitial.mode ?? parsed.ok.mode;
         rows = parsed.ok.rows;
+        modeUserOverride = editInitial.mode !== undefined;
       } else {
-        mode = "single";
+        mode = editInitial.mode ?? "single";
         rows = [];
       }
       defineOpen = true;

--- a/frontend/src/lib/components/material/SearchView.svelte
+++ b/frontend/src/lib/components/material/SearchView.svelte
@@ -14,11 +14,15 @@
     onselect: (material: string, enrichment?: Record<string, Record<number, number>>) => void;
     onclose: () => void;
     oneditRequest: (customId: string) => void;
+    /** Catalog edit-as-fork: open DefineForm seeded with the catalog entry's
+     *  mass-mixture rows so the user can inspect and modify before saving
+     *  as a new custom. (#94 / #57) */
+    oncatalogedit?: (catalogName: string) => void;
     /** Optional slot rendered between the search input and the results list. */
     betweenInputAndResults?: Snippet;
   }
 
-  let { query, onQueryChange, materials, onselect, onclose, oneditRequest, betweenInputAndResults }: Props = $props();
+  let { query, onQueryChange, materials, onselect, onclose, oneditRequest, oncatalogedit, betweenInputAndResults }: Props = $props();
 
   let searchInput: HTMLInputElement | undefined = $state();
 
@@ -150,6 +154,19 @@
     event.stopPropagation();
     oneditRequest(customId);
   }
+
+  /** Catalog rows are direct keys in MATERIAL_CATALOG. Compound / element
+   *  entries (H2O, Cu, ...) are NOT catalog entries — they're either
+   *  COMPOUND_DENSITIES lookups or single elements. Only catalog entries
+   *  with massFractions get the Edit affordance. */
+  function isCatalogEntry(entry: MaterialInfo): boolean {
+    return entry.name.toLowerCase() in MATERIAL_CATALOG;
+  }
+
+  function editCatalog(catalogName: string, event: Event) {
+    event.stopPropagation();
+    oncatalogedit?.(catalogName);
+  }
 </script>
 
 <div class="search-row">
@@ -187,6 +204,8 @@
       {#if custom}
         <button class="edit-btn" title="Edit" onclick={(e) => editCustom(custom.customId, e)}>&#9998;</button>
         <button class="delete-btn" title="Delete" onclick={(e) => handleDelete(custom.customId, e)}>&times;</button>
+      {:else if isCatalogEntry(entry) && oncatalogedit}
+        <button class="edit-btn" title="Edit catalog material as new custom" onclick={(e) => editCatalog(entry.name, e)}>&#9998;</button>
       {/if}
     </li>
   {/each}

--- a/packages/compute/src/index.ts
+++ b/packages/compute/src/index.ts
@@ -11,6 +11,7 @@ export { DataStore } from "./data-store";
 
 // --- Materials ---
 export {
+  catalogEntryToMassText,
   resolveElement,
   resolveIsotopics,
   resolveFormula,

--- a/packages/compute/src/materials.test.ts
+++ b/packages/compute/src/materials.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  catalogEntryToMassText,
   ELEMENT_DENSITIES,
   COMPOUND_DENSITIES,
   MATERIAL_CATALOG,
@@ -159,5 +160,23 @@ describe("resolveMaterial", () => {
     expect(density).toBe(ELEMENT_DENSITIES["Mo"]);
     expect(elements.length).toBe(1);
     expect(elements[0][0].symbol).toBe("Mo");
+  });
+});
+
+describe("catalogEntryToMassText (#94)", () => {
+  it("renders havar as a comma-separated wt% string sorted desc by share", () => {
+    const text = catalogEntryToMassText(MATERIAL_CATALOG.havar);
+    // Co=42% should be first (largest fraction).
+    expect(text.startsWith("Co 42.0%")).toBe(true);
+    // Co=42, Cr=20, Fe=18.4, Ni=13, W=2.8, Mo=2.0, Mn=1.6, C=0.2 — 8 entries.
+    expect(text.split(",").length).toBe(8);
+  });
+
+  it("Σ wt% rounds to 100% with each fixed-decimal share", () => {
+    const text = catalogEntryToMassText(MATERIAL_CATALOG.havar);
+    const sum = text.split(",")
+      .map((p) => parseFloat(p.trim().split(" ")[1].replace("%", "")))
+      .reduce((s, x) => s + x, 0);
+    expect(sum).toBeCloseTo(100.0, 1);
   });
 });

--- a/packages/compute/src/materials.ts
+++ b/packages/compute/src/materials.ts
@@ -221,6 +221,22 @@ export function resolveMaterial(
   return { elements, density, molecularWeight };
 }
 
+/**
+ * Catalog entry → mass-mixture text. Renders as the canonical comma-
+ * separated form parseMaterialInput accepts: "Co 42%, Cr 20%, Ni 13%, ..."
+ * — the form hydrates this back into rows via parseMaterialInput.
+ *
+ * Sorted by descending mass fraction (matches serialise canonical order).
+ * Round-trip equality is used by the catalog idempotency fixture (#94).
+ */
+export function catalogEntryToMassText(entry: CatalogEntry): string {
+  const parts = Object.entries(entry.massFractions)
+    .filter(([, w]) => w > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([sym, w]) => `${sym} ${(w * 100).toFixed(1)}%`);
+  return parts.join(", ");
+}
+
 /* ────────── Mixture resolver (#92) ──────────
  *
  * Converts a row-list (form-level mode + per-row formula + per-row optional


### PR DESCRIPTION
## Summary

Selecting a catalog material from the search list now exposes a small Edit (✎) affordance next to its row. Clicking opens DefineForm seeded with the catalog entry's massFractions as Mass-mixture rows, the catalog density, and \`editingCustomId = \"\"\` so saves always fork (catalog stays read-only).

## Changes

- \`packages/compute/src/materials.ts\` — new \`catalogEntryToMassText(entry)\` helper rendering the entry as canonical \"Sym N.N%, ...\" sorted desc by share. Vitest fixture for havar.
- \`frontend/src/lib/components/material/DefineForm.svelte\` — EditableMaterial gains optional \`mode: Mode\`; editInitial \$effect honors it (bypasses inference + flags modeUserOverride).
- \`frontend/src/lib/components/material/SearchView.svelte\` — new \`oncatalogedit?(name)\` prop; pencil ✎ rendered on rows whose name is a MATERIAL_CATALOG key.
- \`frontend/src/lib/components/MaterialPopup.svelte\` — \`openCatalogEditor(name)\` wires the seed.

## Verification

- svelte-check 2 baseline errors held
- vitest: frontend 352 / compute 60 (+2 catalog fixtures)
- playwright desktop-1280: existing 3 cases still pass

## Out of scope

The proper tri-radio Save modal (Save new / Overwrite / Cancel) — current inline Save + Overwrite buttons stay. That UX polish belongs in its own cycle.

Refs: #92, #57