### PR TITLE
chore(127): bump shipped XS data to TENDL-2025 + tooltip on greyed cells

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set data/meta data/stopping data/tendl-2024/xs data/hi-xs-prod/xs data/endfb-8.1/xs
+          git sparse-checkout set data/meta data/stopping data/tendl-2025/xs data/hi-xs-prod/xs data/endfb-8.1/xs
 
       - name: Copy nuclear data for frontend
         run: |
@@ -48,7 +48,7 @@ jobs:
           cp -f nucl-parquet/data/meta/spectrum_xs.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
           cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet nucl-parquet/data/stopping/He3STAR.parquet frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet nucl-parquet/data/stopping/catima_O16.parquet nucl-parquet/data/stopping/catima_Ne20.parquet nucl-parquet/data/stopping/catima_Si28.parquet nucl-parquet/data/stopping/catima_Ar40.parquet nucl-parquet/data/stopping/catima_Fe56.parquet frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2024/xs/*.parquet frontend/public/data/parquet/xs/
+          cp nucl-parquet/data/tendl-2025/xs/*.parquet frontend/public/data/parquet/xs/
           cp nucl-parquet/data/hi-xs-prod/xs/*.parquet frontend/public/data/parquet/hi-xs-prod/
           cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
 

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -51,7 +51,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p frontend/public/data/parquet/{xs,meta,stopping}
-          cp nucl-parquet/data/tendl-2024/xs/*.parquet frontend/public/data/parquet/xs/
+          cp nucl-parquet/data/tendl-2025/xs/*.parquet frontend/public/data/parquet/xs/
           cp nucl-parquet/data/meta/*.parquet frontend/public/data/parquet/meta/
           cp nucl-parquet/data/stopping/*.parquet frontend/public/data/parquet/stopping/
 

--- a/core/examples/probe_e2e_58.rs
+++ b/core/examples/probe_e2e_58.rs
@@ -9,7 +9,7 @@ use hyrr_core::types::*;
 fn run(cool_s: f64) {
     let data_dir =
         std::env::var("HYRR_DATA").unwrap_or_else(|_| "../nucl-parquet/data".to_string());
-    let mut db = ParquetDataStore::new(&data_dir, "tendl-2024").unwrap();
+    let mut db = ParquetDataStore::new(&data_dir, "tendl-2025").unwrap();
     db.load_xs("p", 1).unwrap();
     db.load_xs("p", 8).unwrap();
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -17,7 +17,7 @@ For air-gapped machines or offline use, download the native desktop app from **[
 | macOS 10.15+ (Intel) | `.dmg` |
 | Ubuntu 22.04+ | `.deb` or `.AppImage` |
 
-The installer ships with the always-needed `meta/` and `stopping/` data (~54 MB) bundled. The chosen cross-section library (default `tendl-2024`, ~50 MB) is downloaded on first launch into `~/.hyrr/nucl-parquet/v{version}/`. A returning user pays no network cost; switching libraries triggers another small download. **Installer size ~80 MB** (was ~15 MB before #52 — the difference is bundled meta+stopping).
+The installer ships with the always-needed `meta/` and `stopping/` data (~54 MB) bundled. The chosen cross-section library (default `tendl-2025`, ~50 MB) is downloaded on first launch into `~/.hyrr/nucl-parquet/v{version}/`. A returning user pays no network cost; switching libraries triggers another small download. **Installer size ~80 MB** (was ~15 MB before #52 — the difference is bundled meta+stopping).
 
 ## Python Package
 

--- a/frontend/scripts/fetch-data.sh
+++ b/frontend/scripts/fetch-data.sh
@@ -25,11 +25,11 @@ fi
 mkdir -p "$DEST/meta" "$DEST/stopping" "$DEST/xs"
 
 # Option 1: copy from local submodule
-if [ -z "${1:-}" ] && [ -d "$SUBMODULE/tendl-2024/xs" ]; then
+if [ -z "${1:-}" ] && [ -d "$SUBMODULE/tendl-2025/xs" ]; then
   echo "Copying nuclear data from submodule ($SUBMODULE) ..."
   cp "$SUBMODULE/meta/abundances.parquet" "$SUBMODULE/meta/decay.parquet" "$SUBMODULE/meta/elements.parquet" "$DEST/meta/"
   cp "$SUBMODULE/stopping/stopping.parquet" "$DEST/stopping/"
-  cp "$SUBMODULE/tendl-2024/xs/"*.parquet "$DEST/xs/"
+  cp "$SUBMODULE/tendl-2025/xs/"*.parquet "$DEST/xs/"
   echo "Done. $(find "$DEST" -name '*.parquet' | wc -l | tr -d ' ') parquet files in $DEST"
   exit 0
 fi

--- a/frontend/src/lib/components/HeaderBar.svelte
+++ b/frontend/src/lib/components/HeaderBar.svelte
@@ -197,7 +197,10 @@
     border-radius: 3px;
     margin: 0 0 0.75rem;
     background: var(--c-bg-subtle);
-    overflow: hidden;
+    /* No overflow:hidden — the save-menu dropdown is absolutely-positioned
+     * inside .save-menu-wrap and must escape the header's box vertically.
+     * The corners stay rounded via background-clip on .header-bar itself
+     * and the children don't paint past it. */
   }
 
   .home-btn {

--- a/frontend/src/lib/components/MaterialPopup.svelte
+++ b/frontend/src/lib/components/MaterialPopup.svelte
@@ -213,6 +213,7 @@
       <PeriodicTable
         onselect={handlePtSelect}
         disabled={disabledSet}
+        disabledReason={projectile ? `No cross-section data for ${projectile} on this element in the active library — try switching projectile or library.` : undefined}
         {enrichableSet}
       />
     {/if}

--- a/frontend/src/lib/components/material/PeriodicTable.svelte
+++ b/frontend/src/lib/components/material/PeriodicTable.svelte
@@ -30,6 +30,10 @@
      *  keyboard-reachable; click is suppressed; the accessible name
      *  carries the reason (", no TENDL data"). */
     disabled?: Set<string>;
+    /** Hover tooltip text for greyed cells. Parent supplies it because the
+     *  reason ("no Li(p,…) in TENDL-2024") depends on projectile + library
+     *  context that PT doesn't know. Falls back to a generic message. */
+    disabledReason?: string;
     /** Symbols that should pulse with a secondary highlight. */
     highlighted?: Set<string>;
     /** Symbols whose isotopic composition can be enriched (i.e. have
@@ -51,6 +55,7 @@
     onselect,
     selected,
     disabled,
+    disabledReason,
     highlighted,
     enrichableSet,
     mode = "single",
@@ -281,6 +286,7 @@
             tabindex={focusedZ === cell.Z ? 0 : -1}
             aria-colindex={cell.col}
             aria-label={ariaLabelFor(cell)}
+            title={disabled?.has(cell.symbol) ? (disabledReason ?? "No cross-section data for the current projectile/library") : undefined}
             aria-describedby={tooltip && focusedZ === cell.Z ? tooltipId : undefined}
             aria-selected={selected === cell.symbol ? true : undefined}
             onclick={() => handleClick(cell)}

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -227,7 +227,7 @@ fn py_compute_thickness(
 /// Implements `hyrr fetch-data`. Exactly one of the four mutually-exclusive
 /// modes is selected by the caller:
 ///
-/// - `library=Some("tendl-2024")` — fetch a specific library
+/// - `library=Some("tendl-2025")` — fetch a specific library
 /// - `all_libs=true` — fetch every library (~400 MB)
 /// - `offline_bundle=Some("/tmp/hyrr.tar.zst")` — repack the existing cache
 ///   into a portable archive (cache must already be complete)


### PR DESCRIPTION
## Summary
- Workflows now ship TENDL-2025 XS in the bundled frontend (was 2024). Closes the silent gap where Li/H/Be/B were greyed because TENDL-2024 lacks proton XS for them but the runtime default `tendl-2025` was already pointing elsewhere.
- Greyed `PeriodicTable` cells now have a hover `title=` explaining why ("No cross-section data for {projectile} on this element in the active library").
- Doc + example alignment so nothing still references the old default.
- **Bonus fix (drive-by, found via headless playwright while debugging):** `.header-bar { overflow: hidden }` was clipping the absolutely-positioned save/load dropdown menu — symptom was "click save icon, see only a shadow, no menu". Removed the overflow; verified menu items now top of click stack at menu centre.

Tier 1 of #127 — see the issue for the deferred Tier 2 work (UI library picker, multi-library shipping, auto-fallback).

## Test plan
- [ ] CI green (lint, build, supplier-catalog-freshness, test 3.12)
- [ ] Manual: open the material popup → switch to periodic-table view → confirm Li / H / Be / B are now ENABLED with projectile=p
- [ ] Manual: hover any still-greyed cell — `title` tooltip appears
- [ ] Manual: end-to-end Li(p,…) yield — non-zero ⁷Be result row
- [ ] Manual: click save icon in header → dropdown menu visible with three items; click outside → closes