### PR TITLE
fix(frontend): material definer UX — modes, balance toggle, mode-switch clear

### DIFF
--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -20,6 +20,7 @@
     updateCustomMaterial,
   } from "../../stores/custom-materials.svelte";
   import {
+    applyRowPatch,
     generateRowId,
     isTabulatedDensity,
     parseMaterialInput,
@@ -161,9 +162,6 @@
     return byRow;
   });
 
-  /** Stable radiogroup name so the browser enforces single-balance selection. */
-  const balanceRadioName = `define-balance-${Math.random().toString(36).slice(2, 10)}`;
-
   // First-time guidance: read flag once on init.
   try {
     if (typeof localStorage !== "undefined" && localStorage.getItem("hyrr.defineform.modeChipSeen") === "1") {
@@ -172,9 +170,15 @@
   } catch { /* no-op */ }
 
   const MODE_LABEL: Record<Mode, string> = {
-    single: "Single formula",
-    mass: "Mass mixture",
-    atom: "Atom mixture",
+    single: "Formula",
+    mass: "wt %",
+    atom: "at %",
+  };
+
+  const MODE_TOOLTIP: Record<Mode, string> = {
+    single: "Chemical formula, e.g. Fe2O3",
+    mass: "Composition by mass fraction",
+    atom: "Composition by atomic fraction",
   };
 
   let modeMenuOpen = $state(false);
@@ -191,19 +195,8 @@
     }
   }
 
-  /** Splice a row immutably with a partial patch. When isBalance flips on,
-   *  also clear it from every other row so only one survives. */
   function patchRow(id: string, patch: Partial<Row>) {
-    rows = rows.map((r) => {
-      if (r.id === id) {
-        return { ...r, ...patch };
-      }
-      // Force-clear other rows' isBalance when the patch turns one on.
-      if (patch.isBalance === true && r.isBalance) {
-        return { ...r, isBalance: false };
-      }
-      return r;
-    });
+    rows = applyRowPatch(rows, id, patch);
   }
 
   function removeRow(id: string) {
@@ -273,6 +266,9 @@
     }
     mode = next;
     modeUserOverride = true;
+    if (next === "single" && rows.some((r) => r.isBalance)) {
+      rows = rows.map((r) => (r.isBalance ? { ...r, isBalance: false } : r));
+    }
   }
 
   // Backwards-compat wrapper — the chip handler / tests still call setMode.
@@ -581,6 +577,7 @@
             class:low-conf={inferenceConfidence === "low"}
             aria-haspopup="true"
             aria-expanded={modeMenuOpen}
+            title={MODE_TOOLTIP[mode]}
             onclick={() => { modeMenuOpen = !modeMenuOpen; dismissModeFirstTime(); }}
           >
             {inferenceConfidence === "low" ? `${MODE_LABEL[mode]}?` : MODE_LABEL[mode]}
@@ -594,6 +591,7 @@
                   role="menuitem"
                   class="mode-option"
                   class:active={mode === m}
+                  title={MODE_TOOLTIP[m]}
                   onclick={() => { setMode(m); modeMenuOpen = false; }}
                 >{MODE_LABEL[m]}</button>
               {/each}
