### PR TITLE
feat(material): URL-hash v3 inline composition (#96, #89)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import "./lib/stores/theme.svelte"; // initialise theme (applies data-theme attribute)
   import { registerServiceWorker } from "./lib/sw-register";
-  import { decodeSerializableConfigFromHash, setConfigInHash } from "./lib/config-url";
+  import { decodeSerializableConfigFromHash, setConfigInHash, setCustomMaterialResolver } from "./lib/config-url";
   import {
     getConfig,
     setConfig,
@@ -151,6 +151,14 @@
     setCustomCompositionLookup((identifier) => {
       const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
       return cm?.massFractions ?? null;
+    });
+    // #96: when encoding share URLs, embed the layer's full composition
+    // inline so the receiver can resolve density + per-element fractions
+    // without first re-defining the custom locally.
+    setCustomMaterialResolver((identifier) => {
+      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
+      if (!cm || !cm.massFractions) return null;
+      return { density: cm.density, massFractions: cm.massFractions };
     });
 
     loadingState = "Ready";

--- a/frontend/src/lib/config-url-v2.test.ts
+++ b/frontend/src/lib/config-url-v2.test.ts
@@ -132,3 +132,61 @@ describe("config-url-v2", () => {
     expect(hash.startsWith("#config=1:")).toBe(true);
   });
 });
+
+describe("v3 inline composition (#96)", () => {
+  it("encodes a layer's composition inline when the resolver returns one", async () => {
+    const { setCustomMaterialResolver } = await import("./config-url-v2");
+    setCustomMaterialResolver((name) =>
+      name === "soda-lime-glass"
+        ? { density: 2.5, massFractions: { Si: 0.34, Na: 0.10, Ca: 0.08, O: 0.48 } }
+        : null,
+    );
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 16, current_mA: 0.150 },
+      items: [{ material: "soda-lime-glass", thickness_cm: 0.025 }],
+      irradiation_s: 3600,
+      cooling_s: 600,
+    };
+    const hash = encodeConfigV2(cfg);
+    const payload = hash.replace("#config=1:", "");
+    const decoded = decodeConfigV2Ser(payload);
+    expect(decoded).not.toBeNull();
+    expect((decoded!.items[0] as { material: string }).material).toBe("soda-lime-glass");
+    setCustomMaterialResolver(null);
+  });
+
+  it("registers a session lookup on decode so resolveMaterial finds the entry", async () => {
+    const { setCustomMaterialResolver } = await import("./config-url-v2");
+    setCustomMaterialResolver((name) =>
+      name === "soda-lime-glass"
+        ? { density: 2.5, massFractions: { Si: 0.34, Na: 0.10, Ca: 0.08, O: 0.48 } }
+        : null,
+    );
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 16, current_mA: 0.150 },
+      items: [{ material: "soda-lime-glass", thickness_cm: 0.025 }],
+      irradiation_s: 3600,
+      cooling_s: 600,
+    };
+    const hash = encodeConfigV2(cfg);
+    // Drop the resolver to simulate the receiver client.
+    setCustomMaterialResolver(null);
+    const payload = hash.replace("#config=1:", "");
+    decodeConfigV2Ser(payload);
+    // The decoder should have registered a session lookup so resolveMaterial
+    // can find density + composition without the user redefining locally.
+    const compute = await import("@hyrr/compute");
+    const mockDb = {
+      getCrossSections: () => [],
+      hasCrossSections: () => false,
+      getStoppingPower: () => ({ energiesMeV: new Float64Array(0), dedx: new Float64Array(0) }),
+      getNaturalAbundances: () => new Map(),
+      getDecayData: () => null,
+      getDoseConstant: () => null,
+      getElementSymbol: () => "?",
+      getElementZ: () => 0,
+    };
+    const r = compute.resolveMaterial(mockDb, "soda-lime-glass");
+    expect(r.density).toBeCloseTo(2.5);
+  });
+});

--- a/frontend/src/lib/config-url-v2.ts
+++ b/frontend/src/lib/config-url-v2.ts
@@ -8,11 +8,44 @@
  */
 
 import { deflateSync, inflateSync } from "fflate";
+import { setCustomDensityLookup, setCustomCompositionLookup } from "@hyrr/compute";
 import type { SimulationConfig, LayerConfig, BeamConfig } from "./types";
 import type { SerializableConfig } from "./stores/config.svelte";
 
 const V2_PREFIX = "1:";
 const MAX_URL_ITEMS = 30;
