### PR TITLE
fix(data-dir): probe data/meta for v0.6.0+ nucl-parquet layout (#51)

### DIFF
--- a/core/src/data_dir.rs
+++ b/core/src/data_dir.rs
@@ -28,20 +28,27 @@ pub fn resolve() -> String {
     let exe_path = std::env::current_exe().unwrap_or_default();
     let exe_dir = exe_path.parent().unwrap_or(std::path::Path::new("."));
 
+    // The v0.6.0+ nucl-parquet layout puts everything under `data/`
+    // (`data/meta/`, `data/tendl-2025/`, `data/stopping/`, …). Earlier
+    // versions had `meta/` at the root, which is what the previous
+    // probe checked — that probe never matched on a current clone, so
+    // the resolver fell through to the literal `"nucl-parquet"` and
+    // every Tauri/MCP launch from outside the dev tree silently
+    // failed. Probe `data/meta` instead.
     for candidate in &[
         exe_dir.join("../../../nucl-parquet"),
         exe_dir.join("../../nucl-parquet"),
         std::path::PathBuf::from("nucl-parquet"),
         std::path::PathBuf::from("../nucl-parquet"),
     ] {
-        if candidate.join("meta").exists() {
+        if candidate.join("data/meta").exists() {
             return candidate.to_string_lossy().to_string();
         }
     }
 
     if let Ok(home) = std::env::var("HOME") {
         let path = format!("{}/.hyrr/nucl-parquet", home);
-        if std::path::Path::new(&path).join("meta").exists() {
+        if std::path::Path::new(&path).join("data/meta").exists() {
             return path;
         }
     }


### PR DESCRIPTION
Closes #51.

## Summary

`hyrr_core::data_dir::resolve()` was probing `<candidate>/meta/` to detect a usable nucl-parquet directory, but the nucl-parquet v0.6.0 release moved everything under `data/` — the actual layout marker is `<candidate>/data/meta/`. Since v0.6.0 the probe has never matched on any candidate, so the resolver fell through to the literal `"nucl-parquet"`, which resolves against the launch CWD (= `/` when Tauri is launched from Finder) and silently breaks both:

- The desktop GUI's native Rust compute path (`init_data_store("nucl-parquet")` fails → frontend silently falls back to WASM).
- `--mcp` mode entirely.

The same class of bug was fixed earlier in `src/hyrr/cli.py` and `tests/integration/conftest.py`; the shared Rust resolver was missed. This PR updates both probes (the sibling-clone candidates and the `~/.hyrr/nucl-parquet` fallback) to check `data/meta`.

Prerequisite for #52 (lazy HTTP-range parquet cache).

## Test plan

- [x] `cargo build` / `cargo test --lib` — clean
- [ ] Manual: launch installed Tauri app from Finder with `~/.hyrr/nucl-parquet/data/...` populated, confirm native engine initializes (no silent WASM fallback)
- [ ] Manual: run `hyrr --mcp` from outside the dev tree with `HYRR_DATA` unset, confirm it finds the sibling clone instead of dying on `"nucl-parquet"`