### PR TITLE
feat(catalog): gas-target entries 18O2, 124Xe, 86SrCO3 (#68)

### DIFF
--- a/packages/compute/src/materials.test.ts
+++ b/packages/compute/src/materials.test.ts
@@ -163,6 +163,30 @@ describe("resolveMaterial", () => {
   });
 });
 
+describe("Gas-target catalog entries (#68)", () => {
+  it("o18-gas: pure O at STP density", () => {
+    const e = MATERIAL_CATALOG["o18-gas"];
+    expect(e).toBeDefined();
+    expect(e.density).toBeCloseTo(1.428e-3, 6);
+    expect(e.massFractions.O).toBe(1.0);
+  });
+
+  it("xe124-gas: pure Xe at STP density", () => {
+    const e = MATERIAL_CATALOG["xe124-gas"];
+    expect(e).toBeDefined();
+    expect(e.density).toBeCloseTo(5.532e-3, 6);
+    expect(e.massFractions.Xe).toBe(1.0);
+  });
+
+  it("sr86-carbonate: stoichiometry sums to ~1", () => {
+    const e = MATERIAL_CATALOG["sr86-carbonate"];
+    expect(e).toBeDefined();
+    expect(e.density).toBeCloseTo(3.50);
+    const sum = Object.values(e.massFractions).reduce((s, v) => s + v, 0);
+    expect(sum).toBeCloseTo(1.0, 3);
+  });
+});
+
 describe("catalogEntryToMassText (#94)", () => {
   it("renders havar as a comma-separated wt% string sorted desc by share", () => {
     const text = catalogEntryToMassText(MATERIAL_CATALOG.havar);

--- a/packages/compute/src/materials.ts
+++ b/packages/compute/src/materials.ts
@@ -29,6 +29,28 @@ export const MATERIAL_CATALOG: Record<string, CatalogEntry> = {
       W: 0.028, Mo: 0.02, Mn: 0.016, C: 0.002,
     },
   },
+  // Gas-target catalog entries (#68). Densities are STP baselines —
+  // operators routinely override for fill pressure / temperature. The
+  // per-row "E" button (#93) sets isotopic enrichment vectors after the
+  // catalog material hydrates into the form's rows.
+  "o18-gas": {
+    // 18O2 at STP (1 atm, 273.15 K). M = 32 g/mol; 32/22.414 ≈ 1.428 g/L
+    // → 1.428e-3 g/cm³. The exact value shifts ~12% with enrichment-mass;
+    // operators override for their fill condition.
+    density: 1.428e-3,
+    massFractions: { O: 1.0 },
+  },
+  "xe124-gas": {
+    // 124Xe at STP. M = 124 g/mol; 124/22.414 ≈ 5.532 g/L → 5.532e-3 g/cm³.
+    density: 5.532e-3,
+    massFractions: { Xe: 1.0 },
+  },
+  "sr86-carbonate": {
+    // 86SrCO3 powder. Solid theoretical density ≈ 3.50 g/cm³. Mass
+    // fractions: 86Sr / M_total where M_total = 86 + 12.011 + 3·16 = 146.011.
+    density: 3.50,
+    massFractions: { Sr: 0.589, C: 0.0823, O: 0.329 },
+  },
 };
 
 /** Convert mass fractions to atom fractions. */


### PR DESCRIPTION
Closes #68 with a minimal data-only addition.

Three entries seeded into MATERIAL_CATALOG with the existing `{density, massFractions}` schema:
- `o18-gas` — 18O2 at STP, ρ = 1.428e-3 g/cm³
- `xe124-gas` — 124Xe at STP, ρ = 5.532e-3 g/cm³
- `sr86-carbonate` — 86SrCO3 powder, ρ = 3.50 g/cm³

Per-row isotopic enrichment is set by the user via the "E" button (#93) after the catalog material hydrates into the form. The richer metadata (defaultEnrichment, role, notes) from #68's original plan stays deferred until #65's catalog expansion lands.

## Verification
- compute vitest: +3 cases (66 total)
- svelte-check 2 baseline errors held
- frontend vitest 354 unchanged

Refs: #68