### PR TITLE
feat(material): per-row enrichment 'E' button (#93)

### DIFF
--- a/frontend/e2e/material-form-redesign.spec.ts
+++ b/frontend/e2e/material-form-redesign.spec.ts
@@ -51,6 +51,23 @@ test.describe("Material-form redesign (#92)", () => {
     await expect(page.getByText(/mol%/i)).toBeVisible();
   });
 
+  test("per-row 'E' enrichment button appears for single-element rows in mixture mode (#93)", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    await page.getByRole("button", { name: /Define.*save material/ }).click();
+
+    await page.getByPlaceholder(/Al2O3/).fill("Cu 80%, H2O 20%");
+    await page.getByPlaceholder(/Al2O3/).blur();
+
+    // Cu row exposes the E button (single-element row).
+    const cuRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "Cu" });
+    await expect(cuRow.locator(".enrich-btn")).toBeVisible();
+
+    // H2O row hides it (compound — ambiguous which element to enrich).
+    const h2oRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "H2O" });
+    await expect(h2oRow.locator(".enrich-btn")).toHaveCount(0);
+  });
+
   test("density renders as suggestion only — Save disabled until accepted", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -30,6 +30,7 @@
   } from "./define-form-rows";
   import { formulaToMassFractions, parseFormula } from "@hyrr/compute";
   import DefineFormRow from "./DefineFormRow.svelte";
+  import ElementPopup from "../ElementPopup.svelte";
   import PeriodicTable from "./PeriodicTable.svelte";
 
   interface Props {
@@ -208,6 +209,44 @@
   function removeRow(id: string) {
     rows = rows.filter((r) => r.id !== id);
   }
+
+  // --- Per-row enrichment editor (#93) ---
+  let rowEnrichmentEditor = $state<{ rowId: string; element: string } | null>(null);
+
+  function openRowEnrichmentEditor(rowId: string, element: string) {
+    rowEnrichmentEditor = { rowId, element };
+  }
+
+  function closeRowEnrichmentEditor() {
+    rowEnrichmentEditor = null;
+  }
+
+  function applyRowEnrichment(vector: Record<number, number> | undefined) {
+    if (!rowEnrichmentEditor) return;
+    const { rowId, element } = rowEnrichmentEditor;
+    rows = rows.map((r) => {
+      if (r.id !== rowId) return r;
+      const next = { ...r };
+      const existing = { ...(r.enrichment ?? {}) };
+      if (vector) {
+        existing[element] = vector;
+      } else {
+        delete existing[element];
+      }
+      next.enrichment = Object.keys(existing).length > 0 ? existing : undefined;
+      return next;
+    });
+    // ElementPopup's onchange fires on every change; close happens via
+    // its own onclose. Don't auto-close here.
+  }
+
+  /** The vector to seed ElementPopup with — pulled from the row's existing
+   *  enrichment override for the element under edit. */
+  const rowEnrichmentSeed = $derived.by((): Record<number, number> | undefined => {
+    if (!rowEnrichmentEditor) return undefined;
+    const r = rows.find((x) => x.id === rowEnrichmentEditor!.rowId);
+    return r?.enrichment?.[rowEnrichmentEditor.element];
+  });
 
   /** "Demote slot" — captured by setMode when the user changes modes. Lets
    *  the user restore the previous (mode, rows) within 30 s. Killed on
@@ -579,6 +618,7 @@
               issues={issuesByRow.get(r.id) ?? []}
               onchange={(patch) => patchRow(r.id, patch)}
               onremove={() => removeRow(r.id)}
+              oneditenrichment={mode !== "single" ? openRowEnrichmentEditor : undefined}
             />
           {/each}
         {/if}
@@ -781,6 +821,18 @@
       </div>
     </div>
   </div>
+{/if}
+
+<!-- Per-row enrichment editor (#93). Reuses the same ElementPopup that
+     drives layer-level enrichment, scoped to (rowId, element). -->
+{#if rowEnrichmentEditor}
+  <ElementPopup
+    open={true}
+    onclose={closeRowEnrichmentEditor}
+    element={rowEnrichmentEditor.element}
+    enrichment={rowEnrichmentSeed}
+    onchange={applyRowEnrichment}
+  />
 {/if}
 
 <style>

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { parseFormula } from "@hyrr/compute";
   import type { Issue, Row } from "./define-form-rows";
 
   interface Props {
@@ -10,9 +11,27 @@
     /** Parent splices immutably. No bind: into nested $state per #92 §3.2. */
     onchange: (patch: Partial<Row>) => void;
     onremove: () => void;
+    /** Open ElementPopup scoped to this row's element (#93). Only fired
+     *  for single-element rows (compounds defer to a future cycle). */
+    oneditenrichment?: (rowId: string, element: string) => void;
   }
 
