### PR TITLE
ci(release): install Tauri Linux deps for parity job

### DIFF
--- a/.github/workflows/release-hyrr-mcp.yml
+++ b/.github/workflows/release-hyrr-mcp.yml
@@ -127,6 +127,15 @@ jobs:
         with:
           python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install Tauri Linux build deps (for desktop --mcp build)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev
       - name: Build hyrr-mcp (Rust standalone) + desktop --mcp
         run: |
           (cd hyrr-mcp && cargo build --release)


### PR DESCRIPTION
## Summary
- The parity job in `release-hyrr-mcp.yml` builds the desktop binary so the parity script can diff `hyrr --mcp` against the standalone `hyrr-mcp` and the wheel.
- On `ubuntu-latest`, the desktop build pulls Tauri 2 → glib-sys/webkit2gtk-sys, which fail without GTK system libs.
- Add the standard Tauri 2 Linux dep set before building.

Refs: #71

## Test plan
- [ ] Re-tag `hyrr-mcp-v0.1.0` after merge; parity job should now compile desktop and emit byte-identical MCP responses across all three entry points.