@@ -616,7 +614,6 @@
           {#each rows as r (r.id)}
             <DefineFormRow
               row={r}
-              radioName={balanceRadioName}
               issues={issuesByRow.get(r.id) ?? []}
               onchange={(patch) => patchRow(r.id, patch)}
               onremove={() => removeRow(r.id)}

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -4,9 +4,6 @@
 
   interface Props {
     row: Row;
-    /** Shared name across all balance radios in this form so the browser
-     *  enforces single-selection within the radiogroup. */
-    radioName: string;
     issues: Issue[];
     /** Parent splices immutably. No bind: into nested $state per #92 §3.2. */
     onchange: (patch: Partial<Row>) => void;
@@ -16,7 +13,7 @@
     oneditenrichment?: (rowId: string, element: string) => void;
   }
 
-  let { row, radioName, issues, onchange, onremove, oneditenrichment }: Props = $props();
+  let { row, issues, onchange, onremove, oneditenrichment }: Props = $props();
 
   /** Single-element rows expose a per-row "E" button to override that
    *  element's isotopic vector. Compound rows hide it (no obvious choice
@@ -54,11 +51,11 @@
     }}
   />
 
-  <label class="balance-label" role="gridcell" title="Use this row to balance to 100%">
+  <label class="balance-label" role="gridcell" title="Use this row to balance to 100% — click again to clear">
     <input
-      type="radio"
-      name={radioName}
+      type="checkbox"
       checked={row.isBalance}
+      aria-label={row.isBalance ? `Clear balance for ${row.formula}` : `Set ${row.formula} as the balance row`}
       onchange={(e) => {
         const checked = (e.target as HTMLInputElement).checked;
         onchange({ isBalance: checked, ...(checked ? { value: null } : {}) });
@@ -164,7 +161,7 @@
     cursor: pointer;
   }
 
-  .balance-label input[type="radio"] {
+  .balance-label input[type="checkbox"] {
     accent-color: var(--c-accent);
     cursor: pointer;
   }

--- a/frontend/src/lib/components/material/define-form-rows.test.ts
+++ b/frontend/src/lib/components/material/define-form-rows.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyRowPatch,
   generateRowId,
   inferMode,
   isTabulatedDensity,
@@ -311,9 +312,11 @@ describe("validate", () => {
     expect(issues.filter((i) => /duplicate/i.test(i.message)).length).toBe(1);
   });
 
-  it("validateSingle rejects balance rows", () => {
+  it("validateSingle does not error on balance rows (auto-cleared on mode switch)", () => {
     const rows: Row[] = [row({ formula: "Al", value: null, isBalance: true })];
-    expect(validateSingle(rows).some((i) => /balance/i.test(i.message))).toBe(true);
+    const issues = validateSingle(rows);
+    expect(issues.some((i) => /balance/i.test(i.message))).toBe(false);
+    expect(issues.some((i) => /stoichiometric/i.test(i.message))).toBe(false);
   });
 
   it("validateAtom flags sum != 1 (no balance)", () => {
@@ -387,5 +390,39 @@ describe("rowAverageAtomicMass", () => {
 
   it("single element returns its standard weight", () => {
     expect(rowAverageAtomicMass("Cu")).toBeCloseTo(63.55, 1);
+  });
+});
+
+describe("applyRowPatch (form-level balance invariant)", () => {
+  it("setting isBalance=true on one row clears it on all other rows", () => {
+    const rows: Row[] = [
+      row({ id: "a", formula: "Fe", value: 50, isBalance: false }),
+      row({ id: "b", formula: "Cr", value: null, isBalance: true }),
+      row({ id: "c", formula: "Ni", value: 30, isBalance: false }),
+    ];
+    const next = applyRowPatch(rows, "a", { isBalance: true, value: null });
+    expect(next.find((r) => r.id === "a")!.isBalance).toBe(true);
+    expect(next.find((r) => r.id === "b")!.isBalance).toBe(false);
+    expect(next.find((r) => r.id === "c")!.isBalance).toBe(false);
+    expect(next.filter((r) => r.isBalance).length).toBe(1);
+  });
+
+  it("setting isBalance=false (un-toggle) leaves zero balance rows", () => {
+    const rows: Row[] = [
+      row({ id: "a", formula: "Fe", value: 50, isBalance: false }),
+      row({ id: "b", formula: "Cr", value: null, isBalance: true }),
+    ];
+    const next = applyRowPatch(rows, "b", { isBalance: false });
+    expect(next.filter((r) => r.isBalance).length).toBe(0);
+  });
+
+  it("non-balance patch leaves other rows' isBalance untouched", () => {
+    const rows: Row[] = [
+      row({ id: "a", formula: "Fe", value: 50, isBalance: false }),
+      row({ id: "b", formula: "Cr", value: null, isBalance: true }),
+    ];
+    const next = applyRowPatch(rows, "a", { value: 60 });
+    expect(next.find((r) => r.id === "a")!.value).toBe(60);
+    expect(next.find((r) => r.id === "b")!.isBalance).toBe(true);
   });
 });

--- a/frontend/src/lib/components/material/define-form-rows.ts
+++ b/frontend/src/lib/components/material/define-form-rows.ts
@@ -393,16 +393,28 @@ export function validateAtom(rows: Row[]): Issue[] {
 
 export function validateSingle(rows: Row[]): Issue[] {
   const issues = validateCommon(rows);
-  const balanceRows = rows.filter((r) => r.isBalance);
-  if (balanceRows.length > 0) {
-    issues.push({ level: "error", message: "Single-formula mode does not allow a balance row" });
-  }
   for (const r of rows) {
+    if (r.isBalance) continue;
     if (r.value === null || !Number.isFinite(r.value) || r.value <= 0) {
       issues.push({ rowId: r.id, level: "error", message: "Stoichiometric count must be > 0" });
     }
   }
   return issues;
+}
+
+/**
+ * Apply a partial patch to the row identified by `id`. When the patch turns
+ * `isBalance` on, force-clear it on every other row — this is the form-level
+ * "only one balance row" invariant that used to be enforced by the browser's
+ * radio-group behaviour. With the toggle now a checkbox (#126), the invariant
+ * lives here.
+ */
+export function applyRowPatch(rows: Row[], id: string, patch: Partial<Row>): Row[] {
+  return rows.map((r) => {
+    if (r.id === id) return { ...r, ...patch };
+    if (patch.isBalance === true && r.isBalance) return { ...r, isBalance: false };
+    return r;
+  });
 }
 
 /** Mode-aware dispatch. */

--- a/frontend/src/types/hyrr-wasm.d.ts
+++ b/frontend/src/types/hyrr-wasm.d.ts
@@ -1,0 +1,11 @@
+// wasm-bindgen `--target web` builds export a callable `default` that
+// loads + instantiates the `.wasm` binary. The auto-generated .d.ts in
+// the `hyrr-wasm` package describes named exports but doesn't declare
+// `default` with a call signature, so `await wasm.default()` in
+// `lib/compute/backend.ts` fails svelte-check. This module augmentation
+// patches the missing signature without touching the runtime path or
+// the wasm-bindgen build config. Tracking issue: #133.
+declare module "hyrr-wasm" {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export default function init(input?: unknown): Promise<any>;
+}


### PR DESCRIPTION
## Summary
- Mode chips renamed to `Formula | wt % | at %` per #126 spike (with hover tooltips matching MCNP/OpenMC/PHITS convention)
- Balance row is now a deselectable checkbox (was: radio that couldn't be unchecked); the "only one balance row" invariant moves into a pure `applyRowPatch` helper
- Switching to formula mode clears the balance flag silently instead of erroring

Closes #126.

## Test plan
- [ ] CI green
- [ ] Manual: enable balance → click again → cleared
- [ ] Manual: switch from wt% to formula with a balance row set → no error
- [ ] Manual: chip tooltips appear on hover