### PR TITLE
chore: default to tendl-2025 across all surfaces (#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Pure Python package for predicting radio-isotope production in stacked target as
 ## Data
 
 - **nucl-parquet** (`../nucl-parquet/`) — standalone repo with 12 evaluated nuclear data libraries (TENDL, ENDF/B, JENDL, JEFF, EXFOR, etc.)
-- Default library: `tendl-2024` (configurable via `DataStore(data_dir, library="...")`, `--library` CLI flag, or `HYRR_LIBRARY` env var)
+- Default library: `tendl-2025` (configurable via `DataStore(data_dir, library="...")`, `--library` CLI flag, or `HYRR_LIBRARY` env var)
 - Data resolution order: `--data-dir` arg > `HYRR_DATA` env > `../nucl-parquet` sibling > `~/.hyrr/nucl-parquet`
 - `frontend/public/data/parquet/` — Parquet files served as static assets for the browser frontend (hyparquet)
 - Stopping power source: PSTAR/ASTAR from libdEdx (APTG/libdedx), shared across all libraries

--- a/core/examples/probe_cooltime.rs
+++ b/core/examples/probe_cooltime.rs
@@ -10,7 +10,7 @@ use hyrr_core::types::*;
 fn run(cool_s: f64) {
     let data_dir =
         std::env::var("HYRR_DATA").unwrap_or_else(|_| "../nucl-parquet/data".to_string());
-    let mut db = ParquetDataStore::new(&data_dir, "tendl-2024").unwrap();
+    let mut db = ParquetDataStore::new(&data_dir, "tendl-2025").unwrap();
     db.load_xs("p", 1).unwrap();
     db.load_xs("p", 8).unwrap();
 

--- a/core/examples/probe_table.rs
+++ b/core/examples/probe_table.rs
@@ -10,7 +10,7 @@ use hyrr_core::types::*;
 fn main() {
     let data_dir =
         std::env::var("HYRR_DATA").unwrap_or_else(|_| "../nucl-parquet/data".to_string());
-    let mut db = ParquetDataStore::new(&data_dir, "tendl-2024").unwrap();
+    let mut db = ParquetDataStore::new(&data_dir, "tendl-2025").unwrap();
     db.load_xs("p", 1).unwrap();
     db.load_xs("p", 8).unwrap();
     db.load_xs("p", 13).unwrap();

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -31,7 +31,7 @@ pub trait DatabaseProtocol: Send + Sync {
     fn get_element_symbol(&self, z: u32) -> String;
     fn get_element_z(&self, symbol: &str) -> u32;
 
-    /// Nuclear data library identifier (e.g. "tendl-2024"). Used so MCP
+    /// Nuclear data library identifier (e.g. "tendl-2025"). Used so MCP
     /// tool responses can echo which library fed the calculation.
     fn library(&self) -> &str;
 }

--- a/core/src/mcp/transport.rs
+++ b/core/src/mcp/transport.rs
@@ -68,9 +68,9 @@ const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
 /// Default nuclear data library when none is specified.
-pub const DEFAULT_LIBRARY: &str = "tendl-2024";
+pub const DEFAULT_LIBRARY: &str = "tendl-2025";
 
-/// Run the MCP stdio server loop with the default library (`tendl-2024`).
+/// Run the MCP stdio server loop with the default library (`tendl-2025`).
 ///
 /// Convenience wrapper around [`run_mcp_server_with_library`].
 pub fn run_mcp_server(data_dir: &str) {
@@ -79,7 +79,7 @@ pub fn run_mcp_server(data_dir: &str) {
 
 /// Run the MCP stdio server loop pinned to `library`.
 ///
-/// `library` is the data-library identifier (e.g. `"tendl-2024"`,
+/// `library` is the data-library identifier (e.g. `"tendl-2025"`,
 /// `"endfb-8.1"`); it must correspond to a `<data_dir>/<library>/` tree.
 /// The server's `library_used` echo footer reflects this value, and every
 /// tool's data fetches happen against this library for the lifetime of

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -74,7 +74,7 @@ fn seed_cache_from_resources(app: &tauri::App) {
 }
 
 /// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`
-/// env → `tendl-2024` (DEFAULT_LIBRARY).
+/// env → `tendl-2025` (DEFAULT_LIBRARY).
 fn resolve_mcp_library(args: &[String]) -> String {
     if args.len() >= 2 {
         for i in 0..args.len() - 1 {

--- a/docs/frontend/webapp.md
+++ b/docs/frontend/webapp.md
@@ -20,7 +20,7 @@ The HYRR web app is a standalone browser application for radioisotope production
 
 ## Supported nuclear data
 
-Default library: **TENDL-2024**. Cross-sections, stopping powers, abundances, and decay data are loaded as Parquet files via hyparquet and cached in the browser.
+Default library: **TENDL-2025**. Cross-sections, stopping powers, abundances, and decay data are loaded as Parquet files via hyparquet and cached in the browser.
 
 ## Bug reports
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,11 +48,11 @@ The Python CLI populates the same managed cache the desktop app uses:
 
 ```bash
 hyrr fetch-data                       # default: meta + stopping
-hyrr fetch-data --library tendl-2024  # specific library (~50 MB)
+hyrr fetch-data --library tendl-2025  # specific library (~50 MB)
 hyrr fetch-data --all                 # every library (~400 MB)
 ```
 
-The default library is `tendl-2024`. Override with `--library` or `HYRR_LIBRARY` env var. The cache is sentinel-protected: a partial download or interrupted extract leaves the dir behind for cleanup but is never picked up as a usable cache.
+The default library is `tendl-2025`. Override with `--library` or `HYRR_LIBRARY` env var. The cache is sentinel-protected: a partial download or interrupted extract leaves the dir behind for cleanup but is never picked up as a usable cache.
 
 ### Air-gapped install
 

--- a/frontend/src/lib/components/HelpModal.svelte
+++ b/frontend/src/lib/components/HelpModal.svelte
@@ -71,7 +71,7 @@
     <section>
       <h3>Nuclear data</h3>
       <p>
-        Cross-sections from <strong>TENDL-2024</strong>, stopping powers from <strong>PSTAR/ASTAR</strong> tabulated data
+        Cross-sections from <strong>TENDL-2025</strong>, stopping powers from <strong>PSTAR/ASTAR</strong> tabulated data
         with velocity scaling for heavier projectiles (more accurate than Bethe-Bloch, especially at low energies relevant to cyclotron targetry).
         Data is loaded as Parquet files and cached in your browser (IndexedDB).
       </p>

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -47,7 +47,7 @@ export async function initBackend(
   if (isTauri()) {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      const lib = library ?? "tendl-2024";
+      const lib = library ?? "tendl-2025";
 
       // #52: cache check before init. `data_ready` is cheap (file-existence
       // only), so we pay nothing on the returning-user path. When the cache
@@ -82,7 +82,7 @@ export async function initBackend(
     if (typeof wasm.default === "function") {
       await wasm.default();
     }
-    wasmStore = new wasm.WasmDataStore(library ?? "tendl-2024");
+    wasmStore = new wasm.WasmDataStore(library ?? "tendl-2025");
 
     // Feed data from existing TS DataStore (hyparquet)
     onProgress?.("Loading nuclear data for WASM...", 0.3);

--- a/hyrr-mcp/src/main.rs
+++ b/hyrr-mcp/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 }
 
 /// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`
-/// env → `tendl-2024` (DEFAULT_LIBRARY).
+/// env → `tendl-2025` (DEFAULT_LIBRARY).
 fn resolve_library(args: &[String]) -> String {
     if args.len() >= 2 {
         for i in 0..args.len() - 1 {
@@ -49,7 +49,7 @@ fn print_help() {
          \n\
          OPTIONS:\n    \
              --data-dir <PATH>  Override nucl-parquet data directory\n    \
-             --library <ID>     Nuclear data library, e.g. tendl-2024 (default), endfb-8.1\n    \
+             --library <ID>     Nuclear data library, e.g. tendl-2025 (default), endfb-8.1\n    \
              --version, -V      Print version and exit\n    \
              --help, -h         Print this help and exit\n\
          \n\

--- a/packages/compute/src/node-data-store.ts
+++ b/packages/compute/src/node-data-store.ts
@@ -65,7 +65,7 @@ async function readParquetFile(filePath: string): Promise<ParquetRow[]> {
  * Priority: explicit arg > HYRR_DATA env > ../nucl-parquet sibling > ~/.hyrr/nucl-parquet
  */
 export function resolveDataDir(dataDir?: string, library?: string): string {
-  const lib = library ?? process.env.HYRR_LIBRARY ?? "tendl-2024";
+  const lib = library ?? process.env.HYRR_LIBRARY ?? "tendl-2025";
 
   if (dataDir) {
     return resolve(dataDir, lib);

--- a/py-mcp/src/lib.rs
+++ b/py-mcp/src/lib.rs
@@ -24,7 +24,7 @@ fn resolve_data_dir() -> String {
     hyrr_core::data_dir::resolve()
 }
 
-/// Default nuclear data library identifier (e.g. "tendl-2024").
+/// Default nuclear data library identifier (e.g. "tendl-2025").
 #[pyfunction]
 fn default_library() -> &'static str {
     hyrr_core::mcp::transport::DEFAULT_LIBRARY

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -30,7 +30,7 @@ struct PyDataStore {
 #[pymethods]
 impl PyDataStore {
     #[new]
-    #[pyo3(signature = (data_dir, library="tendl-2024"))]
+    #[pyo3(signature = (data_dir, library="tendl-2025"))]
     fn new(data_dir: &str, library: &str) -> PyResult<Self> {
         let store = ParquetDataStore::new(data_dir, library)
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;

--- a/src/hyrr/cli.py
+++ b/src/hyrr/cli.py
@@ -31,7 +31,7 @@ def main(argv: list[str] | None = None) -> int:
         "--library",
         type=str,
         default=None,
-        help="Cross-section library (default: tendl-2024)",
+        help="Cross-section library (default: tendl-2025)",
     )
 
     # hyrr run
@@ -47,7 +47,7 @@ def main(argv: list[str] | None = None) -> int:
         "--library",
         type=str,
         default=None,
-        help="Cross-section library (default: tendl-2024)",
+        help="Cross-section library (default: tendl-2025)",
     )
     run_parser.add_argument(
         "--output-dir", type=Path, default=None, help="Output directory"

--- a/src/hyrr/db.py
+++ b/src/hyrr/db.py
@@ -11,7 +11,7 @@ import numpy as np
 import numpy.typing as npt
 import polars as pl
 
-DEFAULT_LIBRARY = "tendl-2024"
+DEFAULT_LIBRARY = "tendl-2025"
 
 
 def load_catalog(data_dir: str | Path) -> dict[str, Any]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,7 +131,7 @@ class TestCLIInfo:
         meta.mkdir()
         stopping = tmp_path / "stopping"
         stopping.mkdir()
-        xs = tmp_path / "tendl-2024" / "xs"
+        xs = tmp_path / "tendl-2025" / "xs"
         xs.mkdir(parents=True)
 
         pl.DataFrame({"Z": [42], "symbol": ["Mo"]}).cast({"Z": pl.Int32}).write_parquet(


### PR DESCRIPTION
Closes #91.

## Summary

TENDL-2025 has been in the `nucl-parquet` submodule (`data/tendl-2025/`) for a while, but every code default and doc still pointed at TENDL-2024. This PR flips the default everywhere so a fresh user gets the newest evaluation. Explicit overrides (`--library`, `HYRR_LIBRARY` env, constructor args) continue to work unchanged.

17 files, 22 lines — see the commit message for the full inventory by surface (Python lib, pyo3, Rust core/MCP, Tauri, WASM, Node, frontend, examples, docs, CLAUDE.md, one test fixture).

## Why a single PR

Default is a public-facing knob — the moment any one surface flips, downstream tools (MCP server, Tauri app, browser frontend, hyrr-mcp CLI) become inconsistent with each other. Bundling keeps the user-visible default coherent.

## Test plan

- [x] `cargo build` (core, hyrr-mcp) clean
- [x] `cargo test --lib` — 23/23 pass
- [x] `npm run --workspace=frontend test` — 385/385 pass
- [x] `uv run pytest tests/ --ignore=tests/integration` — 303/303 pass
- [ ] Manual: open the frontend with no `HYRR_LIBRARY` set, confirm the help modal shows TENDL-2025 and a simulation runs
- [ ] Manual: `hyrr info` (no `--library`) resolves to `tendl-2025/`