+
+/**
+ * Custom-material resolver for inline-composition layers (#96). The
+ * encoder calls this with each layer's material name; if the resolver
+ * returns a non-null entry, the layer's compact form gains an `x` field
+ * carrying density + per-element mass fractions inline. The decoder, on
+ * seeing `x`, registers a session-only lookup so resolveMaterial finds
+ * the entry on the receiving client.
+ */
+let customResolver: ((name: string) => { density: number; massFractions: Record<string, number> } | null) | null = null;
+
+export function setCustomMaterialResolver(fn: typeof customResolver): void {
+  customResolver = fn;
+}
+
+/** Inline-composition data carried by a layer when its material is a
+ *  user-saved custom (or hydrated catalog fork). Receiver registers it
+ *  via setCustomDensityLookup + setCustomCompositionLookup so the
+ *  simulator can resolve density and per-element fractions on the fly. */
+interface InlineComposition {
+  /** density g/cm³ */
+  d: number;
+  /** per-element mass fractions, summing to ~1 */
+  e: Record<string, number>;
+}
+
+const __sessionCompositions = new Map<string, InlineComposition>();
+function registerSessionComposition(name: string, x: InlineComposition): void {
+  __sessionCompositions.set(name, x);
+  setCustomDensityLookup((id) => __sessionCompositions.get(id)?.d ?? null);
+  setCustomCompositionLookup((id) => __sessionCompositions.get(id)?.e ?? null);
+}
 
 /** Compact a single layer. */
 function compactLayer(l: LayerConfig): any {
@@ -22,6 +55,14 @@ function compactLayer(l: LayerConfig): any {
   if (l.energy_out_MeV !== undefined) cl.o = l.energy_out_MeV;
   if (l.enrichment) cl.n = l.enrichment;
   if (l.is_monitor) cl.f = true;
+  // #96 v3 invariant: embed inline composition when the material is a
+  // user-saved custom. Receiver registers via setCustomDensityLookup +
+  // setCustomCompositionLookup so resolveMaterial finds it without the
+  // user having to redefine the material first.
+  if (customResolver) {
+    const x = customResolver(l.material);
+    if (x) cl.x = { d: x.density, e: x.massFractions };
+  }
   return cl;
 }
 
@@ -74,6 +115,12 @@ function expandLayer(cl: any): LayerConfig {
   if (cl.o !== undefined) layer.energy_out_MeV = cl.o;
   if (cl.n) layer.enrichment = cl.n;
   if (cl.f) layer.is_monitor = true;
+  // #96 v3: layer carries inline composition for ad-hoc / custom materials.
+  // Register session-only so resolveMaterial finds it. Validate shape so a
+  // malformed share URL doesn't poison the session.
+  if (cl.x && typeof cl.x === "object" && typeof cl.x.d === "number" && cl.x.e && typeof cl.x.e === "object") {
+    registerSessionComposition(layer.material, { d: cl.x.d, e: cl.x.e });
+  }
   return layer;
 }
 

--- a/frontend/src/lib/config-url.ts
+++ b/frontend/src/lib/config-url.ts
@@ -11,7 +11,10 @@ import {
   decodeSerializableFromHash,
   decodeConfigFromHashV2,
   setConfigInHashV2,
+  setCustomMaterialResolver,
 } from "./config-url-v2";
+
+export { setCustomMaterialResolver };
 
 /** Decode a config from the current URL hash — preserves groups. */
 export function decodeSerializableConfigFromHash(): SerializableConfig | null {


### PR DESCRIPTION
Closes #89 the practical way: layer compact form gains an optional \`x\` field carrying the layer's composition inline so a share URL opens correctly on a fresh client without the receiver first re-defining the custom material.

## Mechanics

- **Encoder side**: \`setCustomMaterialResolver(fn)\` registers a callback that maps a layer's material name → \`{ density, massFractions }\`. \`compactLayer\` calls it; if the resolver returns truthy, the layer's compact form gains \`x: { d, e }\`.
- **Decoder side**: \`expandLayer\` validates \`cl.x\` shape and registers a session-scoped \`setCustomDensityLookup\` + \`setCustomCompositionLookup\`. Receiver's \`resolveMaterial(name)\` finds it on the next call.
- **App.svelte** wires the resolver against \`getCustomMaterials()\` at boot.

## Verification

- svelte-check 2 baseline errors held
- vitest: frontend 352 → 354 (+2 codec round-trip + session-lookup fixture)
- backwards compatible: layers without \`x\` decode unchanged

## Out of scope

\`?compose=\` dual-encoding for authored rows (mode + Row[]) is not shipped here. Round-trip of per-row enrichment (#93) is preserved at the layer level via the existing \`l.n\` field; the authored-row structure is informational only and tracked as P2.

Refs: #92, #89