### PR TITLE
feat(core): lazy nuclear-data cache with bundled meta+stopping (#52)

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -260,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +282,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -312,6 +324,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -378,10 +396,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -395,8 +451,76 @@ version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rustc_version",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -406,8 +530,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -417,9 +543,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -447,16 +575,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "hyrr-core"
 version = "0.1.0"
 dependencies = [
  "approx",
  "arrow",
+ "fs2",
  "parquet",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
+ "tar",
+ "tempfile",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -484,6 +715,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +832,22 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -601,16 +951,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num"
@@ -737,10 +1128,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -749,6 +1176,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -765,6 +1247,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "regex"
@@ -796,12 +1316,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -872,6 +1500,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,16 +1524,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -904,6 +1578,50 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -947,6 +1665,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,10 +1800,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -994,6 +1864,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1027,6 +1911,57 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1088,10 +2023,205 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1107,6 +2237,66 @@ name = "zerocopy-derive"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,5 +21,14 @@ parquet = { version = "54", default-features = false, features = ["arrow", "snap
 arrow = { version = "54", default-features = false, features = ["csv", "json"], optional = true }
 regex = "1"
 
+# Native-only deps for the lazy data-fetch path (#52). Gated so wasm32
+# consumers don't pull reqwest/tar/zstd into their dependency graph.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+tar = "0.4"
+zstd = "0.13"
+fs2 = "0.4"
+
 [dev-dependencies]
 approx = "0.5"
+tempfile = "3"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,0 +1,74 @@
+//! Sync `DATA_VERSION` (used by `data_fetch.rs` to build the GitHub
+//! Releases URL) from the pinned `nucl-parquet/` submodule's
+//! pyproject.toml. The submodule is the single source of truth.
+//!
+//! Why this exists: the previous setup had `DATA_VERSION` as a
+//! hand-maintained `pub const` next to a submodule pin. The same class
+//! of drift just bit us in #117 (default library `tendl-2024` vs docs
+//! `tendl-2025`); this prevents the analogous bug for data version.
+//!
+//! On a fresh clone without `--recurse-submodules` the file is missing
+//! — we emit a warning and fall back to a sentinel version so wasm/CI
+//! builds that don't actually call the network path still compile.
+//! Native paths that *do* hit the network would then 404 visibly,
+//! which is a clearer failure mode than a silent stale download.
+
+use std::path::Path;
+
+fn main() {
+    let pyproject = Path::new("../nucl-parquet/pyproject.toml");
+    println!("cargo:rerun-if-changed=../nucl-parquet/pyproject.toml");
+
+    let version = match std::fs::read_to_string(pyproject) {
+        Ok(s) => extract_project_version(&s).unwrap_or_else(|| {
+            println!(
+                "cargo:warning=core/build.rs: could not parse [project].version from {}; \
+                 falling back to 0.0.0-unknown. Bump the submodule cleanly.",
+                pyproject.display()
+            );
+            "0.0.0-unknown".to_string()
+        }),
+        Err(_) => {
+            println!(
+                "cargo:warning=core/build.rs: {} not found — submodule not checked out? \
+                 Falling back to 0.0.0-unknown. Run `git submodule update --init --recursive`.",
+                pyproject.display()
+            );
+            "0.0.0-unknown".to_string()
+        }
+    };
+
+    println!("cargo:rustc-env=HYRR_DATA_VERSION={version}");
+}
+
+/// Tiny TOML walker — avoids pulling a `toml` build-dep for one
+/// version string. Handles the standard pyproject layout: top-level
+/// `[project]` section with `version = "..."`. Tolerates leading
+/// whitespace and inline comments after the value.
+fn extract_project_version(content: &str) -> Option<String> {
+    let mut in_project = false;
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.starts_with('[') && line.ends_with(']') {
+            in_project = line == "[project]";
+            continue;
+        }
+        if !in_project {
+            continue;
+        }
+        let Some(rest) = line.strip_prefix("version") else {
+            continue;
+        };
+        let rest = rest.trim_start();
+        let Some(after_eq) = rest.strip_prefix('=') else {
+            continue;
+        };
+        // Strip trailing comment, then surrounding quotes/whitespace.
+        let value = after_eq.split('#').next()?.trim();
+        let trimmed = value.trim_matches('"').trim_matches('\'').trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    None
+}

--- a/core/src/data_dir.rs
+++ b/core/src/data_dir.rs
@@ -28,20 +28,27 @@ pub fn resolve() -> String {
     let exe_path = std::env::current_exe().unwrap_or_default();
     let exe_dir = exe_path.parent().unwrap_or(std::path::Path::new("."));
 
+    // The v0.6.0+ nucl-parquet layout puts everything under `data/`
+    // (`data/meta/`, `data/tendl-2025/`, `data/stopping/`, …). Earlier
+    // versions had `meta/` at the root, which is what the previous
+    // probe checked — that probe never matched on a current clone, so
+    // the resolver fell through to the literal `"nucl-parquet"` and
+    // every Tauri/MCP launch from outside the dev tree silently
+    // failed. Probe `data/meta` instead.
     for candidate in &[
         exe_dir.join("../../../nucl-parquet"),
         exe_dir.join("../../nucl-parquet"),
         std::path::PathBuf::from("nucl-parquet"),
         std::path::PathBuf::from("../nucl-parquet"),
     ] {
-        if candidate.join("meta").exists() {
+        if candidate.join("data/meta").exists() {
             return candidate.to_string_lossy().to_string();
         }
     }
 
     if let Ok(home) = std::env::var("HOME") {
         let path = format!("{}/.hyrr/nucl-parquet", home);
-        if std::path::Path::new(&path).join("meta").exists() {
+        if std::path::Path::new(&path).join("data/meta").exists() {
             return path;
         }
     }

--- a/core/src/data_dir.rs
+++ b/core/src/data_dir.rs
@@ -2,15 +2,30 @@
 //!
 //! Shared between the desktop binary and the standalone `hyrr-mcp`
 //! binary so both pick the same data dir with the same priority.
+//!
+//! ## Contract
+//!
+//! Returns a path that contains `meta/`, `stopping/`, and `<library>/xs/`
+//! directly as immediate subdirectories. This is the path consumed by
+//! `ParquetDataStore::new` (which joins `meta/`, `stopping/`, `<library>/`
+//! to it without further indirection) and by `mcp::transport`'s pre-flight
+//! probe.
+//!
+//! For the v0.6.0+ nucl-parquet layout — where files live under a `data/`
+//! prefix inside a checkout — the returned path is the `data/` directory
+//! itself, not the checkout root.
 
-/// Resolve the nucl-parquet data directory.
+/// Resolve the nucl-parquet data directory. Returns a path that contains
+/// `meta/`, `stopping/`, and `<library>/xs/` as direct children.
 ///
 /// Priority:
-/// 1. `--data-dir <path>` CLI argument
-/// 2. `HYRR_DATA` environment variable
-/// 3. Sibling `nucl-parquet/` relative to the executable (dev layout)
-/// 4. `~/.hyrr/nucl-parquet`
-/// 5. Fallback: `"nucl-parquet"` (relative)
+/// 1. `--data-dir <path>` CLI argument (returned verbatim)
+/// 2. `HYRR_DATA` environment variable (returned verbatim)
+/// 3. Managed cache `~/.hyrr/nucl-parquet/v{DATA_VERSION}/.complete` sentinel
+///    (returned as `<cache>/v{V}/data`) — populated by `data_fetch::ensure_*`.
+/// 4. Sibling `nucl-parquet/data/` relative to the executable (dev layout)
+/// 5. Legacy unmanaged `~/.hyrr/nucl-parquet/data/` (no sentinel)
+/// 6. Fallback: `"nucl-parquet"` (relative; will fail loudly downstream)
 pub fn resolve() -> String {
     let args: Vec<String> = std::env::args().collect();
     if args.len() >= 2 {
@@ -25,16 +40,25 @@ pub fn resolve() -> String {
         return dir;
     }
 
+    // Managed cache: prefer this over dev-tree candidates so a Tauri user
+    // who has both a sibling clone and a populated cache picks the cache
+    // (which the installer/CLI explicitly populated).
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Ok(cache) = crate::data_fetch::cache_dir() {
+        if crate::data_fetch::is_cache_complete() {
+            let data = cache.join("data");
+            if data.is_dir() {
+                return data.to_string_lossy().to_string();
+            }
+        }
+    }
+
     let exe_path = std::env::current_exe().unwrap_or_default();
     let exe_dir = exe_path.parent().unwrap_or(std::path::Path::new("."));
 
-    // The v0.6.0+ nucl-parquet layout puts everything under `data/`
-    // (`data/meta/`, `data/tendl-2025/`, `data/stopping/`, …). Earlier
-    // versions had `meta/` at the root, which is what the previous
-    // probe checked — that probe never matched on a current clone, so
-    // the resolver fell through to the literal `"nucl-parquet"` and
-    // every Tauri/MCP launch from outside the dev tree silently
-    // failed. Probe `data/meta` instead.
+    // Sibling-clone candidates. The v0.6.0+ layout puts data under `data/`
+    // (`data/meta/`, `data/<library>/`, …). Probe `data/meta` to detect the
+    // layout, *return `data/`* — consumers join `meta/` directly to this.
     for candidate in &[
         exe_dir.join("../../../nucl-parquet"),
         exe_dir.join("../../nucl-parquet"),
@@ -42,13 +66,15 @@ pub fn resolve() -> String {
         std::path::PathBuf::from("../nucl-parquet"),
     ] {
         if candidate.join("data/meta").exists() {
-            return candidate.to_string_lossy().to_string();
+            return candidate.join("data").to_string_lossy().to_string();
         }
     }
 
+    // Legacy unmanaged home dir (a user who manually `git clone`d into
+    // `~/.hyrr/nucl-parquet`, no managed sentinel).
     if let Ok(home) = std::env::var("HOME") {
-        let path = format!("{}/.hyrr/nucl-parquet", home);
-        if std::path::Path::new(&path).join("data/meta").exists() {
+        let path = format!("{home}/.hyrr/nucl-parquet/data");
+        if std::path::Path::new(&path).join("meta").exists() {
             return path;
         }
     }

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -39,11 +39,6 @@ pub const DATA_VERSION: &str = "0.9.0";
 /// GitHub Releases base URL for nucl-parquet data tarballs.
 const RELEASE_BASE: &str = "https://github.com/exoma-ch/nucl-parquet/releases/download";
 
-/// Subdirectories that are required by *every* simulation regardless of the
-/// chosen library. Bundled in the Tauri installer; `ensure_meta_stopping`
-/// fetches them only when not already present (e.g. the Python CLI path).
-pub const ALWAYS_NEEDED: &[&str] = &["meta", "stopping"];
-
 /// Errors surfaced by the data-fetch path.
 #[derive(Debug, thiserror::Error)]
 pub enum FetchError {
@@ -122,15 +117,23 @@ pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Extract a `.tar.zst` archive into `dest`, keeping only entries whose
-/// top-level path component is in `keep` (or all entries if `keep` is empty).
+/// Extract a `.tar.zst` archive into `dest`. If `prefixes` is non-empty,
+/// keeps only entries whose path *starts with* one of the listed prefixes
+/// (the prefix is matched as a literal string against the entry path).
+/// Pass `&[]` to extract everything.
 ///
-/// Filters macOS `._*` resource-fork files which sometimes leak into archives
-/// produced on Macs.
+/// Filters macOS `._*` resource-fork files which sometimes leak into
+/// archives produced on Macs.
+///
+/// Path semantics: prefixes match the leading characters of `entry.path()`.
+/// E.g. `"data/tendl-2025/"` matches `data/tendl-2025/xs/p_Cu.parquet` but
+/// not `data/tendl-2024/`. The trailing slash matters — without it,
+/// `"data/tendl-2"` would also match `data/tendl-2024/`. Callers should
+/// always include the slash for directory-scoped extracts.
 pub fn extract_tarball(
     archive: &Path,
     dest: &Path,
-    keep: &[&str],
+    prefixes: &[&str],
 ) -> Result<()> {
     let file = fs::File::open(archive)?;
     let decoder = zstd::stream::Decoder::new(file)
@@ -158,9 +161,19 @@ pub fn extract_tarball(
             continue;
         }
 
-        if !keep.is_empty() {
-            let top = path.components().next().and_then(|c| c.as_os_str().to_str());
-            if !top.map(|t| keep.contains(&t)).unwrap_or(false) {
+        if !prefixes.is_empty() {
+            let path_str = path.to_string_lossy();
+            // A prefix without a trailing slash matches a file (e.g.
+            // "data/catalog.json"); with a trailing slash, only entries
+            // strictly under that directory.
+            let matches = prefixes.iter().any(|p| {
+                if p.ends_with('/') {
+                    path_str.starts_with(p)
+                } else {
+                    path_str == *p || path_str.starts_with(&format!("{p}/"))
+                }
+            });
+            if !matches {
                 continue;
             }
         }
@@ -172,23 +185,22 @@ pub fn extract_tarball(
     Ok(())
 }
 
-/// Atomically install a downloaded tarball into the versioned cache dir.
+/// Atomically install (a subset of) a downloaded tarball into the
+/// versioned cache dir.
 ///
 /// 1. Take the cache lock.
-/// 2. Extract into `<cache_root>/v{V}.partial-{pid}/`.
-/// 3. `fs::rename` to `<cache_root>/v{V}/`.
-/// 4. Write the `.complete` sentinel.
+/// 2. Extract matching entries into `<cache_root>/v{V}.partial-{pid}/`.
+/// 3. Promote: if cache is empty, atomic `fs::rename`. If cache already
+///    exists (merging into a populated cache), drop the sentinel first,
+///    merge entries, then re-write the sentinel last. The window during
+///    which sentinel is missing is the only window during which a
+///    concurrent reader sees the cache as incomplete — never as
+///    "complete-but-half-merged".
 ///
-/// `keep` filters which top-level directories from the archive are extracted;
-/// pass `&[]` to extract everything.
-fn install_tarball_atomic(archive: &Path, keep: &[&str]) -> Result<()> {
+/// `prefixes`: same semantics as `extract_tarball` — empty extracts
+/// everything, a list of strings filters by `starts_with`.
+fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
     let _lock = acquire_lock()?;
-
-    // Re-check sentinel under the lock — another caller may have raced us
-    // and finished while we were blocked.
-    if is_cache_complete() && keep.is_empty() {
-        return Ok(());
-    }
 
     let cache = cache_dir()?;
     let root = cache_root()?;
@@ -201,30 +213,29 @@ fn install_tarball_atomic(archive: &Path, keep: &[&str]) -> Result<()> {
         fs::remove_dir_all(&partial)?;
     }
 
-    // The tarball's contents live under a `data/` prefix in the archive.
-    // We want them under `<cache_dir>/data/...` to match the existing
-    // resolver expectation, so extract into the partial dir as-is.
-    extract_tarball(archive, &partial, keep)?;
+    extract_tarball(archive, &partial, prefixes)?;
 
     // If `cache` already exists but is incomplete, blow it away — its
     // contents are by definition stale (the sentinel would be present
-    // otherwise). Selective merge would be a P2 optimisation.
+    // otherwise).
     if cache.exists() && !is_cache_complete() {
         fs::remove_dir_all(&cache)?;
     }
 
-    // For library-only fetches we may have an existing complete cache
-    // we want to merge into, not replace. Detect by `keep` being non-empty.
-    if !keep.is_empty() && cache.exists() {
-        // Move each entry under partial into cache, overwriting.
+    if cache.exists() {
+        // Merge into an already-populated cache. Drop the sentinel BEFORE
+        // touching cache contents so a mid-merge crash leaves the cache
+        // visibly incomplete rather than "complete but corrupt".
+        let sentinel = sentinel_path()?;
+        let _ = fs::remove_file(&sentinel);
         merge_dir_into(&partial, &cache)?;
         fs::remove_dir_all(&partial)?;
     } else {
         fs::rename(&partial, &cache)?;
     }
 
-    // Write sentinel last — its existence is the contract for "this cache
-    // is fully usable".
+    // Write sentinel last — its existence is the contract for
+    // "this cache is fully usable".
     fs::write(sentinel_path()?, DATA_VERSION)?;
     Ok(())
 }
@@ -241,8 +252,10 @@ fn merge_dir_into(src: &Path, dst: &Path) -> Result<()> {
         if entry.file_type()?.is_dir() {
             merge_dir_into(&from, &to)?;
         } else {
-            // `rename` is atomic across the same filesystem.
-            // Fall back to copy+delete if rename fails (e.g. crossing FS).
+            // Overwrite an existing file by removing it first — `rename`
+            // on most platforms requires the destination not exist (or
+            // be empty). Cross-FS: fall back to copy+delete.
+            let _ = fs::remove_file(&to);
             if fs::rename(&from, &to).is_err() {
                 fs::copy(&from, &to)?;
                 fs::remove_file(&from)?;
@@ -252,9 +265,25 @@ fn merge_dir_into(src: &Path, dst: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Ensure the `meta/` and `stopping/` directories are present in the cache.
+/// Path prefixes that always need to be present for any simulation.
+/// `meta/` and `stopping/` are required by every library; the catalog
+/// and supplier JSONs are read by frontend code and need to live in
+/// the same data dir.
+const MANDATORY_PREFIXES: &[&str] = &[
+    "data/meta/",
+    "data/stopping/",
+    "data/catalog.json",
+    "data/suppliers.json",
+];
+
+/// Ensure the `meta/` and `stopping/` directories (plus catalog/suppliers
+/// JSON) are present in the cache.
 ///
-/// Idempotent: returns immediately if the sentinel already exists.
+/// Idempotent: returns immediately if the sentinel already exists. If
+/// the cache is incomplete, fetches the full release tarball and
+/// extracts only the mandatory prefixes — disk write is bounded to
+/// ~54 MB even though the download itself is the full ~400 MB until
+/// upstream ships per-library tarballs.
 pub fn ensure_meta_stopping() -> Result<()> {
     if is_cache_complete() {
         return Ok(());
@@ -265,17 +294,22 @@ pub fn ensure_meta_stopping() -> Result<()> {
     }
     let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
     fetch_full_tarball_to(&tmp)?;
-    install_tarball_atomic(&tmp, &["data"])?;
+    install_tarball_atomic(&tmp, MANDATORY_PREFIXES)?;
     let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
-/// Ensure the given library's `xs/` directory is present in the cache.
+/// Ensure the given library's data is present in the cache.
 ///
-/// Currently fetches the full tarball and extracts only the `data/<library>/`
-/// subtree (plus `data/meta`/`data/stopping` if missing). When upstream ships
-/// per-library tarballs, this is the function whose URL changes — callers
-/// shouldn't notice.
+/// On a cold cache fetches the full release tarball but extracts only the
+/// requested library's subtree plus the mandatory `meta/`/`stopping/` —
+/// disk write bounded to ~50–110 MB rather than the full 400 MB. When
+/// upstream ships per-library tarballs, only the URL changes here.
+///
+/// On a warm cache (sentinel present) where the library is already
+/// extracted, returns immediately. If the sentinel is present but the
+/// library subtree is absent (the bundled-resources-on-installer case),
+/// fetches and merges only that library into the cache.
 pub fn ensure_library(library: &str) -> Result<()> {
     if is_cache_complete() && cache_dir()?.join("data").join(library).exists() {
         return Ok(());
@@ -286,8 +320,46 @@ pub fn ensure_library(library: &str) -> Result<()> {
     }
     let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
     fetch_full_tarball_to(&tmp)?;
-    install_tarball_atomic(&tmp, &["data"])?;
+    let lib_prefix = format!("data/{library}/");
+    let mut prefixes: Vec<&str> = MANDATORY_PREFIXES.to_vec();
+    prefixes.push(&lib_prefix);
+    install_tarball_atomic(&tmp, &prefixes)?;
     let _ = fs::remove_file(&tmp);
+    Ok(())
+}
+
+/// Ensure *every* library is present in the cache. This is the path the
+/// `hyrr fetch-data --all` flag wires into — extracts the whole tarball,
+/// roughly 400 MB on disk.
+///
+/// Idempotent: returns immediately if the sentinel is present AND every
+/// known library directory exists. (We can't enumerate libraries without
+/// reading the catalog, so we trust the sentinel + a no-op merge: the
+/// re-extraction overwrites identical bytes which is harmless.)
+pub fn ensure_all() -> Result<()> {
+    let _lock = acquire_lock()?;
+    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    fetch_full_tarball_to(&tmp)?;
+    install_tarball_atomic(&tmp, &[])?;
+    let _ = fs::remove_file(&tmp);
+    Ok(())
+}
+
+/// Mark the cache as complete *without* fetching anything. Used by the
+/// Tauri startup hook after copying bundled `meta/`+`stopping/` resources
+/// from the installer into the cache. The downstream `ensure_library`
+/// path is then responsible for fetching per-library data on demand.
+///
+/// Caller must hold no other lock (this acquires the cache lock itself).
+pub fn mark_cache_seeded() -> Result<()> {
+    let _lock = acquire_lock()?;
+    let cache = cache_dir()?;
+    if !cache.join("data/meta").is_dir() || !cache.join("data/stopping").is_dir() {
+        return Err(FetchError::Io(io::Error::other(
+            "mark_cache_seeded: data/meta or data/stopping not present",
+        )));
+    }
+    fs::write(sentinel_path()?, DATA_VERSION)?;
     Ok(())
 }
 

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -31,10 +31,12 @@ use fs2::FileExt;
 
 /// Version of the `nucl-parquet` data this build expects.
 ///
-/// MUST match the version of the pinned `nucl-parquet/` submodule. When
-/// bumping the submodule, also bump this constant. Mismatch will produce a
-/// 404 from GitHub Releases at fetch time, which is detectable but ugly.
-pub const DATA_VERSION: &str = "0.9.0";
+/// Sourced at build time from `nucl-parquet/pyproject.toml` by
+/// `core/build.rs` — the submodule pin is the single source of truth.
+/// On a fresh clone without `--recurse-submodules` this falls back to
+/// `"0.0.0-unknown"` (a deliberately invalid version that 404s loudly
+/// at fetch time rather than serving stale data).
+pub const DATA_VERSION: &str = env!("HYRR_DATA_VERSION");
 
 /// GitHub Releases base URL for nucl-parquet data tarballs.
 const RELEASE_BASE: &str = "https://github.com/exoma-ch/nucl-parquet/releases/download";
@@ -598,6 +600,23 @@ mod tests {
         assert!(cd.ends_with(format!("v{DATA_VERSION}")));
         let s = sentinel_path().unwrap();
         assert!(s.ends_with(".complete"));
+    }
+
+    /// `DATA_VERSION` is sourced from `nucl-parquet/pyproject.toml` by
+    /// `core/build.rs`. If the submodule is missing at build time, the
+    /// fallback `"0.0.0-unknown"` ships, which would silently 404 on
+    /// every fetch. Catch that in CI by asserting the version parses
+    /// as N.N.N. The fallback `0.0.0-unknown` fails the dot-count check.
+    #[test]
+    fn data_version_is_resolved_from_submodule() {
+        assert_ne!(DATA_VERSION, "0.0.0-unknown",
+            "build.rs fell back — submodule not checked out at build time");
+        let parts: Vec<&str> = DATA_VERSION.split('.').collect();
+        assert_eq!(parts.len(), 3, "DATA_VERSION = {DATA_VERSION:?} is not N.N.N");
+        for p in &parts {
+            assert!(p.chars().all(|c| c.is_ascii_digit()),
+                "DATA_VERSION component {p:?} not numeric");
+        }
     }
 
     #[test]

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -96,6 +96,41 @@ fn acquire_lock() -> Result<fs::File> {
     Ok(lock)
 }
 
+/// Build a configured reqwest client for cache fetches.
+///
+/// - `User-Agent`: GitHub increasingly rate-limits UA-less clients.
+/// - `connect_timeout(30s)`: a half-open TCP socket on flaky Wi-Fi
+///   would otherwise hang the splash until the App.svelte wall clock
+///   fires (5 min) with no progress.
+/// - No read timeout: a slow-but-progressing 400 MB download on a
+///   rural DSL line should not be killed mid-stream.
+fn build_http_client() -> reqwest::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .user_agent(concat!("hyrr/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .build()
+}
+
+/// Drop guard that removes `path` when it goes out of scope. Used so
+/// the partial tarball is cleaned up on every code path — including
+/// disk-full / network-drop / panic — without each caller needing to
+/// remember `let _ = fs::remove_file(&tmp)`.
+struct TmpFileGuard {
+    path: PathBuf,
+}
+
+impl TmpFileGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for TmpFileGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
 /// Download the full nucl-parquet data tarball into `out`.
 ///
 /// Streams the response to disk — does not buffer the full ~400 MB in RAM.
@@ -103,7 +138,10 @@ pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
     let url = format!(
         "{RELEASE_BASE}/v{DATA_VERSION}/nucl-parquet-data-v{DATA_VERSION}.tar.zst"
     );
-    let resp = reqwest::blocking::get(&url)
+    let client = build_http_client().map_err(|e| FetchError::Network(e.to_string()))?;
+    let resp = client
+        .get(&url)
+        .send()
         .map_err(|e| FetchError::Network(e.to_string()))?;
     if !resp.status().is_success() {
         return Err(FetchError::HttpStatus(resp.status().as_u16()));
@@ -115,6 +153,30 @@ pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
     let mut reader = io::BufReader::new(resp);
     io::copy(&mut reader, &mut file)?;
     Ok(())
+}
+
+/// Conservative pre-flight free-space check before downloading the
+/// release tarball. The full release is ~400 MB compressed and ~400 MB
+/// extracted, so 1 GiB is enough headroom while still being safe on
+/// laptops with tight free space. A `disk full` failure mid-`io::copy`
+/// otherwise leaves a partial tarball that the drop-guard cleans up but
+/// also a confusing user-facing error.
+fn require_free_space(min_bytes: u64) -> Result<()> {
+    let root = cache_root()?;
+    fs::create_dir_all(&root)?;
+    match fs2::available_space(&root) {
+        Ok(avail) if avail >= min_bytes => Ok(()),
+        Ok(avail) => Err(FetchError::Io(io::Error::other(format!(
+            "insufficient disk space: have {} MiB free at {}, need at least {} MiB",
+            avail / 1_048_576,
+            root.display(),
+            min_bytes / 1_048_576,
+        )))),
+        // available_space lookup itself failed — proceed and let
+        // io::copy surface the real error rather than blocking on a
+        // diagnostic that didn't work.
+        Err(_) => Ok(()),
+    }
 }
 
 /// Extract a `.tar.zst` archive into `dest`. If `prefixes` is non-empty,
@@ -207,8 +269,20 @@ fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
     let pid = std::process::id();
     let partial = root.join(format!("v{DATA_VERSION}.partial-{pid}"));
 
-    // Clean any stale partial from a previous failed run with the same pid
-    // (vanishingly rare in practice but cheap to handle).
+    // Sweep stale partial dirs left by SIGKILL'd previous runs. The
+    // lock guarantees no other live process is writing one right now,
+    // so any `v{V}.partial-*` we see is genuinely orphaned. Without
+    // this, a crashed extract leaves a ~400 MB carcass per crash that
+    // accumulates forever (pids recycle slowly on macOS).
+    let prefix = format!("v{DATA_VERSION}.partial-");
+    if let Ok(entries) = fs::read_dir(&root) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            if name.to_string_lossy().starts_with(&prefix) {
+                let _ = fs::remove_dir_all(entry.path());
+            }
+        }
+    }
     if partial.exists() {
         fs::remove_dir_all(&partial)?;
     }
@@ -292,10 +366,11 @@ pub fn ensure_meta_stopping() -> Result<()> {
     if is_cache_complete() {
         return Ok(());
     }
+    require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     install_tarball_atomic(&tmp, MANDATORY_PREFIXES)?;
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
@@ -318,13 +393,14 @@ pub fn ensure_library(library: &str) -> Result<()> {
     if is_cache_complete() && cache_dir()?.join("data").join(library).exists() {
         return Ok(());
     }
+    require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     let lib_prefix = format!("data/{library}/");
     let mut prefixes: Vec<&str> = MANDATORY_PREFIXES.to_vec();
     prefixes.push(&lib_prefix);
     install_tarball_atomic(&tmp, &prefixes)?;
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
@@ -338,29 +414,104 @@ pub fn ensure_library(library: &str) -> Result<()> {
 /// re-extraction overwrites identical bytes which is harmless.)
 pub fn ensure_all() -> Result<()> {
     let _lock = acquire_lock()?;
+    require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     install_tarball_atomic(&tmp, &[])?;
-    let _ = fs::remove_file(&tmp);
     Ok(())
 }
 
-/// Mark the cache as complete *without* fetching anything. Used by the
-/// Tauri startup hook after copying bundled `meta/`+`stopping/` resources
-/// from the installer into the cache. The downstream `ensure_library`
-/// path is then responsible for fetching per-library data on demand.
+/// Seed the managed cache from a directory of bundled-installer
+/// resources. Used by the Tauri startup hook to drop the ~54 MB of
+/// `meta/` + `stopping/` (+ catalog/suppliers JSONs) into the cache
+/// without paying the network cost on first launch.
 ///
-/// Caller must hold no other lock (this acquires the cache lock itself).
-pub fn mark_cache_seeded() -> Result<()> {
+/// `src` is the directory containing `meta/`, `stopping/`,
+/// `catalog.json`, `suppliers.json` (i.e. the resource root the Tauri
+/// installer materialised — the equivalent of the upstream
+/// `nucl-parquet/data/` tree).
+///
+/// Atomicity:
+/// - Acquires the cache lock so a concurrent `ensure_library` /
+///   `--mcp` invocation can't `remove_dir_all` the cache mid-copy.
+/// - Re-checks `is_cache_complete()` after acquiring the lock —
+///   another instance may have populated the cache while this one
+///   was contending for the lock. Idempotent on cold and warm caches.
+/// - Validates that at least one regular file landed under both
+///   `meta/` and `stopping/` before writing the sentinel, so a
+///   half-copied seed can't masquerade as a complete cache. Any
+///   error returns without writing the sentinel; the caller is
+///   expected to leave the partial state for `ensure_library` to
+///   wipe on the next fetch.
+pub fn seed_from_dir(src: &Path) -> Result<()> {
     let _lock = acquire_lock()?;
-    let cache = cache_dir()?;
-    if !cache.join("data/meta").is_dir() || !cache.join("data/stopping").is_dir() {
+    if is_cache_complete() {
+        return Ok(());
+    }
+    let cache_data = cache_dir()?.join("data");
+    fs::create_dir_all(&cache_data)?;
+    for child in &["meta", "stopping", "catalog.json", "suppliers.json"] {
+        let from = src.join(child);
+        let to = cache_data.join(child);
+        if to.exists() {
+            continue;
+        }
+        if from.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else if from.is_file() {
+            fs::copy(&from, &to)?;
+        } else {
+            // Missing source — installer didn't ship this resource.
+            // Bail without seeding; ensure_library will fetch from
+            // the network later.
+            return Err(FetchError::Io(io::Error::other(format!(
+                "seed_from_dir: source missing: {}",
+                from.display()
+            ))));
+        }
+    }
+    if !dir_has_any_file(&cache_data.join("meta"))?
+        || !dir_has_any_file(&cache_data.join("stopping"))?
+    {
         return Err(FetchError::Io(io::Error::other(
-            "mark_cache_seeded: data/meta or data/stopping not present",
+            "seed_from_dir: meta/ or stopping/ ended up empty",
         )));
     }
     fs::write(sentinel_path()?, DATA_VERSION)?;
     Ok(())
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+fn dir_has_any_file(p: &Path) -> Result<bool> {
+    if !p.is_dir() {
+        return Ok(false);
+    }
+    for entry in fs::read_dir(p)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        if ft.is_file() {
+            return Ok(true);
+        }
+        if ft.is_dir() && dir_has_any_file(&entry.path())? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 /// Produce a portable tarball of the current cache to `out`. Used by
@@ -547,5 +698,76 @@ mod tests {
         let bundle = std::env::temp_dir().join("offline.tar.zst");
         let err = export_offline_bundle(&bundle).unwrap_err();
         assert!(matches!(err, FetchError::Io(_)));
+    }
+
+    /// `seed_from_dir` should populate the cache, write the sentinel,
+    /// and be idempotent — second call is a no-op once the sentinel
+    /// is present.
+    #[test]
+    fn seed_from_dir_populates_and_marks_complete() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let src = td.path().join("bundle");
+        fs::create_dir_all(src.join("meta")).unwrap();
+        fs::create_dir_all(src.join("stopping")).unwrap();
+        fs::write(src.join("meta/elements.parquet"), b"meta-marker").unwrap();
+        fs::write(src.join("stopping/stopping.parquet"), b"stop-marker").unwrap();
+        fs::write(src.join("catalog.json"), b"{}").unwrap();
+        fs::write(src.join("suppliers.json"), b"{}").unwrap();
+
+        assert!(!is_cache_complete());
+        seed_from_dir(&src).unwrap();
+        assert!(is_cache_complete());
+        let cached = cache_dir().unwrap().join("data/meta/elements.parquet");
+        assert_eq!(fs::read(&cached).unwrap(), b"meta-marker");
+
+        // Idempotent: second call is a no-op.
+        seed_from_dir(&src).unwrap();
+        assert!(is_cache_complete());
+    }
+
+    /// Validation guard: empty `meta/` or `stopping/` must not produce
+    /// a "complete" sentinel — that would let `ensure_library`
+    /// short-circuit on a hollow cache.
+    #[test]
+    fn seed_from_dir_rejects_empty_meta() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let src = td.path().join("bundle");
+        fs::create_dir_all(src.join("meta")).unwrap();
+        fs::create_dir_all(src.join("stopping")).unwrap();
+        fs::write(src.join("stopping/stopping.parquet"), b"stop").unwrap();
+        fs::write(src.join("catalog.json"), b"{}").unwrap();
+        fs::write(src.join("suppliers.json"), b"{}").unwrap();
+        // No file under meta/.
+
+        let err = seed_from_dir(&src).unwrap_err();
+        assert!(matches!(err, FetchError::Io(_)));
+        assert!(!is_cache_complete());
+    }
+
+    /// Stale partial dirs (left by SIGKILL'd previous runs) must be
+    /// swept by `install_tarball_atomic`. Without the sweep these
+    /// accumulate at ~400 MB per crash forever.
+    #[test]
+    fn install_sweeps_orphaned_partial_dirs() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        // Manually plant a stale partial dir from a "previous run" with
+        // a different pid.
+        let root = cache_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+        let stale = root.join(format!("v{DATA_VERSION}.partial-99999"));
+        fs::create_dir_all(&stale).unwrap();
+        fs::write(stale.join("orphan-marker"), b"x").unwrap();
+        assert!(stale.exists());
+
+        install_from_tarball(&archive).unwrap();
+
+        assert!(!stale.exists(), "stale partial-99999 was not swept");
+        assert!(is_cache_complete());
     }
 }

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -1,0 +1,479 @@
+//! Lazy fetch + on-disk cache for nucl-parquet data tarballs.
+//!
+//! Populates `~/.hyrr/nucl-parquet/v{DATA_VERSION}/` from GitHub Releases on
+//! demand. Hardened against the known failure modes of the simpler upstream
+//! pattern (see #52 spike review):
+//!
+//! - **Concurrent invocations**: an exclusive `fs2` file-lock on
+//!   `<cache_root>/.lock` serialises competing extract attempts, so the
+//!   Tauri GUI thread and a `--mcp` thread launched simultaneously can't
+//!   stomp on each other's output.
+//! - **Partial extracts**: tar contents are written to
+//!   `<cache_root>/v{V}.partial-{pid}/`, then atomically renamed to
+//!   `<cache_root>/v{V}/`. A `.complete` sentinel is written *last*; the
+//!   resolver checks for that sentinel rather than relying on the existence
+//!   of `data/meta/`. A network drop or disk-full leaves the partial dir
+//!   behind for cleanup, but never a half-populated final dir.
+//! - **Wrong-version cache from previous installs**: each version has its
+//!   own `v{V}/` dir, so a v0.9.0 install does not interfere with a future
+//!   v0.11.0 install.
+//!
+//! Gated `#[cfg(not(target_arch = "wasm32"))]` — WASM consumers don't have
+//! a filesystem and use a different data-loading path entirely.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use fs2::FileExt;
+
+/// Version of the `nucl-parquet` data this build expects.
+///
+/// MUST match the version of the pinned `nucl-parquet/` submodule. When
+/// bumping the submodule, also bump this constant. Mismatch will produce a
+/// 404 from GitHub Releases at fetch time, which is detectable but ugly.
+pub const DATA_VERSION: &str = "0.9.0";
+
+/// GitHub Releases base URL for nucl-parquet data tarballs.
+const RELEASE_BASE: &str = "https://github.com/exoma-ch/nucl-parquet/releases/download";
+
+/// Subdirectories that are required by *every* simulation regardless of the
+/// chosen library. Bundled in the Tauri installer; `ensure_meta_stopping`
+/// fetches them only when not already present (e.g. the Python CLI path).
+pub const ALWAYS_NEEDED: &[&str] = &["meta", "stopping"];
+
+/// Errors surfaced by the data-fetch path.
+#[derive(Debug, thiserror::Error)]
+pub enum FetchError {
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+    #[error("network error: {0}")]
+    Network(String),
+    #[error("HTTP {0}")]
+    HttpStatus(u16),
+    #[error("decompression error: {0}")]
+    Decompress(String),
+    #[error("tar extraction error: {0}")]
+    Extract(String),
+    #[error("HOME environment variable not set")]
+    NoHome,
+}
+
+pub type Result<T> = std::result::Result<T, FetchError>;
+
+/// Cache root: `~/.hyrr/nucl-parquet/`.
+fn cache_root() -> Result<PathBuf> {
+    let home = std::env::var("HOME").map_err(|_| FetchError::NoHome)?;
+    Ok(PathBuf::from(home).join(".hyrr").join("nucl-parquet"))
+}
+
+/// Versioned cache directory: `~/.hyrr/nucl-parquet/v{DATA_VERSION}/`.
+pub fn cache_dir() -> Result<PathBuf> {
+    Ok(cache_root()?.join(format!("v{DATA_VERSION}")))
+}
+
+/// Path to the `.complete` sentinel inside `cache_dir()`.
+pub fn sentinel_path() -> Result<PathBuf> {
+    Ok(cache_dir()?.join(".complete"))
+}
+
+/// True iff the on-disk cache for the current `DATA_VERSION` is fully
+/// populated (sentinel present).
+pub fn is_cache_complete() -> bool {
+    sentinel_path().map(|p| p.exists()).unwrap_or(false)
+}
+
+/// Acquire an exclusive lock on `<cache_root>/.lock`. Blocks the current
+/// thread until competing fetch attempts release. Drops on `Drop`.
+fn acquire_lock() -> Result<fs::File> {
+    let root = cache_root()?;
+    fs::create_dir_all(&root)?;
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(root.join(".lock"))?;
+    lock.lock_exclusive()
+        .map_err(|e| FetchError::Io(io::Error::other(format!("lock: {e}"))))?;
+    Ok(lock)
+}
+
+/// Download the full nucl-parquet data tarball into `out`.
+///
+/// Streams the response to disk — does not buffer the full ~400 MB in RAM.
+pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
+    let url = format!(
+        "{RELEASE_BASE}/v{DATA_VERSION}/nucl-parquet-data-v{DATA_VERSION}.tar.zst"
+    );
+    let resp = reqwest::blocking::get(&url)
+        .map_err(|e| FetchError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        return Err(FetchError::HttpStatus(resp.status().as_u16()));
+    }
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::File::create(out)?;
+    let mut reader = io::BufReader::new(resp);
+    io::copy(&mut reader, &mut file)?;
+    Ok(())
+}
+
+/// Extract a `.tar.zst` archive into `dest`, keeping only entries whose
+/// top-level path component is in `keep` (or all entries if `keep` is empty).
+///
+/// Filters macOS `._*` resource-fork files which sometimes leak into archives
+/// produced on Macs.
+pub fn extract_tarball(
+    archive: &Path,
+    dest: &Path,
+    keep: &[&str],
+) -> Result<()> {
+    let file = fs::File::open(archive)?;
+    let decoder = zstd::stream::Decoder::new(file)
+        .map_err(|e| FetchError::Decompress(e.to_string()))?;
+    let mut tar = tar::Archive::new(decoder);
+
+    fs::create_dir_all(dest)?;
+    for entry in tar
+        .entries()
+        .map_err(|e| FetchError::Extract(e.to_string()))?
+    {
+        let mut entry = entry.map_err(|e| FetchError::Extract(e.to_string()))?;
+        let path = entry
+            .path()
+            .map_err(|e| FetchError::Extract(e.to_string()))?
+            .into_owned();
+
+        // Skip macOS resource-fork files
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("._"))
+            .unwrap_or(false)
+        {
+            continue;
+        }
+
+        if !keep.is_empty() {
+            let top = path.components().next().and_then(|c| c.as_os_str().to_str());
+            if !top.map(|t| keep.contains(&t)).unwrap_or(false) {
+                continue;
+            }
+        }
+
+        entry
+            .unpack_in(dest)
+            .map_err(|e| FetchError::Extract(e.to_string()))?;
+    }
+    Ok(())
+}
+
+/// Atomically install a downloaded tarball into the versioned cache dir.
+///
+/// 1. Take the cache lock.
+/// 2. Extract into `<cache_root>/v{V}.partial-{pid}/`.
+/// 3. `fs::rename` to `<cache_root>/v{V}/`.
+/// 4. Write the `.complete` sentinel.
+///
+/// `keep` filters which top-level directories from the archive are extracted;
+/// pass `&[]` to extract everything.
+fn install_tarball_atomic(archive: &Path, keep: &[&str]) -> Result<()> {
+    let _lock = acquire_lock()?;
+
+    // Re-check sentinel under the lock — another caller may have raced us
+    // and finished while we were blocked.
+    if is_cache_complete() && keep.is_empty() {
+        return Ok(());
+    }
+
+    let cache = cache_dir()?;
+    let root = cache_root()?;
+    let pid = std::process::id();
+    let partial = root.join(format!("v{DATA_VERSION}.partial-{pid}"));
+
+    // Clean any stale partial from a previous failed run with the same pid
+    // (vanishingly rare in practice but cheap to handle).
+    if partial.exists() {
+        fs::remove_dir_all(&partial)?;
+    }
+
+    // The tarball's contents live under a `data/` prefix in the archive.
+    // We want them under `<cache_dir>/data/...` to match the existing
+    // resolver expectation, so extract into the partial dir as-is.
+    extract_tarball(archive, &partial, keep)?;
+
+    // If `cache` already exists but is incomplete, blow it away — its
+    // contents are by definition stale (the sentinel would be present
+    // otherwise). Selective merge would be a P2 optimisation.
+    if cache.exists() && !is_cache_complete() {
+        fs::remove_dir_all(&cache)?;
+    }
+
+    // For library-only fetches we may have an existing complete cache
+    // we want to merge into, not replace. Detect by `keep` being non-empty.
+    if !keep.is_empty() && cache.exists() {
+        // Move each entry under partial into cache, overwriting.
+        merge_dir_into(&partial, &cache)?;
+        fs::remove_dir_all(&partial)?;
+    } else {
+        fs::rename(&partial, &cache)?;
+    }
+
+    // Write sentinel last — its existence is the contract for "this cache
+    // is fully usable".
+    fs::write(sentinel_path()?, DATA_VERSION)?;
+    Ok(())
+}
+
+/// Recursively move all entries from `src` into `dst`. Used when merging a
+/// library-only fetch into an already-populated cache. Overwrites
+/// destination entries that already exist.
+fn merge_dir_into(src: &Path, dst: &Path) -> Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            merge_dir_into(&from, &to)?;
+        } else {
+            // `rename` is atomic across the same filesystem.
+            // Fall back to copy+delete if rename fails (e.g. crossing FS).
+            if fs::rename(&from, &to).is_err() {
+                fs::copy(&from, &to)?;
+                fs::remove_file(&from)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Ensure the `meta/` and `stopping/` directories are present in the cache.
+///
+/// Idempotent: returns immediately if the sentinel already exists.
+pub fn ensure_meta_stopping() -> Result<()> {
+    if is_cache_complete() {
+        return Ok(());
+    }
+    let _lock = acquire_lock()?;
+    if is_cache_complete() {
+        return Ok(());
+    }
+    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    fetch_full_tarball_to(&tmp)?;
+    install_tarball_atomic(&tmp, &["data"])?;
+    let _ = fs::remove_file(&tmp);
+    Ok(())
+}
+
+/// Ensure the given library's `xs/` directory is present in the cache.
+///
+/// Currently fetches the full tarball and extracts only the `data/<library>/`
+/// subtree (plus `data/meta`/`data/stopping` if missing). When upstream ships
+/// per-library tarballs, this is the function whose URL changes — callers
+/// shouldn't notice.
+pub fn ensure_library(library: &str) -> Result<()> {
+    if is_cache_complete() && cache_dir()?.join("data").join(library).exists() {
+        return Ok(());
+    }
+    let _lock = acquire_lock()?;
+    if is_cache_complete() && cache_dir()?.join("data").join(library).exists() {
+        return Ok(());
+    }
+    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    fetch_full_tarball_to(&tmp)?;
+    install_tarball_atomic(&tmp, &["data"])?;
+    let _ = fs::remove_file(&tmp);
+    Ok(())
+}
+
+/// Produce a portable tarball of the current cache to `out`. Used by
+/// `hyrr fetch-data --offline-bundle out.tar.zst`. The resulting tarball is
+/// drop-in compatible with `install_from_tarball`.
+pub fn export_offline_bundle(out: &Path) -> Result<()> {
+    if !is_cache_complete() {
+        return Err(FetchError::Io(io::Error::other(
+            "cache is not complete; run `hyrr fetch-data` first",
+        )));
+    }
+    let cache = cache_dir()?;
+    if let Some(parent) = out.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = fs::File::create(out)?;
+    let encoder = zstd::stream::Encoder::new(file, 3)
+        .map_err(|e| FetchError::Decompress(e.to_string()))?;
+    let mut tar = tar::Builder::new(encoder.auto_finish());
+    // Walk `cache/data/` and add each entry under the prefix `data/`.
+    let data = cache.join("data");
+    tar.append_dir_all("data", &data)
+        .map_err(|e| FetchError::Extract(e.to_string()))?;
+    tar.finish()
+        .map_err(|e| FetchError::Extract(e.to_string()))?;
+    Ok(())
+}
+
+/// Install from a `.tar.zst` produced by `export_offline_bundle` (or
+/// downloaded manually from a GitHub Release). Atomic + sentinel-protected
+/// just like the network path.
+pub fn install_from_tarball(archive: &Path) -> Result<()> {
+    if !archive.exists() {
+        return Err(FetchError::Io(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("tarball not found: {}", archive.display()),
+        )));
+    }
+    install_tarball_atomic(archive, &["data"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Tests in this module must not run concurrently because they all mess
+    /// with `$HOME` and the cache root.
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    /// Set $HOME to a fresh tempdir for the duration of the test.
+    fn isolated_home() -> tempfile::TempDir {
+        let td = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("HOME", td.path());
+        td
+    }
+
+    /// Build a minimal v{V} tarball at `out` containing `data/meta/marker`.
+    fn make_test_tarball(out: &Path) {
+        let file = fs::File::create(out).unwrap();
+        let encoder = zstd::stream::Encoder::new(file, 0).unwrap().auto_finish();
+        let mut tar = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        let payload = b"test-marker";
+        header.set_size(payload.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, "data/meta/marker", payload.as_slice()).unwrap();
+        // Also include a library subtree so ensure_library can find it.
+        let mut h2 = tar::Header::new_gnu();
+        let p2 = b"xs-marker";
+        h2.set_size(p2.len() as u64);
+        h2.set_mode(0o644);
+        h2.set_cksum();
+        tar.append_data(&mut h2, "data/tendl-test/xs/p_Cu.parquet", p2.as_slice()).unwrap();
+        tar.finish().unwrap();
+    }
+
+    #[test]
+    fn cache_paths_use_data_version() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let cd = cache_dir().unwrap();
+        assert!(cd.ends_with(format!("v{DATA_VERSION}")));
+        let s = sentinel_path().unwrap();
+        assert!(s.ends_with(".complete"));
+    }
+
+    #[test]
+    fn install_from_tarball_writes_sentinel_last() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        assert!(!is_cache_complete());
+        install_from_tarball(&archive).unwrap();
+        assert!(is_cache_complete());
+
+        // Sentinel content is the version
+        let sentinel = fs::read_to_string(sentinel_path().unwrap()).unwrap();
+        assert_eq!(sentinel, DATA_VERSION);
+
+        // Marker file made it through the atomic dance
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists());
+        assert_eq!(fs::read(&marker).unwrap(), b"test-marker");
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        install_from_tarball(&archive).unwrap();
+        let mtime1 = fs::metadata(sentinel_path().unwrap()).unwrap().modified().unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Second call short-circuits — we still call install_from_tarball
+        // unconditionally to verify it's safe; the function is allowed to
+        // re-extract under the lock, but must not corrupt state.
+        install_from_tarball(&archive).unwrap();
+        assert!(is_cache_complete());
+        let mtime2 = fs::metadata(sentinel_path().unwrap()).unwrap().modified().unwrap();
+        // Either the second run no-op'd (mtime unchanged) or re-wrote
+        // (mtime advanced); both are fine — what matters is the cache is
+        // still usable.
+        let _ = (mtime1, mtime2);
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn partial_dir_gets_promoted_to_complete() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        install_from_tarball(&archive).unwrap();
+
+        let root = cache_root().unwrap();
+        // Any v{V}.partial-* should be cleaned up
+        let partials: Vec<_> = fs::read_dir(&root)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(&format!("v{DATA_VERSION}.partial"))
+            })
+            .collect();
+        assert!(partials.is_empty(), "stale partial dir left behind");
+    }
+
+    #[test]
+    fn export_offline_bundle_round_trips() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+        install_from_tarball(&archive).unwrap();
+
+        let bundle = td.path().join("offline.tar.zst");
+        export_offline_bundle(&bundle).unwrap();
+        assert!(bundle.exists());
+
+        // Move HOME to a fresh dir, ingest the bundle, verify the marker
+        // is back.
+        let td2 = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", td2.path());
+        assert!(!is_cache_complete());
+        install_from_tarball(&bundle).unwrap();
+        assert!(is_cache_complete());
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn export_refuses_when_cache_incomplete() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let bundle = std::env::temp_dir().join("offline.tar.zst");
+        let err = export_offline_bundle(&bundle).unwrap_err();
+        assert!(matches!(err, FetchError::Io(_)));
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,8 @@ pub mod chains;
 pub mod compute;
 pub mod constants;
 pub mod data_dir;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod data_fetch;
 pub mod db;
 pub mod formula;
 pub mod interpolation;

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -533,6 +533,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1032,17 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1099,6 +1126,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1315,8 +1353,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1326,9 +1366,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1626,6 +1668,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,11 +1711,15 @@ name = "hyrr-core"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "fs2",
  "parquet",
  "regex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tar",
  "thiserror 2.0.18",
+ "zstd",
 ]
 
 [[package]]
@@ -2112,8 +2174,17 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2135,6 +2206,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2578,7 +2655,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2830,6 +2907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "plist"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3056,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,6 +3157,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3039,6 +3187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3085,6 +3252,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -3151,6 +3327,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3208,6 +3424,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3220,6 +3450,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3449,6 +3727,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,7 +3894,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -3703,6 +3993,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3820,6 +4116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,7 +4162,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4219,6 +4526,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4230,6 +4552,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4524,6 +4856,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4770,6 +5108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,6 +5171,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5053,6 +5410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5480,6 +5846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5542,6 +5918,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/desktop/src-tauri/build.rs
+++ b/desktop/src-tauri/build.rs
@@ -1,3 +1,33 @@
+//! Tauri build hook + a guard against silently bundling empty
+//! resources when the `nucl-parquet/` submodule isn't checked out.
+//!
+//! The failure mode this prevents: a fresh clone without
+//! `--recurse-submodules`, then `cargo tauri build`, produces an
+//! installer that ships with empty resource dirs (or, on some
+//! platforms, fails to materialise them at all). The user launches,
+//! `seed_cache_from_resources` returns silently because `data/meta`
+//! isn't a dir, and they pay the *full* ~400 MB lazy fetch instead of
+//! the ~50 MB the docs promise — a silent ~7× regression.
+
+use std::path::Path;
+
 fn main() {
+    // Only enforce when actually bundling — `cargo check` and unit
+    // tests should not fail just because the submodule is missing.
+    if std::env::var("PROFILE").as_deref() == Ok("release") {
+        let canary = Path::new("../../nucl-parquet/data/meta/elements.parquet");
+        if !canary.exists() {
+            panic!(
+                "nucl-parquet submodule not checked out: {} missing.\n\
+                 Run `git submodule update --init --recursive` before \
+                 `cargo tauri build` — otherwise the installer ships \
+                 with empty resource dirs and users pay the full ~400 MB \
+                 lazy fetch on first launch.",
+                canary.display()
+            );
+        }
+        println!("cargo:rerun-if-changed=../../nucl-parquet/data/meta/elements.parquet");
+    }
+
     tauri_build::build()
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -177,17 +177,71 @@ fn layer_composition(layer: &Layer) -> Vec<(u32, f64)> {
 // ---------------------------------------------------------------------------
 
 /// Initialize the Parquet data store. Must be called before compute commands.
+///
+/// If `data_dir` is empty, falls back to the same resolver used by the
+/// `--mcp` mode (`hyrr_core::data_dir::resolve()`), which prefers a managed
+/// cache populated by [`ensure_data`]. If the cache is incomplete the
+/// caller should invoke [`ensure_data`] first and surface progress to the
+/// user, otherwise this call returns the underlying ParquetDataStore error
+/// (which the frontend currently swallows into a silent WASM fallback —
+/// known issue #52).
 #[tauri::command]
 pub fn init_data_store(
     state: State<'_, DataStoreState>,
     data_dir: String,
     library: String,
 ) -> Result<(), String> {
-    let store =
-        ParquetDataStore::new(&data_dir, &library).map_err(|e| format!("Failed to init DB: {e}"))?;
+    let resolved = if data_dir.is_empty() {
+        hyrr_core::data_dir::resolve()
+    } else {
+        data_dir
+    };
+    let store = ParquetDataStore::new(&resolved, &library)
+        .map_err(|e| format!("Failed to init DB at {resolved}: {e}"))?;
     let mut guard = state.0.lock().map_err(|e| e.to_string())?;
     *guard = Some(store);
     Ok(())
+}
+
+/// Ensure the managed nucl-parquet cache contains the given `library`,
+/// downloading from GitHub Releases if necessary. Idempotent, blocking,
+/// and safe to call from multiple threads (see `data_fetch` hardening).
+///
+/// Returns the resolved data directory the caller should hand to
+/// [`init_data_store`]. Frontend callers should display a "Initializing
+/// nuclear data…" splash while this runs because a cold cache pulls
+/// ~50 MB at minimum.
+///
+/// Pass an empty `library` (or a known-good library name) to ensure only
+/// `meta/`+`stopping/` are present (e.g. for a depth preview that doesn't
+/// need cross-sections).
+#[tauri::command]
+pub fn ensure_data(library: String) -> Result<String, String> {
+    if library.is_empty() {
+        hyrr_core::data_fetch::ensure_meta_stopping()
+            .map_err(|e| format!("ensure_meta_stopping: {e}"))?;
+    } else {
+        hyrr_core::data_fetch::ensure_library(&library)
+            .map_err(|e| format!("ensure_library({library}): {e}"))?;
+    }
+    let cache = hyrr_core::data_fetch::cache_dir()
+        .map_err(|e| format!("cache_dir: {e}"))?;
+    Ok(cache.join("data").to_string_lossy().to_string())
+}
+
+/// Quick check from the frontend: does the cache already have everything we
+/// need to skip the splash entirely? Cheap (just file-existence checks).
+#[tauri::command]
+pub fn data_ready(library: String) -> bool {
+    if !hyrr_core::data_fetch::is_cache_complete() {
+        return false;
+    }
+    if library.is_empty() {
+        return true;
+    }
+    hyrr_core::data_fetch::cache_dir()
+        .map(|c| c.join("data").join(&library).is_dir())
+        .unwrap_or(false)
 }
 
 /// Run a full HYRR simulation. Returns SimulationResult JSON.

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -45,10 +45,12 @@ fn main() {
 }
 
 /// Copy bundled `meta/` and `stopping/` into the managed cache iff the
-/// cache is not already complete. Idempotent: a returning user pays no
-/// IO. Failures here are logged and swallowed because the user can still
-/// fall through to the lazy-fetch path if the bundle copy fails (e.g. the
-/// installer didn't ship resources for some reason).
+/// cache is not already complete. The actual copy + sentinel-write is
+/// done by `data_fetch::seed_from_dir` under the cache lock — that's
+/// the only safe way to write into the final cache directory while a
+/// concurrent `--mcp` invocation might be calling `ensure_library`.
+/// Failures are logged and swallowed: the user can still fall through
+/// to the lazy-fetch path on first simulation.
 fn seed_cache_from_resources(app: &tauri::App) {
     if hyrr_core::data_fetch::is_cache_complete() {
         return;
@@ -66,61 +68,9 @@ fn seed_cache_from_resources(app: &tauri::App) {
         // builds where bundle.resources isn't materialized.
         return;
     }
-    let cache = match hyrr_core::data_fetch::cache_dir() {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("seed_cache: no cache_dir: {e}");
-            return;
-        }
-    };
-    let cache_data = cache.join("data");
-    if let Err(e) = std::fs::create_dir_all(&cache_data) {
-        eprintln!("seed_cache: mkdir {}: {e}", cache_data.display());
-        return;
+    if let Err(e) = hyrr_core::data_fetch::seed_from_dir(&bundled_data) {
+        eprintln!("seed_cache: seed_from_dir: {e}");
     }
-    for child in &["meta", "stopping", "catalog.json", "suppliers.json"] {
-        let from = bundled_data.join(child);
-        let to = cache_data.join(child);
-        if to.exists() {
-            continue;
-        }
-        if from.is_dir() {
-            if let Err(e) = copy_dir_recursive(&from, &to) {
-                eprintln!("seed_cache: copy {} → {}: {e}", from.display(), to.display());
-                return;
-            }
-        } else if from.is_file() {
-            if let Err(e) = std::fs::copy(&from, &to) {
-                eprintln!("seed_cache: copy {} → {}: {e}", from.display(), to.display());
-                return;
-            }
-        }
-    }
-    // Mark the cache as complete so the resolver picks it up on the very
-    // first launch — without this, the bundled meta+stopping copy would be
-    // wasted: `is_cache_complete()` would still return false, and the
-    // splash-screen `data_ready` check would fall through to a network
-    // fetch even though the bytes are already on disk. The chosen library's
-    // xs/ data is still missing on first launch and is fetched lazily by
-    // `commands::ensure_data` when the user runs their first simulation.
-    if let Err(e) = hyrr_core::data_fetch::mark_cache_seeded() {
-        eprintln!("seed_cache: mark_cache_seeded: {e}");
-    }
-}
-
-fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
-    std::fs::create_dir_all(dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let from = entry.path();
-        let to = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_dir_recursive(&from, &to)?;
-        } else {
-            std::fs::copy(&from, &to)?;
-        }
-    }
-    Ok(())
 }
 
 /// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,6 +6,8 @@ mod commands;
 
 use std::sync::Mutex;
 
+use tauri::Manager;
+
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -22,13 +24,98 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .manage(commands::DataStoreState(Mutex::new(None)))
+        .setup(|app| {
+            // Seed the managed cache from bundled `meta/`+`stopping/` on
+            // first launch so default-library users get an immediate first
+            // simulation without a network call. Library-specific xs/ data
+            // is still fetched lazily on first use of that library — see
+            // `commands::ensure_data`.
+            seed_cache_from_resources(app);
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::init_data_store,
             commands::run_compute_stack,
             commands::compute_depth_preview,
+            commands::ensure_data,
+            commands::data_ready,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Copy bundled `meta/` and `stopping/` into the managed cache iff the
+/// cache is not already complete. Idempotent: a returning user pays no
+/// IO. Failures here are logged and swallowed because the user can still
+/// fall through to the lazy-fetch path if the bundle copy fails (e.g. the
+/// installer didn't ship resources for some reason).
+fn seed_cache_from_resources(app: &tauri::App) {
+    if hyrr_core::data_fetch::is_cache_complete() {
+        return;
+    }
+    let resource_root = match app.path().resource_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("seed_cache: no resource_dir: {e}");
+            return;
+        }
+    };
+    let bundled_data = resource_root.join("data");
+    if !bundled_data.join("meta").is_dir() {
+        // No bundled data — falls through to lazy fetch. Common in dev
+        // builds where bundle.resources isn't materialized.
+        return;
+    }
+    let cache = match hyrr_core::data_fetch::cache_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("seed_cache: no cache_dir: {e}");
+            return;
+        }
+    };
+    let cache_data = cache.join("data");
+    if let Err(e) = std::fs::create_dir_all(&cache_data) {
+        eprintln!("seed_cache: mkdir {}: {e}", cache_data.display());
+        return;
+    }
+    for child in &["meta", "stopping", "catalog.json", "suppliers.json"] {
+        let from = bundled_data.join(child);
+        let to = cache_data.join(child);
+        if to.exists() {
+            continue;
+        }
+        if from.is_dir() {
+            if let Err(e) = copy_dir_recursive(&from, &to) {
+                eprintln!("seed_cache: copy {} → {}: {e}", from.display(), to.display());
+                return;
+            }
+        } else if from.is_file() {
+            if let Err(e) = std::fs::copy(&from, &to) {
+                eprintln!("seed_cache: copy {} → {}: {e}", from.display(), to.display());
+                return;
+            }
+        }
+    }
+    // Sentinel: meta+stopping alone don't make a "complete" cache by the
+    // contract — a library is still needed. We do NOT write the .complete
+    // sentinel here; the lazy-fetch of a library is what eventually writes
+    // it. Bundling just shaves the 27+27=54 MB blocking download off the
+    // first sim.
+}
+
+fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
 }
 
 /// Resolve the nuclear data library: `--library <id>` arg → `HYRR_LIBRARY`

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -96,11 +96,16 @@ fn seed_cache_from_resources(app: &tauri::App) {
             }
         }
     }
-    // Sentinel: meta+stopping alone don't make a "complete" cache by the
-    // contract — a library is still needed. We do NOT write the .complete
-    // sentinel here; the lazy-fetch of a library is what eventually writes
-    // it. Bundling just shaves the 27+27=54 MB blocking download off the
-    // first sim.
+    // Mark the cache as complete so the resolver picks it up on the very
+    // first launch — without this, the bundled meta+stopping copy would be
+    // wasted: `is_cache_complete()` would still return false, and the
+    // splash-screen `data_ready` check would fall through to a network
+    // fetch even though the bytes are already on disk. The chosen library's
+    // xs/ data is still missing on first launch and is fetched lazily by
+    // `commands::ensure_data` when the user runs their first simulation.
+    if let Err(e) = hyrr_core::data_fetch::mark_cache_seeded() {
+        eprintln!("seed_cache: mark_cache_seeded: {e}");
+    }
 }
 
 fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -31,7 +31,12 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": [],
+    "resources": {
+      "../../nucl-parquet/data/meta": "data/meta",
+      "../../nucl-parquet/data/stopping": "data/stopping",
+      "../../nucl-parquet/data/catalog.json": "data/catalog.json",
+      "../../nucl-parquet/data/suppliers.json": "data/suppliers.json"
+    },
     "windows": {
       "nsis": {
         "installMode": "perMachine"

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ For air-gapped machines or offline use, download the native desktop app from **[
 | macOS 10.15+ (Intel) | `.dmg` |
 | Ubuntu 22.04+ | `.deb` or `.AppImage` |
 
-All nuclear data (~68 MB Parquet) is bundled — no internet connection required after install. Installer size ~15 MB.
+The installer ships with the always-needed `meta/` and `stopping/` data (~54 MB) bundled. The chosen cross-section library (default `tendl-2025`, ~50 MB) is downloaded on first launch into `~/.hyrr/nucl-parquet/v{version}/`. A returning user pays no network cost; switching libraries triggers another small download. **Installer size ~80 MB** (was ~15 MB before #52 — the difference is bundled meta+stopping).
 
 ## Python Package
 
@@ -39,13 +39,46 @@ HYRR uses the [nucl-parquet](https://github.com/exoma-ch/nucl-parquet) data pack
 
 1. `--data-dir` CLI argument
 2. `HYRR_DATA` environment variable
-3. `../nucl-parquet` sibling directory (submodule)
-4. `~/.hyrr/nucl-parquet` fallback
+3. Managed cache at `~/.hyrr/nucl-parquet/v{version}/` (sentinel-protected)
+4. `../nucl-parquet` sibling directory (submodule, dev layout)
 
-To download data manually:
+### Fetching data
+
+The Python CLI populates the same managed cache the desktop app uses:
 
 ```bash
-hyrr download-data
+hyrr fetch-data                       # default: meta + stopping
+hyrr fetch-data --library tendl-2025  # specific library (~50 MB)
+hyrr fetch-data --all                 # every library (~400 MB)
 ```
 
-The default library is `tendl-2024`. Override with `--library` or `HYRR_LIBRARY` env var.
+The default library is `tendl-2025`. Override with `--library` or `HYRR_LIBRARY` env var. The cache is sentinel-protected: a partial download or interrupted extract leaves the dir behind for cleanup but is never picked up as a usable cache.
+
+### Air-gapped install
+
+For machines without internet (Faraday-cage labs, isolated networks):
+
+1. **On a connected machine**, populate the cache and pack it:
+
+   ```bash
+   hyrr fetch-data --all
+   hyrr fetch-data --offline-bundle hyrr-data.tar.zst
+   ```
+
+2. **Copy** `hyrr-data.tar.zst` to the air-gapped machine (USB stick, internal share, etc.)
+
+3. **On the air-gapped machine**, install the bundle:
+
+   ```bash
+   hyrr fetch-data --from hyrr-data.tar.zst
+   ```
+
+Both machines must run matching `hyrr` versions for the bundle to apply cleanly — the cache is version-pinned, so a v0.9 bundle won't be picked up by a v0.10 install. Alternatively, drop the upstream GitHub Releases tarball directly:
+
+```bash
+# On a connected machine
+curl -LO https://github.com/exoma-ch/nucl-parquet/releases/download/v0.9.0/nucl-parquet-data-v0.9.0.tar.zst
+
+# On the air-gapped machine
+hyrr fetch-data --from nucl-parquet-data-v0.9.0.tar.zst
+```

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ For air-gapped machines or offline use, download the native desktop app from **[
 | macOS 10.15+ (Intel) | `.dmg` |
 | Ubuntu 22.04+ | `.deb` or `.AppImage` |
 
-The installer ships with the always-needed `meta/` and `stopping/` data (~54 MB) bundled. The chosen cross-section library (default `tendl-2025`, ~50 MB) is downloaded on first launch into `~/.hyrr/nucl-parquet/v{version}/`. A returning user pays no network cost; switching libraries triggers another small download. **Installer size ~80 MB** (was ~15 MB before #52 — the difference is bundled meta+stopping).
+The installer ships with the always-needed `meta/` and `stopping/` data (~54 MB) bundled. The chosen cross-section library (default `tendl-2024`, ~50 MB) is downloaded on first launch into `~/.hyrr/nucl-parquet/v{version}/`. A returning user pays no network cost; switching libraries triggers another small download. **Installer size ~80 MB** (was ~15 MB before #52 — the difference is bundled meta+stopping).
 
 ## Python Package
 
@@ -48,11 +48,11 @@ The Python CLI populates the same managed cache the desktop app uses:
 
 ```bash
 hyrr fetch-data                       # default: meta + stopping
-hyrr fetch-data --library tendl-2025  # specific library (~50 MB)
+hyrr fetch-data --library tendl-2024  # specific library (~50 MB)
 hyrr fetch-data --all                 # every library (~400 MB)
 ```
 
-The default library is `tendl-2025`. Override with `--library` or `HYRR_LIBRARY` env var. The cache is sentinel-protected: a partial download or interrupted extract leaves the dir behind for cleanup but is never picked up as a usable cache.
+The default library is `tendl-2024`. Override with `--library` or `HYRR_LIBRARY` env var. The cache is sentinel-protected: a partial download or interrupted extract leaves the dir behind for cleanup but is never picked up as a usable cache.
 
 ### Air-gapped install
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -112,7 +112,11 @@
     loadingState = "Loading nuclear data...";
     loadingProgress = 0;
 
-    const TIMEOUT_MS = 30_000;
+    // 5-minute ceiling. Covers first-launch downloads (~50 MB at hotel-wifi
+    // speeds is up to 5 min per the #52 spike bench). The progress callback
+    // keeps the user informed during any wait — a hard timeout is the
+    // backstop if something is genuinely wedged, not a snappiness signal.
+    const TIMEOUT_MS = 300_000;
     try {
       const loadPromise = initDataStore("./data/parquet", (msg: string, fraction?: number) => {
         loadingState = msg;
@@ -120,7 +124,7 @@
       });
 
       const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Data loading timed out after 30s")), TIMEOUT_MS),
+        setTimeout(() => reject(new Error("Data loading timed out after 5 min")), TIMEOUT_MS),
       );
 
       await Promise.race([loadPromise, timeoutPromise]);

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -47,8 +47,25 @@ export async function initBackend(
   if (isTauri()) {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      const dir = dataDir ?? resolveDataDir();
       const lib = library ?? "tendl-2024";
+
+      // #52: cache check before init. `data_ready` is cheap (file-existence
+      // only), so we pay nothing on the returning-user path. When the cache
+      // is missing, `ensure_data` downloads — ~50 MB for the default
+      // library, less if meta+stopping were already bundled in the
+      // installer. We surface the progress message so the user understands
+      // they're not staring at a hang.
+      const ready = await invoke<boolean>("data_ready", { library: lib });
+      let dir = dataDir ?? "";
+      if (!ready) {
+        onProgress?.(
+          `Initializing nuclear data (${lib}) — first-launch download...`,
+          0.05,
+        );
+        dir = await invoke<string>("ensure_data", { library: lib });
+        onProgress?.("Nuclear data ready", 0.95);
+      }
+
       await invoke("init_data_store", { dataDir: dir, library: lib });
       activeBackend = "tauri";
       return "tauri";

--- a/py/Cargo.lock
+++ b/py/Cargo.lock
@@ -251,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +273,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -303,6 +315,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -369,10 +387,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -386,8 +436,76 @@ version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rustc_version",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -397,8 +515,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -408,9 +528,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -444,15 +566,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "hyrr-core"
 version = "0.1.0"
 dependencies = [
  "arrow",
+ "fs2",
  "parquet",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -490,6 +714,109 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +831,22 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -607,16 +950,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num"
@@ -743,16 +1127,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -822,6 +1242,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -835,6 +1310,44 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
 
 [[package]]
 name = "regex"
@@ -866,12 +1379,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -942,6 +1563,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,16 +1587,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -974,6 +1641,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -1023,6 +1721,125 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,10 +1856,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1070,6 +1920,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1103,6 +1967,57 @@ checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1164,10 +2079,205 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1183,6 +2293,66 @@ name = "zerocopy-derive"
 version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -4,10 +4,12 @@
 //! JSON-in/JSON-out strategy — simple, correct, matches the Tauri/WASM approach.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use hyrr_core::bateman::bateman_activity as rust_bateman;
 use hyrr_core::compute::compute_stack;
+use hyrr_core::data_fetch;
 use hyrr_core::db::ParquetDataStore;
 use hyrr_core::formula::parse_formula;
 use hyrr_core::materials::resolve_material;
@@ -219,6 +221,90 @@ fn py_compute_thickness(
 }
 
 // ---------------------------------------------------------------------------
+// Data-fetch CLI surface (#52)
+// ---------------------------------------------------------------------------
+
+/// Implements `hyrr fetch-data`. Exactly one of the four mutually-exclusive
+/// modes is selected by the caller:
+///
+/// - `library=Some("tendl-2024")` — fetch a specific library
+/// - `all_libs=true` — fetch every library (~400 MB)
+/// - `offline_bundle=Some("/tmp/hyrr.tar.zst")` — repack the existing cache
+///   into a portable archive (cache must already be complete)
+/// - `from_tarball=Some("/tmp/hyrr.tar.zst")` — install from a local tarball
+///
+/// With all four left default, fetches the always-needed `meta/`+`stopping/`
+/// (the "default library" path — caller is expected to specify a library
+/// for the actual XS data).
+#[pyfunction]
+#[pyo3(signature = (library=None, all_libs=false, offline_bundle=None, from_tarball=None))]
+fn py_fetch_data(
+    library: Option<&str>,
+    all_libs: bool,
+    offline_bundle: Option<&str>,
+    from_tarball: Option<&str>,
+) -> PyResult<()> {
+    let active = [
+        library.is_some(),
+        all_libs,
+        offline_bundle.is_some(),
+        from_tarball.is_some(),
+    ]
+    .iter()
+    .filter(|&&b| b)
+    .count();
+    if active > 1 {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "fetch-data: --library, --all, --offline-bundle, --from are mutually exclusive",
+        ));
+    }
+
+    if let Some(path) = from_tarball {
+        return data_fetch::install_from_tarball(&PathBuf::from(path))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
+    }
+    if let Some(path) = offline_bundle {
+        return data_fetch::export_offline_bundle(&PathBuf::from(path))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
+    }
+    if all_libs {
+        return data_fetch::ensure_meta_stopping()
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
+    }
+    if let Some(name) = library {
+        return data_fetch::ensure_library(name)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
+    }
+    // Default mode: ensure meta/+stopping/. Library-specific fetch is the
+    // caller's responsibility because we don't know their default here.
+    data_fetch::ensure_meta_stopping()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+}
+
+/// Path to the managed cache root: `~/.hyrr/nucl-parquet/v{DATA_VERSION}/data/`.
+/// Returns the path even if the cache isn't yet populated; check
+/// [`py_cache_is_complete`] for usability.
+#[pyfunction]
+fn py_cache_data_dir() -> PyResult<String> {
+    let cache = data_fetch::cache_dir()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
+    Ok(cache.join("data").to_string_lossy().to_string())
+}
+
+/// True iff the managed cache is fully populated (sentinel present).
+#[pyfunction]
+fn py_cache_is_complete() -> bool {
+    data_fetch::is_cache_complete()
+}
+
+/// Version of the nucl-parquet data this build expects (matches submodule
+/// pin). Surfaced for diagnostics / sanity-checks.
+#[pyfunction]
+fn py_data_version() -> &'static str {
+    data_fetch::DATA_VERSION
+}
+
+// ---------------------------------------------------------------------------
 // Internal types for JSON deserialization
 // ---------------------------------------------------------------------------
 
@@ -286,5 +372,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_dedx_mev_per_cm, m)?)?;
     m.add_function(wrap_pyfunction!(py_compute_energy_out, m)?)?;
     m.add_function(wrap_pyfunction!(py_compute_thickness, m)?)?;
+    m.add_function(wrap_pyfunction!(py_fetch_data, m)?)?;
+    m.add_function(wrap_pyfunction!(py_cache_data_dir, m)?)?;
+    m.add_function(wrap_pyfunction!(py_cache_is_complete, m)?)?;
+    m.add_function(wrap_pyfunction!(py_data_version, m)?)?;
     Ok(())
 }

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -268,7 +268,7 @@ fn py_fetch_data(
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
     }
     if all_libs {
-        return data_fetch::ensure_meta_stopping()
+        return data_fetch::ensure_all()
             .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")));
     }
     if let Some(name) = library {

--- a/src/hyrr/cli.py
+++ b/src/hyrr/cli.py
@@ -69,18 +69,55 @@ def main(argv: list[str] | None = None) -> int:
         "--layer", type=int, default=None, help="Filter to specific layer index"
     )
 
-    # hyrr download-data
+    # hyrr fetch-data (#52) — new canonical surface
+    fd_parser = subparsers.add_parser(
+        "fetch-data",
+        help="Fetch nuclear data into the managed cache (~/.hyrr/nucl-parquet/)",
+    )
+    fd_group = fd_parser.add_mutually_exclusive_group()
+    fd_group.add_argument(
+        "--library",
+        type=str,
+        default=None,
+        metavar="ID",
+        help="Fetch a specific library (e.g. tendl-2025)",
+    )
+    fd_group.add_argument(
+        "--all",
+        action="store_true",
+        help="Fetch every library (~400 MB)",
+    )
+    fd_group.add_argument(
+        "--offline-bundle",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Repack the existing cache into a portable .tar.zst at PATH",
+    )
+    fd_group.add_argument(
+        "--from",
+        dest="from_tarball",
+        type=Path,
+        default=None,
+        metavar="PATH",
+        help="Install from a local .tar.zst (use after --offline-bundle on a connected machine)",
+    )
+
+    # hyrr download-data — deprecated alias retained for legacy docs
     dl_parser = subparsers.add_parser(
-        "download-data", help="Download pre-built database from GitHub Releases"
+        "download-data",
+        help="(deprecated) alias for `fetch-data --all`",
     )
     dl_parser.add_argument(
         "--output-dir",
         type=Path,
         default=Path.home() / ".hyrr",
-        help="Directory to store the database (default: ~/.hyrr/)",
+        help="(deprecated, ignored) cache always lives at ~/.hyrr/nucl-parquet/",
     )
     dl_parser.add_argument(
-        "--force", action="store_true", help="Overwrite existing database"
+        "--force",
+        action="store_true",
+        help="(deprecated, ignored)",
     )
 
     # hyrr generate-xs
@@ -130,6 +167,8 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_run(args)
     elif args.command == "compare":
         return _cmd_compare(args)
+    elif args.command == "fetch-data":
+        return _cmd_fetch_data(args)
     elif args.command == "download-data":
         return _cmd_download_data(args)
     elif args.command == "generate-xs":
@@ -462,46 +501,89 @@ def _cmd_compare(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_download_data(args: argparse.Namespace) -> int:
-    """Download pre-built nucl-parquet data from GitHub Releases."""
-    import subprocess
-    import urllib.request
+def _cmd_fetch_data(args: argparse.Namespace) -> int:
+    """Fetch nuclear data into the managed cache (#52).
 
-    output_dir = args.output_dir
-    data_dir = output_dir / "nucl-parquet"
-
-    if data_dir.is_dir() and not args.force:
-        print(f"Data already exists: {data_dir}")
-        print("Use --force to overwrite.")
-        return 0
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    release_url = "https://github.com/eXoma-ch/nucl-parquet/releases/latest/download/nucl-parquet.tar.zst"
-
-    print(f"Downloading data from {release_url} ...")
-
+    Routes the four mutually-exclusive flags to the underlying Rust
+    `data_fetch` module. The cache lives at `~/.hyrr/nucl-parquet/v{V}/`
+    with a `.complete` sentinel and atomic install semantics — partial
+    downloads can't masquerade as a usable cache.
+    """
     try:
-        archive_path = output_dir / "nucl-parquet.tar.zst"
-        urllib.request.urlretrieve(release_url, str(archive_path))
-
-        try:
-            subprocess.run(
-                ["tar", "--zstd", "-xf", str(archive_path), "-C", str(output_dir)],
-                check=True,
-            )
-            archive_path.unlink()
-            print(f"Data extracted to: {data_dir}")
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            print(f"Downloaded archive: {archive_path}")
-            print("Extract manually with: tar --zstd -xf nucl-parquet.tar.zst")
-    except Exception as e:
-        print(f"Download failed: {e}", file=sys.stderr)
+        from hyrr import _native
+    except ImportError as e:
         print(
-            "Clone nucl-parquet manually from https://github.com/eXoma-ch/nucl-parquet",
+            f"hyrr._native not available: {e}\n"
+            "fetch-data requires the compiled Rust extension. "
+            "Reinstall hyrr or run `maturin develop` if working from source.",
             file=sys.stderr,
         )
         return 1
+
+    try:
+        if args.from_tarball is not None:
+            print(f"Installing from {args.from_tarball} ...")
+            _native.py_fetch_data(from_tarball=str(args.from_tarball))
+            print(f"Installed to ~/.hyrr/nucl-parquet/v{_native.py_data_version()}/")
+            return 0
+
+        if args.offline_bundle is not None:
+            if not _native.py_cache_is_complete():
+                print(
+                    "Cache is not complete; run `hyrr fetch-data --all` (or "
+                    "`--library X`) first to populate it.",
+                    file=sys.stderr,
+                )
+                return 1
+            print(f"Packing cache into {args.offline_bundle} ...")
+            _native.py_fetch_data(offline_bundle=str(args.offline_bundle))
+            print(f"Wrote {args.offline_bundle}")
+            return 0
+
+        if args.all:
+            print(
+                f"Fetching all nucl-parquet libraries (v{_native.py_data_version()}, "
+                "~400 MB) ..."
+            )
+            _native.py_fetch_data(all_libs=True)
+        elif args.library:
+            print(
+                f"Fetching library `{args.library}` "
+                f"(v{_native.py_data_version()}) ..."
+            )
+            _native.py_fetch_data(library=args.library)
+        else:
+            print(
+                f"Fetching meta + stopping (v{_native.py_data_version()}) ..."
+            )
+            _native.py_fetch_data()
+
+        print(
+            f"Cached at: {_native.py_cache_data_dir()}\n"
+            "(set HYRR_DATA to override)"
+        )
+        return 0
+    except Exception as e:
+        print(f"fetch-data failed: {e}", file=sys.stderr)
+        return 1
+
+
+def _cmd_download_data(args: argparse.Namespace) -> int:
+    """(deprecated) Alias for `fetch-data --all`. Retained for legacy docs."""
+    print(
+        "warning: `hyrr download-data` is deprecated; use `hyrr fetch-data --all` "
+        "(or `--library X`) instead.",
+        file=sys.stderr,
+    )
+    # Translate to the new surface — ignore the legacy --output-dir / --force
+    # since the cache always lives at ~/.hyrr/nucl-parquet/v{V}/ now.
+    new_args = argparse.Namespace(
+        all=True,
+        library=None,
+        offline_bundle=None,
+        from_tarball=None,
+    )
+    return _cmd_fetch_data(new_args)
 
     return 0
 

--- a/src/hyrr/cli.py
+++ b/src/hyrr/cli.py
@@ -585,8 +585,6 @@ def _cmd_download_data(args: argparse.Namespace) -> int:
     )
     return _cmd_fetch_data(new_args)
 
-    return 0
-
 
 def _cmd_generate_xs(args: argparse.Namespace) -> int:
     """Generate cross-section data using TALYS."""

--- a/src/hyrr/cli.py
+++ b/src/hyrr/cli.py
@@ -548,20 +548,14 @@ def _cmd_fetch_data(args: argparse.Namespace) -> int:
             _native.py_fetch_data(all_libs=True)
         elif args.library:
             print(
-                f"Fetching library `{args.library}` "
-                f"(v{_native.py_data_version()}) ..."
+                f"Fetching library `{args.library}` (v{_native.py_data_version()}) ..."
             )
             _native.py_fetch_data(library=args.library)
         else:
-            print(
-                f"Fetching meta + stopping (v{_native.py_data_version()}) ..."
-            )
+            print(f"Fetching meta + stopping (v{_native.py_data_version()}) ...")
             _native.py_fetch_data()
 
-        print(
-            f"Cached at: {_native.py_cache_data_dir()}\n"
-            "(set HYRR_DATA to override)"
-        )
+        print(f"Cached at: {_native.py_cache_data_dir()}\n(set HYRR_DATA to override)")
         return 0
     except Exception as e:
         print(f"fetch-data failed: {e}", file=sys.stderr)


### PR DESCRIPTION
Closes #52, #119, #120.

## Summary

Replaces the dead `bundle.resources = []` Tauri config with a hybrid cache strategy that keeps the installer at ~80 MB while making the native engine viable on a fresh install.

- **Bundled in installer**: `meta/` + `stopping/` + `catalog.json` + `suppliers.json` (~54 MB) — required by every simulation regardless of library, copied into `~/.hyrr/nucl-parquet/v{V}/data/` on first launch.
- **Lazy-fetched on first use**: the chosen library's xs/ data (~50 MB for `tendl-2024`) downloads from GitHub Releases the first time the user runs a simulation. A splash-screen `data_ready` check makes returning users pay nothing.
- **Air-gapped workflow**: `hyrr fetch-data --offline-bundle out.tar.zst` repacks the populated cache; `hyrr fetch-data --from out.tar.zst` ingests it on the disconnected machine. Drop-in compatible with the upstream nucl-parquet release tarball.

## Architecture

`core/src/data_fetch.rs` is the single source of truth. Hardened against the failure modes that simpler mirror-of-pattern implementations get wrong:

- **Atomic install**: extract to `v{V}.partial-{pid}/`, `fs::rename` to `v{V}/`, write `.complete` sentinel **last**. The resolver checks the sentinel — partial extracts can never masquerade as a usable cache.
- **Concurrent invocations**: exclusive `fs2` lock on `<root>/.lock` serialises GUI / `--mcp` / CLI competing for the same cache.
- **Sentinel-protected merge**: when a library fetch merges into an already-populated cache (the bundled-resources case), the sentinel is dropped *before* touching files and rewritten *after* — closes the half-merged-but-marked-complete corruption window.
- **Wrong-version isolation**: each `DATA_VERSION` lives in its own `v{V}/` dir.

## CLI surface

```
hyrr fetch-data                       # default: meta + stopping
hyrr fetch-data --library tendl-2025  # specific library
hyrr fetch-data --all                 # every library (~400 MB)
hyrr fetch-data --offline-bundle X    # repack cache
hyrr fetch-data --from X              # install from local tarball
```

Mutually-exclusive flags enforced in argparse + a final guard in pyo3.

## Tauri surface

- `data_ready(library)` — cheap file-existence check; called by the splash before showing it
- `ensure_data(library)` — blocking download path; surfaces progress to the splash
- `init_data_store` falls back to the resolver when `data_dir` is empty

## Review history

This PR is the result of a `/spike` → `/land` cycle (8 commits). The last commit (`fix(core): address P0 review findings`) addresses three issues found by post-implementation review:

1. `--all` was a lie (~54 MB despite the message claiming ~400 MB)
2. The bundled-resources Tauri hook never wrote the sentinel, so the bundled bytes were unused
3. The `extract_tarball` filter was a no-op — every production caller defeated the lazy-extraction promise

## Test plan

- [x] `cargo test --manifest-path core/Cargo.toml --lib` — 29 passed, including 6 `data_fetch::tests` covering atomicity, idempotence, sentinel-last, partial cleanup, and round-trip via offline bundle
- [x] `cargo check` on `py/` and `desktop/src-tauri/` (clean)
- [ ] Manual: `hyrr fetch-data --library tendl-2025`, `--offline-bundle`, `--from` round-trip
- [ ] Manual: Tauri build with bundled resources — verify first-launch splash + library fetch