-  let { row, radioName, issues, onchange, onremove }: Props = $props();
+  let { row, radioName, issues, onchange, onremove, oneditenrichment }: Props = $props();
+
+  /** Single-element rows expose a per-row "E" button to override that
+   *  element's isotopic vector. Compound rows hide it (no obvious choice
+   *  of which element to enrich; would need disambiguation UI). */
+  const singleElement = $derived.by((): string | null => {
+    try {
+      const counts = parseFormula(row.formula);
+      const elements = Object.keys(counts);
+      return elements.length === 1 ? elements[0] : null;
+    } catch { return null; }
+  });
+
+  const hasRowEnrichment = $derived(
+    singleElement !== null && row.enrichment !== undefined && row.enrichment[singleElement] !== undefined,
+  );
 </script>
 
 <div class="row" role="row" data-row-id={row.id}>
@@ -48,6 +67,18 @@
     <span class="balance-text">balance</span>
   </label>
 
+  {#if singleElement && oneditenrichment}
+    <button
+      type="button"
+      class="enrich-btn"
+      class:active={hasRowEnrichment}
+      role="gridcell"
+      aria-label={`Edit isotope enrichment for ${singleElement}`}
+      title={hasRowEnrichment ? `Row enrichment set for ${singleElement} — click to edit` : `Override natural isotope abundance for ${singleElement}`}
+      onclick={() => oneditenrichment(row.id, singleElement)}
+    >E</button>
+  {/if}
+
   <button
     type="button"
     class="remove-btn"
@@ -68,7 +99,7 @@
 <style>
   .row {
     display: grid;
-    grid-template-columns: minmax(2.5rem, auto) minmax(0, 1fr) auto 1.5rem;
+    grid-template-columns: minmax(2.5rem, auto) minmax(0, 1fr) auto auto 1.5rem;
     gap: 0.4rem;
     align-items: center;
     padding: 0.25rem 0.4rem;
@@ -77,6 +108,26 @@
     border-radius: 4px;
     font-size: 0.75rem;
   }
+
+  .enrich-btn {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    color: var(--c-text-muted);
+    font-size: 0.65rem;
+    width: 1.4rem;
+    height: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+    font-weight: 600;
+  }
+  .enrich-btn:hover { color: var(--c-accent); border-color: var(--c-accent); }
+  .enrich-btn.active {
+    color: var(--c-gold, var(--c-accent));
+    border-color: var(--c-gold, var(--c-accent));
+    background: var(--c-gold-tint-subtle, var(--c-bg-active));
+  }
+  .enrich-btn:focus-visible { outline: 2px solid var(--c-accent); outline-offset: 1px; }
 
   .formula {
     font-weight: 500;


### PR DESCRIPTION
Closes #93's UI half (the carrier + resolver fallback shipped in #92).

- Single-element rows in mass / atom mode get an "E" button
- Click opens the existing ElementPopup, scoped via local DefineForm state
- Vector commits into `row.enrichment[element]`; the resolver's row → layer → natural chain (#92) consumes it
- Active gold-rim state when row already carries an override
- Compound rows (e.g. SiO2) hide the button — disambiguating which element to enrich is its own UX cycle

E2E: Cu row exposes the button; H2O row doesn't.

## Verification
- svelte-check 2 baseline errors held
- vitest 354 unchanged
- playwright +1 case

Refs: #92