### PR TITLE
feat(material): curated supplier links for enriched-isotope targets (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,13 @@ jobs:
         run: uv sync --dev
       - name: Run tests with coverage
         run: uv run pytest tests/ --cov --benchmark-disable --ignore=tests/integration
+
+  supplier-catalog-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Warn if supplier catalog is stale (>90 days)
+        run: node frontend/scripts/check-suppliers-fresh.mjs

--- a/frontend/e2e/material-supplier-chips.spec.ts
+++ b/frontend/e2e/material-supplier-chips.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+/** Same TC99M preset used by the other material-popup specs. */
+const TC99M_URL =
+  "/hyrr/#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+
+async function waitReady(page: import("@playwright/test").Page) {
+  await page.waitForSelector(".status-bar", { state: "hidden", timeout: 30_000 }).catch(() => {});
+  await page.waitForSelector(".activity-table-enhanced", { timeout: 30_000 });
+}
+
+test.describe("Supplier chips in inspect panel (#66)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TC99M_URL);
+    await waitReady(page);
+  });
+
+  test("no supplier block when no enrichment is configured", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+
+    // Type something that will produce element badges but no enrichment yet.
+    await page.locator(".material-popup input[type='text']").first().fill("Mo");
+
+    await expect(page.getByTestId("supplier-block")).toHaveCount(0);
+  });
+
+  test("setting Mo-100 enrichment renders supplier chips with deep-link + flag", async ({ page }) => {
+    // Open material popup on first layer.
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+
+    // Type Mo so the inspect panel exposes the Mo enrichment badge.
+    const queryInput = page.locator(".material-popup input[type='text']").first();
+    await queryInput.fill("Mo");
+
+    // Click the Mo badge inside the inspect panel's enrichment row.
+    await page.locator(".enrichment-row .el-badge", { hasText: "Mo" }).click();
+    await page.waitForSelector(".element-popup", { timeout: 5_000 });
+
+    // Quick-ratio "Mo-100: 99" then Apply.
+    await page.locator(".quick-ratio-input").fill("Mo-100: 99");
+    await page.locator(".quick-ratio-input").press("Enter");
+    await page.getByRole("button", { name: /^Apply$/ }).click();
+
+    // ElementPopup closed. Material popup is still open and the inspect
+    // panel now shows the sourcing block.
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+    const block = page.getByTestId("supplier-block");
+    await expect(block).toBeVisible();
+
+    // Header text mentions ¹⁰⁰Mo.
+    await expect(block.getByText(/Where to source/i)).toBeVisible();
+    await expect(block.getByText(/¹⁰⁰Mo/)).toBeVisible();
+
+    // At least 2 chips are rendered (acceptance: ≥ 2 suppliers for ¹⁰⁰Mo).
+    const chips = block.getByTestId("supplier-chip");
+    expect(await chips.count()).toBeGreaterThanOrEqual(2);
+
+    // Every chip is an external link with rel safety attributes.
+    for (const chip of await chips.all()) {
+      await expect(chip).toHaveAttribute("target", "_blank");
+      await expect(chip).toHaveAttribute("rel", "noopener noreferrer");
+      const href = await chip.getAttribute("href");
+      expect(href).toMatch(/^https?:\/\//);
+    }
+
+    // The JSC Isotope chip exists and carries a sanctions flag glyph.
+    const jsc = block.locator('[data-supplier-id="jsc-isotope"]');
+    await expect(jsc).toBeVisible();
+    await expect(jsc).toHaveClass(/flagged/);
+
+    // Footer shows last-reviewed date.
+    await expect(block.getByText(/last reviewed/i)).toBeVisible();
+  });
+
+  test("Isoflex chip points at the Isoflex top-level URL", async ({ page }) => {
+    await page.locator(".material-name").first().click();
+    await page.waitForSelector(".material-popup", { timeout: 5_000 });
+
+    const queryInput = page.locator(".material-popup input[type='text']").first();
+    await queryInput.fill("Mo");
+    await page.locator(".enrichment-row .el-badge", { hasText: "Mo" }).click();
+    await page.waitForSelector(".element-popup", { timeout: 5_000 });
+    await page.locator(".quick-ratio-input").fill("Mo-100: 99");
+    await page.locator(".quick-ratio-input").press("Enter");
+    await page.getByRole("button", { name: /^Apply$/ }).click();
+
+    const block = page.getByTestId("supplier-block");
+    const isoflex = block.locator('[data-supplier-id="isoflex"]');
+    await expect(isoflex).toBeVisible();
+    await expect(isoflex).toHaveAttribute("href", "https://isoflex.com/");
+  });
+});

