### PR TITLE
feat(pwa): add manifest + iOS meta tags for "Add to Home Screen" (#34)

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -50,6 +50,17 @@
 
     <link rel="icon" type="image/svg+xml" href="/hyrr/favicon.svg" />
     <link rel="apple-touch-icon" href="/hyrr/hyrr-icon-180.png" />
+
+    <!-- PWA installability: lets users "Add to Home Screen" on iOS Safari
+         and Chrome Android, and run in standalone mode (no browser chrome).
+         Service-worker caching is already handled by /hyrr/sw.js. -->
+    <link rel="manifest" href="/hyrr/manifest.webmanifest" />
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0f1117" media="(prefers-color-scheme: dark)" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-title" content="HYRR" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   </head>
   <body>
     <script>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "HYRR — Radioisotope Production Calculator",
+  "short_name": "HYRR",
+  "description": "Browser-based calculator for radioisotope production yields in stacked target assemblies. Cross-sections from TENDL, stopping powers from PSTAR/ASTAR, Bateman decay chains. Runs entirely in your browser — no server, no data upload.",
+  "start_url": "/hyrr/",
+  "scope": "/hyrr/",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#0f1117",
+  "background_color": "#0f1117",
+  "categories": ["education", "science", "utilities"],
+  "icons": [
+    {
+      "src": "/hyrr/hyrr-icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/hyrr/hyrr-icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #34 (browser/PWA half).

## Summary

The original #34 reporter hit the app on iPhone Safari. Service-worker caching for `.parquet`/`.wasm`/JS bundles already exists in `frontend/public/sw.js`, so the only piece blocking offline use was installability — no `manifest.webmanifest`, no iOS standalone meta tags, so "Add to Home Screen" launched as a normal Safari bookmark.

This PR closes the browser half:
- `frontend/public/manifest.webmanifest` — `name`, `short_name=HYRR`, `scope=/hyrr/`, `display=standalone`, 192/512 icons, theme/background `#0f1117` (matches the default dark theme).
- `<link rel="manifest">` in `index.html`.
- `theme-color` meta tags with `prefers-color-scheme` media queries so the status bar tracks light/dark.
- `mobile-web-app-capable` + the `apple-mobile-web-app-*` set so iOS Safari launches standalone with the app title "HYRR".

The desktop/Tauri half of #34 was already split into #51 (path resolver — landed in #114) and #52 (lazy parquet cache — spike pending).

## Test plan

- [x] `npm run --workspace=frontend test` — 385/385 pass
- [x] `npm run --workspace=frontend build` — clean; manifest is copied to `dist/`, all meta tags present in built `index.html`
- [ ] Manual: deploy preview, open on iPhone Safari, confirm "Add to Home Screen" → app launches in standalone mode with no browser chrome
- [ ] Manual: same on Chrome Android, confirm install prompt appears and PWA installs
- [ ] Manual: Lighthouse PWA audit on the deploy preview