--- a/frontend/e2e/material-supplier-chips.spec.ts
+++ b/frontend/e2e/material-supplier-chips.spec.ts
@@ -65,10 +65,13 @@ test.describe("Supplier chips in inspect panel (#66)", () => {
       expect(href).toMatch(/^https?:\/\//);
     }
 
-    // The JSC Isotope chip exists and carries a sanctions flag glyph.
+    // The JSC Isotope chip exists, carries a sanctions flag glyph, and the
+    // tooltip surfaces the sanctions reason (pitfall #3 in the issue —
+    // sanctions visibility, not just exclusion).
     const jsc = block.locator('[data-supplier-id="jsc-isotope"]');
     await expect(jsc).toBeVisible();
     await expect(jsc).toHaveClass(/flagged/);
+    await expect(jsc).toHaveAttribute("title", /sanctions/i);
 
     // Footer shows last-reviewed date.
     await expect(block.getByText(/last reviewed/i)).toBeVisible();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "check:suppliers-fresh": "node scripts/check-suppliers-fresh.mjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/frontend/scripts/check-suppliers-fresh.mjs
+++ b/frontend/scripts/check-suppliers-fresh.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Warn (don't fail) if the supplier catalog hasn't been reviewed in > 90 days.
+ *
+ * Per #66's review cadence: enriched-isotope supplier inventories drift
+ * (URL changes, new sanctions regimes, new entrants), so we want a
+ * visible nudge in CI without blocking merges.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const STALE_DAYS = 90;
+const here = dirname(fileURLToPath(import.meta.url));
+const catalogPath = resolve(here, "../src/lib/data/suppliers.json");
+const catalog = JSON.parse(readFileSync(catalogPath, "utf8"));
+
+const reviewed = new Date(catalog.last_reviewed + "T00:00:00Z");
+if (Number.isNaN(reviewed.getTime())) {
+  console.error(`::error::suppliers.json last_reviewed "${catalog.last_reviewed}" is not a valid date`);
+  process.exit(1);
+}
+
+const ageDays = Math.floor((Date.now() - reviewed.getTime()) / (1000 * 60 * 60 * 24));
+
+if (ageDays > STALE_DAYS) {
+  // GitHub Actions warning syntax — surfaces in the PR check summary.
+  console.log(
+    `::warning file=frontend/src/lib/data/suppliers.json::Supplier catalog last_reviewed=${catalog.last_reviewed} is ${ageDays} days old (> ${STALE_DAYS}). Re-verify supplier URLs, isotope offerings, and sanctions flags, then bump last_reviewed.`,
+  );
+} else {
+  console.log(`Supplier catalog reviewed ${ageDays} days ago — fresh (≤ ${STALE_DAYS}).`);
+}
+
+process.exit(0);

--- a/frontend/src/lib/components/material/InspectPanel.svelte
+++ b/frontend/src/lib/components/material/InspectPanel.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
   import { parseFormula } from "@hyrr/compute";
+  import {
+    SUPPLIER_CATALOG,
+    getSuppliersForIsotope,
+    resolveSupplierUrl,
+    type Supplier,
+  } from "../../data/suppliers";
 
   interface Props {
     query: string;
@@ -14,6 +20,58 @@
     if (!q) return [];
     try { return Object.keys(parseFormula(q)); } catch { return []; }
   });
+
+  /** Per enriched element: dominant mass + its fraction. */
+  type EnrichedTarget = { element: string; mass: number; fraction: number };
+
+  let enrichedTargets = $derived.by<EnrichedTarget[]>(() => {
+    const out: EnrichedTarget[] = [];
+    if (!currentEnrichment) return out;
+    for (const [el, masses] of Object.entries(currentEnrichment)) {
+      const entries = Object.entries(masses);
+      if (entries.length === 0) continue;
+      let bestMass = -1;
+      let bestFrac = -1;
+      for (const [m, f] of entries) {
+        if (f > bestFrac) {
+          bestFrac = f;
+          bestMass = Number(m);
+        }
+      }
+      if (bestMass > 0) out.push({ element: el, mass: bestMass, fraction: bestFrac });
+    }
+    return out;
+  });
+
+  /** Format an integer mass as a Unicode superscript prefix (e.g. 68 → "⁶⁸"). */
+  const SUPER = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"];
+  function superMass(mass: number): string {
+    return String(mass).split("").map((d) => SUPER[Number(d)] ?? d).join("");
+  }
+
+  function formatFraction(frac: number): string {
+    const pct = frac * 100;
+    return pct >= 99.95 ? "100" : pct.toFixed(pct >= 10 ? 1 : 2);
+  }
+
+  function flagSummary(s: Supplier): string {
+    const flags = s.flags ?? [];
+    if (flags.length === 0) return "";
+    return flags.map((f) => `${f.type}: ${f.detail} (as of ${f.asOf})`).join("\n");
+  }
+
+  function chipTitle(s: Supplier): string {
+    const parts = [s.country];
+    if (s.notes) parts.push(s.notes);
+    parts.push(`Last reviewed: ${SUPPLIER_CATALOG.last_reviewed}`);
+    const flag = flagSummary(s);
+    if (flag) parts.push(flag);
+    return parts.join("\n");
+  }
+
+  function suppliersFor(t: EnrichedTarget): Supplier[] {
+    return getSuppliersForIsotope(t.element, t.mass);
+  }
 </script>
 
 {#if queryElements.length > 0 && onenrichment}
@@ -26,6 +84,46 @@
         onclick={() => onenrichment?.(el)}
       >{el}{#if currentEnrichment?.[el]}<span class="enr-dot"></span>{/if}</button>
     {/each}
+  </div>
+{/if}
+
+{#if enrichedTargets.length > 0}
+  <div class="sourcing-block" data-testid="supplier-block">
+    {#each enrichedTargets as t (t.element + t.mass)}
+      {@const suppliers = suppliersFor(t)}
+      <div class="sourcing-row">
+        <span class="src-label">
+          Where to source <span class="iso-name">{superMass(t.mass)}{t.element}</span>
+          @ {formatFraction(t.fraction)}%:
+        </span>
+        {#if suppliers.length === 0}
+          <span class="empty">No curated suppliers in catalog.</span>
+        {:else}
+          <div class="chips">
+            {#each suppliers as s (s.id)}
+              <a
+                class="supplier-chip"
+                class:flagged={(s.flags ?? []).length > 0}
+                href={resolveSupplierUrl(s, t.element, t.mass)}
+                target="_blank"
+                rel="noopener noreferrer"
+                title={chipTitle(s)}
+                data-testid="supplier-chip"
+                data-supplier-id={s.id}
+              >
+                <span class="chip-name">{s.name}</span>
+                {#if (s.flags ?? []).length > 0}
+                  <span class="chip-flag" aria-label="restricted supplier">⚑</span>
+                {/if}
+              </a>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    {/each}
+    <div class="reviewed-footer">
+      Supplier catalog last reviewed: {SUPPLIER_CATALOG.last_reviewed}
+    </div>
   </div>
 {/if}
 
@@ -74,5 +172,83 @@
     border-radius: 50%;
     margin-left: 0.2rem;
     vertical-align: middle;
+  }
+
+  .sourcing-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-top: 0.4rem;
+    padding: 0.4rem 0.5rem;
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+  }
+
+  .sourcing-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .src-label {
+    font-size: 0.7rem;
+    color: var(--c-text-muted);
+  }
+
+  .iso-name {
+    color: var(--c-gold);
+    font-weight: 600;
+  }
+
+  .chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .supplier-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    background: var(--c-bg-muted);
+    border: 1px solid var(--c-border);
+    border-radius: 999px;
+    color: var(--c-text-default);
+    font-size: 0.7rem;
+    line-height: 1;
+    padding: 0.2rem 0.5rem;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .supplier-chip:hover {
+    border-color: var(--c-accent);
+    color: var(--c-accent);
+    background: var(--c-accent-tint-subtle, var(--c-bg-muted));
+  }
+
+  .supplier-chip.flagged {
+    border-color: var(--c-warning, #c87a00);
+    color: var(--c-warning, #c87a00);
+    background: var(--c-warning-tint-subtle, var(--c-bg-muted));
+  }
+
+  .chip-flag {
+    font-size: 0.65rem;
+  }
+
+  .empty {
+    font-size: 0.7rem;
+    color: var(--c-text-muted);
+    font-style: italic;
+  }
+
+  .reviewed-footer {
+    font-size: 0.62rem;
+    color: var(--c-text-muted);
+    opacity: 0.75;
+    margin-top: 0.1rem;
   }
 </style>

--- a/frontend/src/lib/components/material/InspectPanel.svelte
+++ b/frontend/src/lib/components/material/InspectPanel.svelte
@@ -33,9 +33,13 @@
       let bestMass = -1;
       let bestFrac = -1;
       for (const [m, f] of entries) {
-        if (f > bestFrac) {
+        const mass = Number(m);
+        // On a tie (e.g. user sets Mo-98 = Mo-100 = 0.5) prefer the
+        // heavier isotope — the typical procurement intent for medical
+        // targets is the more-neutron-rich mass.
+        if (f > bestFrac || (f === bestFrac && mass > bestMass)) {
           bestFrac = f;
-          bestMass = Number(m);
+          bestMass = mass;
         }
       }
       if (bestMass > 0) out.push({ element: el, mass: bestMass, fraction: bestFrac });

--- a/frontend/src/lib/data/suppliers.json
+++ b/frontend/src/lib/data/suppliers.json
@@ -1,0 +1,142 @@
+{
+  "$schema": "hyrr-supplier-catalog/1",
+  "last_reviewed": "2026-05-03",
+  "policy": "Curated, hand-maintained catalog of suppliers for enriched stable isotopes used as cyclotron target material. Editorial decisions: (1) we link only to top-level supplier URLs, never deep-links — supplier sites change structure too often for templates to stay accurate, and many suppliers' ToS are ambiguous about third-party deep-linking; (2) suppliers under sanctions/export control are listed with a visible flag rather than removed — users planning a procurement campaign need to know the restriction exists; (3) no prices in this catalog (quote-only suppliers + liability); (4) reviewed quarterly. Out of scope: scraping, API integrations, structural-material suppliers (Cu, Kapton, etc.).",
+  "suppliers": [
+    {
+      "id": "isoflex",
+      "name": "Isoflex USA",
+      "url": "https://isoflex.com/",
+      "country": "United States",
+      "countryCode": "US",
+      "isotopesOffered": [
+        "Li-6", "Li-7", "Be-9", "B-10", "B-11", "C-13",
+        "N-15", "O-17", "O-18", "Mg-24", "Mg-25", "Mg-26",
+        "Si-28", "Si-29", "Si-30", "S-33", "S-34", "S-36",
+        "Ca-40", "Ca-42", "Ca-43", "Ca-44", "Ca-46", "Ca-48",
+        "Ti-46", "Ti-47", "Ti-48", "Ti-49", "Ti-50",
+        "Cr-50", "Cr-52", "Cr-53", "Cr-54",
+        "Fe-54", "Fe-56", "Fe-57", "Fe-58",
+        "Ni-58", "Ni-60", "Ni-61", "Ni-62", "Ni-64",
+        "Cu-63", "Cu-65",
+        "Zn-64", "Zn-66", "Zn-67", "Zn-68", "Zn-70",
+        "Ga-69", "Ga-71",
+        "Ge-70", "Ge-72", "Ge-73", "Ge-74", "Ge-76",
+        "Se-74", "Se-76", "Se-77", "Se-78", "Se-80", "Se-82",
+        "Sr-84", "Sr-86", "Sr-87", "Sr-88",
+        "Mo-92", "Mo-94", "Mo-95", "Mo-96", "Mo-97", "Mo-98", "Mo-100",
+        "Cd-106", "Cd-108", "Cd-110", "Cd-111", "Cd-112", "Cd-113", "Cd-114", "Cd-116",
+        "Te-120", "Te-122", "Te-123", "Te-124", "Te-125", "Te-126", "Te-128", "Te-130",
+        "Xe-124", "Xe-126", "Xe-128", "Xe-129", "Xe-130", "Xe-131", "Xe-132", "Xe-134", "Xe-136"
+      ],
+      "notes": "Broad enriched-stable-isotope catalog. Quote-only pricing. US-based."
+    },
+    {
+      "id": "trace-sciences",
+      "name": "Trace Sciences International",
+      "url": "https://www.tracesciences.com/",
+      "country": "Canada",
+      "countryCode": "CA",
+      "isotopesOffered": [
+        "Li-6", "Li-7", "B-10", "B-11", "C-13", "N-15", "O-17", "O-18",
+        "Ca-40", "Ca-42", "Ca-43", "Ca-44", "Ca-46", "Ca-48",
+        "Ti-46", "Ti-47", "Ti-48", "Ti-49", "Ti-50",
+        "Fe-54", "Fe-56", "Fe-57", "Fe-58",
+        "Ni-58", "Ni-60", "Ni-61", "Ni-62", "Ni-64",
+        "Cu-63", "Cu-65",
+        "Zn-64", "Zn-66", "Zn-67", "Zn-68", "Zn-70",
+        "Ga-69", "Ga-71",
+        "Sr-84", "Sr-86", "Sr-87", "Sr-88",
+        "Mo-92", "Mo-94", "Mo-95", "Mo-96", "Mo-97", "Mo-98", "Mo-100",
+        "Cd-106", "Cd-108", "Cd-111", "Cd-112", "Cd-114", "Cd-116",
+        "Te-122", "Te-123", "Te-124", "Te-125", "Te-126", "Te-128", "Te-130",
+        "Xe-124", "Xe-128", "Xe-129", "Xe-131", "Xe-132", "Xe-134", "Xe-136"
+      ],
+      "notes": "Broad enriched-stable-isotope catalog. Quote-only pricing. Canada-based."
+    },
+    {
+      "id": "eurisotop",
+      "name": "Eurisotop / Cambridge Isotope Labs",
+      "url": "https://www.eurisotop.com/",
+      "country": "France / United States",
+      "countryCode": "FR",
+      "isotopesOffered": ["H-2", "C-13", "N-15", "O-17", "O-18", "S-34"],
+      "notes": "Primarily stable light isotopes for chemistry/biology. High-purity ¹⁸O water for medical-cyclotron ¹⁸F production."
+    },
+    {
+      "id": "ornl-nidc",
+      "name": "ORNL National Isotope Development Center",
+      "url": "https://www.isotopes.gov/",
+      "country": "United States",
+      "countryCode": "US",
+      "isotopesOffered": [
+        "Ca-48", "Ni-64", "Zn-68", "Mo-100",
+        "Ac-225", "Ac-227", "Ra-223", "Ra-224", "Ra-225", "Ra-226", "Ra-228",
+        "Th-228", "Th-229", "Th-230", "Th-232",
+        "U-232", "U-233", "U-234", "U-235", "U-236", "U-238",
+        "Cf-252", "Bk-249",
+        "Cu-67", "Sr-82", "Ge-68"
+      ],
+      "notes": "US National Isotope Development Center. Rare/heavy isotopes including ²²⁵Ac, ²²⁸Th. Allocation-based — request via isotopes.gov.",
+      "flags": [
+        {
+          "type": "export-control",
+          "asOf": "2026-05-03",
+          "detail": "Several heavy-element isotopes are export-controlled from the US (e.g. ²²⁸Th, ²²⁵Ac, ²³²U). Eligibility depends on destination + end-use; requires ORNL approval."
+        }
+      ]
+    },
+    {
+      "id": "jsc-isotope",
+      "name": "JSC Isotope",
+      "url": "https://isotop.ru/en/",
+      "country": "Russian Federation",
+      "countryCode": "RU",
+      "isotopesOffered": [
+        "Li-6", "Li-7", "B-10", "B-11", "C-13", "N-15", "O-17", "O-18",
+        "Mg-24", "Mg-25", "Mg-26",
+        "Si-28", "Si-29", "Si-30",
+        "Ca-40", "Ca-42", "Ca-43", "Ca-44", "Ca-46", "Ca-48",
+        "Ti-46", "Ti-47", "Ti-48", "Ti-49", "Ti-50",
+        "Cr-50", "Cr-52", "Cr-53", "Cr-54",
+        "Fe-54", "Fe-56", "Fe-57", "Fe-58",
+        "Ni-58", "Ni-60", "Ni-61", "Ni-62", "Ni-64",
+        "Cu-63", "Cu-65",
+        "Zn-64", "Zn-66", "Zn-67", "Zn-68", "Zn-70",
+        "Ge-70", "Ge-72", "Ge-73", "Ge-74", "Ge-76",
+        "Se-74", "Se-76", "Se-77", "Se-78", "Se-80", "Se-82",
+        "Sr-84", "Sr-86", "Sr-87", "Sr-88",
+        "Mo-92", "Mo-94", "Mo-95", "Mo-96", "Mo-97", "Mo-98", "Mo-100",
+        "Cd-106", "Cd-108", "Cd-110", "Cd-111", "Cd-112", "Cd-113", "Cd-114", "Cd-116",
+        "Te-120", "Te-122", "Te-123", "Te-124", "Te-125", "Te-126", "Te-128", "Te-130",
+        "Xe-124", "Xe-126", "Xe-128", "Xe-129", "Xe-130", "Xe-131", "Xe-132", "Xe-134", "Xe-136",
+        "Ac-225"
+      ],
+      "notes": "Historically dominant global supplier of enriched stable isotopes. Quote-only.",
+      "flags": [
+        {
+          "type": "sanctions",
+          "asOf": "2026-05-03",
+          "detail": "JSC Isotope is subject to international sanctions (US/EU/UK) following the 2022 invasion of Ukraine. Imports are restricted or prohibited from many jurisdictions; check current export-control regimes before procuring."
+        }
+      ]
+    },
+    {
+      "id": "sigma-aldrich",
+      "name": "Sigma-Aldrich / Merck",
+      "url": "https://www.sigmaaldrich.com/",
+      "country": "Germany / Global",
+      "countryCode": "DE",
+      "isotopesOffered": [
+        "H-2", "C-13", "N-15", "O-17", "O-18",
+        "Mg-25", "Mg-26",
+        "Ca-44", "Ca-48",
+        "Fe-57", "Fe-58",
+        "Ni-62", "Ni-64",
+        "Zn-67", "Zn-68",
+        "Mo-95", "Mo-97", "Mo-100"
+      ],
+      "notes": "Small-quantity research grades; convenient for proof-of-concept buys. Higher unit price than dedicated isotope houses."
+    }
+  ]
+}

--- a/frontend/src/lib/data/suppliers.test.ts
+++ b/frontend/src/lib/data/suppliers.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  SUPPLIER_CATALOG,
+  getSuppliersForIsotope,
+  resolveSupplierUrl,
+  daysSinceReview,
+  type Supplier,
+} from "./suppliers";
+
+describe("supplier catalog — schema validation", () => {
+  it("declares the expected schema version", () => {
+    expect(SUPPLIER_CATALOG.$schema).toBe("hyrr-supplier-catalog/1");
+  });
+
+  it("has a valid ISO date for last_reviewed", () => {
+    expect(SUPPLIER_CATALOG.last_reviewed).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(new Date(SUPPLIER_CATALOG.last_reviewed).toString()).not.toBe("Invalid Date");
+  });
+
+  it("contains a non-empty editorial policy", () => {
+    expect(SUPPLIER_CATALOG.policy.length).toBeGreaterThan(50);
+  });
+
+  it("each supplier has the required fields", () => {
+    for (const s of SUPPLIER_CATALOG.suppliers) {
+      expect(s.id, `supplier missing id`).toBeTruthy();
+      expect(s.name, `${s.id}: missing name`).toBeTruthy();
+      expect(s.url, `${s.id}: missing url`).toMatch(/^https?:\/\//);
+      expect(s.country, `${s.id}: missing country`).toBeTruthy();
+      expect(s.countryCode, `${s.id}: countryCode must be 2-letter ISO`).toMatch(/^[A-Z]{2}$/);
+      expect(Array.isArray(s.isotopesOffered), `${s.id}: isotopesOffered must be array`).toBe(true);
+      expect(s.isotopesOffered.length, `${s.id}: empty isotopesOffered`).toBeGreaterThan(0);
+    }
+  });
+
+  it("isotope identifiers all match Symbol-Mass format", () => {
+    for (const s of SUPPLIER_CATALOG.suppliers) {
+      for (const iso of s.isotopesOffered) {
+        expect(iso, `${s.id}: malformed isotope "${iso}"`).toMatch(/^[A-Z][a-z]?-\d+$/);
+      }
+    }
+  });
+
+  it("supplier ids are unique", () => {
+    const ids = SUPPLIER_CATALOG.suppliers.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("flagged suppliers carry asOf and detail", () => {
+    for (const s of SUPPLIER_CATALOG.suppliers) {
+      for (const flag of s.flags ?? []) {
+        expect(["sanctions", "export-control", "restricted"]).toContain(flag.type);
+        expect(flag.asOf, `${s.id}/${flag.type}: missing asOf`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(flag.detail.length, `${s.id}/${flag.type}: empty detail`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe("getSuppliersForIsotope — acceptance fixtures", () => {
+  // Acceptance criteria from #66: each of these isotopes returns ≥ 2 suppliers.
+  const FIXTURES: Array<[string, number]> = [
+    ["Zn", 68],
+    ["Mo", 100],
+    ["Ca", 44],
+    ["O", 18],
+    ["Ac", 225],
+  ];
+
+  for (const [symbol, mass] of FIXTURES) {
+    it(`returns ≥ 2 suppliers for ${mass}${symbol}`, () => {
+      const suppliers = getSuppliersForIsotope(symbol, mass);
+      expect(suppliers.length, `${mass}${symbol}: expected ≥ 2 suppliers`).toBeGreaterThanOrEqual(2);
+    });
+  }
+
+  it("returns an empty list for an isotope no supplier offers", () => {
+    const suppliers = getSuppliersForIsotope("Bk", 249);
+    // Only ORNL stocks Bk-249 in the seed catalog; sanity-check it's exactly that.
+    expect(suppliers.map((s) => s.id)).toEqual(["ornl-nidc"]);
+  });
+
+  it("returns nothing for a fictional isotope", () => {
+    expect(getSuppliersForIsotope("Xx", 999)).toEqual([]);
+  });
+
+  it("sorts unflagged suppliers before flagged suppliers", () => {
+    const suppliers = getSuppliersForIsotope("Mo", 100);
+    const flaggedIdx = suppliers.findIndex((s) => (s.flags ?? []).length > 0);
+    const lastUnflaggedIdx = (() => {
+      for (let i = suppliers.length - 1; i >= 0; i--) {
+        if ((suppliers[i].flags ?? []).length === 0) return i;
+      }
+      return -1;
+    })();
+    if (flaggedIdx >= 0 && lastUnflaggedIdx >= 0) {
+      expect(lastUnflaggedIdx).toBeLessThan(flaggedIdx);
+    }
+  });
+});
+
+describe("resolveSupplierUrl", () => {
+  it("falls back to the top-level url when no template is set", () => {
+    const s: Supplier = {
+      id: "x",
+      name: "X",
+      url: "https://example.com/",
+      country: "X",
+      countryCode: "XX",
+      isotopesOffered: [],
+    };
+    expect(resolveSupplierUrl(s, "Mo", 100)).toBe("https://example.com/");
+  });
+
+  it("substitutes {symbol}, {mass}, and {massSymbol}", () => {
+    const s: Supplier = {
+      id: "x",
+      name: "X",
+      url: "https://example.com/",
+      country: "X",
+      countryCode: "XX",
+      isotopesOffered: [],
+      deepLinkTemplate: "https://example.com/{symbol}/{mass}/{massSymbol}",
+    };
+    expect(resolveSupplierUrl(s, "Mo", 100)).toBe("https://example.com/Mo/100/100Mo");
+  });
+});
+
+describe("daysSinceReview", () => {
+  it("computes whole-day differences", () => {
+    const fakeCatalog = { ...SUPPLIER_CATALOG, last_reviewed: "2026-01-01" };
+    const now = new Date("2026-04-01T12:00:00Z");
+    expect(daysSinceReview(fakeCatalog, now)).toBe(90);
+  });
+});

--- a/frontend/src/lib/data/suppliers.test.ts
+++ b/frontend/src/lib/data/suppliers.test.ts
@@ -47,9 +47,11 @@ describe("supplier catalog — schema validation", () => {
   });
 
   it("flagged suppliers carry asOf and detail", () => {
+    const VALID_FLAG_TYPES = ["sanctions", "export-control", "restricted"] as const;
     for (const s of SUPPLIER_CATALOG.suppliers) {
       for (const flag of s.flags ?? []) {
-        expect(["sanctions", "export-control", "restricted"]).toContain(flag.type);
+        // Runtime check — TS types alone don't guard the JSON file.
+        expect(VALID_FLAG_TYPES, `${s.id}: unknown flag.type "${flag.type}"`).toContain(flag.type);
         expect(flag.asOf, `${s.id}/${flag.type}: missing asOf`).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         expect(flag.detail.length, `${s.id}/${flag.type}: empty detail`).toBeGreaterThan(0);
       }

--- a/frontend/src/lib/data/suppliers.ts
+++ b/frontend/src/lib/data/suppliers.ts
@@ -1,0 +1,79 @@
+import catalogJson from "./suppliers.json";
+
+export type SupplierFlagType = "sanctions" | "export-control" | "restricted";
+
+export interface SupplierFlag {
+  type: SupplierFlagType;
+  asOf: string;
+  detail: string;
+}
+
+export interface Supplier {
+  id: string;
+  name: string;
+  url: string;
+  country: string;
+  countryCode: string;
+  isotopesOffered: string[];
+  deepLinkTemplate?: string;
+  notes?: string;
+  flags?: SupplierFlag[];
+}
+
+export interface SupplierCatalog {
+  $schema: string;
+  last_reviewed: string;
+  policy: string;
+  suppliers: Supplier[];
+}
+
+export const SUPPLIER_CATALOG: SupplierCatalog = catalogJson as SupplierCatalog;
+
+export function isotopeKey(symbol: string, mass: number): string {
+  return `${symbol}-${mass}`;
+}
+
+/** Resolve a deep-link URL for an isotope, falling back to the supplier's
+ *  top-level URL if no template is set. Templates support {symbol}, {mass},
+ *  and {massSymbol} (e.g. "100Mo") placeholders. */
+export function resolveSupplierUrl(
+  supplier: Supplier,
+  symbol: string,
+  mass: number,
+): string {
+  if (!supplier.deepLinkTemplate) return supplier.url;
+  return supplier.deepLinkTemplate
+    .replace(/\{symbol\}/g, symbol)
+    .replace(/\{mass\}/g, String(mass))
+    .replace(/\{massSymbol\}/g, `${mass}${symbol}`);
+}
+
+/** Suppliers that offer the given isotope, sorted: deep-linkable first,
+ *  then unflagged, then alphabetical by name. */
+export function getSuppliersForIsotope(
+  symbol: string,
+  mass: number,
+  catalog: SupplierCatalog = SUPPLIER_CATALOG,
+): Supplier[] {
+  const key = isotopeKey(symbol, mass);
+  const matches = catalog.suppliers.filter((s) => s.isotopesOffered.includes(key));
+  return matches.sort((a, b) => {
+    const aDeep = a.deepLinkTemplate ? 0 : 1;
+    const bDeep = b.deepLinkTemplate ? 0 : 1;
+    if (aDeep !== bDeep) return aDeep - bDeep;
+    const aFlag = a.flags && a.flags.length > 0 ? 1 : 0;
+    const bFlag = b.flags && b.flags.length > 0 ? 1 : 0;
+    if (aFlag !== bFlag) return aFlag - bFlag;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/** Days since the catalog was last reviewed. Useful for staleness checks. */
+export function daysSinceReview(
+  catalog: SupplierCatalog = SUPPLIER_CATALOG,
+  now: Date = new Date(),
+): number {
+  const reviewed = new Date(catalog.last_reviewed + "T00:00:00Z");
+  const ms = now.getTime() - reviewed.getTime();
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+}


### PR DESCRIPTION
## Summary

Closes #66. Implements P0 of the curated-supplier-catalog spec — when a layer has isotopic enrichment configured, the inspect panel renders a "Where to source" section with chips that link out to the suppliers that stock that isotope.

- **Catalog (`frontend/src/lib/data/suppliers.json`)** — 6 seed entries: Isoflex USA, Trace Sciences, Eurisotop / Cambridge Isotope Labs, ORNL NIDC, JSC Isotope (sanctions-flagged), Sigma-Aldrich. Top-level URLs only — no deep-link templates in the seed list, but `resolveSupplierUrl` supports `{symbol}/{mass}/{massSymbol}` placeholders for future entries.
- **Helper (`frontend/src/lib/data/suppliers.ts`)** — pure `getSuppliersForIsotope(symbol, mass)` and `daysSinceReview`; sorts deep-linkable + unflagged ahead of flagged.
- **UI (`InspectPanel.svelte`)** — sourcing block with chips (target=_blank, rel=noopener noreferrer), JSC carries a ⚑ glyph + warning-palette styling + sanctions-detail tooltip. Tie-breaks dominant isotope toward heavier mass. `last_reviewed: 2026-05-03` footer.
- **Stale-data check** — `frontend/scripts/check-suppliers-fresh.mjs` emits a GitHub Actions `::warning::` when `last_reviewed` > 90 days old; wired into `ci.yml` as a non-blocking job (per #66 pitfall #2 — staleness matters but shouldn't block unrelated PRs).
- **Tests** — 18 vitest cases (schema invariants, fixture coverage for {Zn-68, Mo-100, Ca-44, O-18, Ac-225}, sort order, runtime flag.type validation) + 3 Playwright cases (no-enrichment hides block, Mo-100 enrichment renders chips with safety attrs + flag tooltip, Isoflex href is the top-level URL).

Out of scope per #66 P1/P2: country filter, top-level Sourcing tab, form-factor info, scraping, prices.

Round-1 review by a generalist agent flagged three nice-to-haves (tie-break, sanctions-tooltip e2e assertion, runtime flag.type check) — all addressed in the final commit.

## Test plan

- [x] `npm test` (frontend) — 372 passing including 18 new in `suppliers.test.ts`
- [x] `npx playwright test e2e/material-supplier-chips.spec.ts` — 3/3
- [x] `node frontend/scripts/check-suppliers-fresh.mjs` — fresh (0 days)
- [x] svelte-check — no new errors (2 pre-existing on main)
- [x] Manual: opening an enriched ¹⁰⁰Mo target shows chips that link out to each supplier in a new tab; JSC chip is visually distinct + tooltip mentions sanctions