### PR TITLE
feat(frontend): Greek symbols for decay/reaction labels (#131)

### DIFF
--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -5,6 +5,7 @@
   import { getDoseConstant, type DoseSource } from "../utils/dose-constants";
   import { toggleIsotope, isSelected, clearSelection, getSelectedIsotopes } from "../stores/selection.svelte";
   import { getIsotopeFilter } from "../stores/isotope-filter.svelte";
+  import { formatReaction } from "../format";
 
   interface Props {
     result: SimulationResult;
@@ -429,7 +430,7 @@
             <td class="col-a">{row.A}</td>
             <td class="col-hl">{formatHalfLife(row.half_life_s)}</td>
             <td class="col-reaction">
-              {#each [...row.reactions, ...row.decayNotations] as rxn, i}{#if i > 0}, {/if}{rxn}{/each}
+              {#each [...row.reactions, ...row.decayNotations] as rxn, i}{#if i > 0}, {/if}{formatReaction(rxn)}{/each}
               {#if row.reactions.length === 0 && row.decayNotations.length === 0 && row.source === "daughter"}decay{/if}
             </td>
             <td class="col-act">{fmtActivity(row.activity_eob_Bq)}</td>

--- a/frontend/src/lib/components/IsotopeFilterBar.svelte
+++ b/frontend/src/lib/components/IsotopeFilterBar.svelte
@@ -10,6 +10,7 @@
     resetFilter,
   } from "../stores/isotope-filter.svelte";
   import type { SimulationResult } from "../types";
+  import { formatReaction } from "../format";
 
   interface Props {
     result: SimulationResult;
@@ -147,7 +148,7 @@
           <span class="filter-label">Reaction</span>
           <div class="chip-group">
             {#each availableMechanisms as mech}
-              <button class="chip" class:active={filter.reactions.has(mech)} onclick={() => toggleFilterReaction(mech)}>{mech}</button>
+              <button class="chip" class:active={filter.reactions.has(mech)} onclick={() => toggleFilterReaction(mech)} title={mech}>{formatReaction(`(${mech})`).slice(1, -1)}</button>
             {/each}
             {#if filter.reactions.size > 0}
               <button class="chip chip-clear" onclick={clearFilterReactions}>All</button>

--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -23,6 +23,7 @@
   import type { DecayMode, CrossSectionData, ProjectileType } from "@hyrr/compute";
   import { getDepthPreview } from "../stores/depth-preview.svelte";
   import type { CsvTrace } from "../plotting/csv-export";
+  import { formatDecayMode } from "../format";
   import SaveMenu from "./SaveMenu.svelte";
 
   interface Props {
@@ -906,7 +907,7 @@
             <span class="prop-value">
               {#each decayInfo.decayModes as mode, i}
                 {#if i > 0}<span class="prop-sep">, </span>{/if}
-                {mode.mode}{#if mode.branching < 1 && mode.branching > 0}
+                <span title={mode.mode}>{formatDecayMode(mode.mode)}</span>{#if mode.branching < 1 && mode.branching > 0}
                   <span class="branching"> ({(mode.branching * 100).toFixed(1)}%)</span>
                 {/if}
               {/each}
@@ -923,7 +924,7 @@
           {#if parentDecays.length > 0}
             <div class="chain-group">
               {#each parentDecays as p}
-                <span class="chain-nuc parent" title="{p.mode} ({(p.branching * 100).toFixed(1)}%)">{@html nucHtml(p.name)}</span>
+                <span class="chain-nuc parent" title="{formatDecayMode(p.mode)} ({(p.branching * 100).toFixed(1)}%) [{p.mode}]">{@html nucHtml(p.name)}</span>
               {/each}
             </div>
             <span class="chain-arrow">&rarr;</span>
@@ -934,7 +935,7 @@
             <div class="chain-group">
               {#each decayInfo.decayModes.filter(m => m.daughterZ !== null) as mode}
                 {@const dSym = Z_TO_SYMBOL[mode.daughterZ!] ?? `Z${mode.daughterZ}`}
-                <span class="chain-nuc daughter" title="{mode.mode} ({(mode.branching * 100).toFixed(1)}%)">
+                <span class="chain-nuc daughter" title="{formatDecayMode(mode.mode)} ({(mode.branching * 100).toFixed(1)}%) [{mode.mode}]">
                   {@html nucHtml(`${dSym}-${mode.daughterA}${mode.daughterState || ""}`)}
                 </span>
               {/each}

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { formatDecayMode, formatProjectile, formatReaction, reactionFilterMatches } from "./format";
+
+describe("formatDecayMode", () => {
+  it("maps beta_plus / beta+ / positron to β⁺", () => {
+    expect(formatDecayMode("beta_plus")).toBe("β⁺");
+    expect(formatDecayMode("beta+")).toBe("β⁺");
+    expect(formatDecayMode("positron")).toBe("β⁺");
+    expect(formatDecayMode("B+")).toBe("β⁺");
+  });
+
+  it("maps beta_minus / beta- / electron to β⁻", () => {
+    expect(formatDecayMode("beta_minus")).toBe("β⁻");
+    expect(formatDecayMode("beta-")).toBe("β⁻");
+    expect(formatDecayMode("electron")).toBe("β⁻");
+  });
+
+  it("maps alpha → α and gamma → γ", () => {
+    expect(formatDecayMode("alpha")).toBe("α");
+    expect(formatDecayMode("gamma")).toBe("γ");
+  });
+
+  it("passes IT and EC through unchanged", () => {
+    expect(formatDecayMode("IT")).toBe("IT");
+    expect(formatDecayMode("EC")).toBe("EC");
+  });
+
+  it("passes unknown / empty modes through", () => {
+    expect(formatDecayMode("")).toBe("");
+    expect(formatDecayMode("unknown_mode")).toBe("unknown_mode");
+  });
+});
+
+describe("formatProjectile", () => {
+  it("maps light hadrons unchanged", () => {
+    expect(formatProjectile("p")).toBe("p");
+    expect(formatProjectile("n")).toBe("n");
+    expect(formatProjectile("d")).toBe("d");
+    expect(formatProjectile("t")).toBe("t");
+  });
+
+  it("maps alpha → α and gamma → γ", () => {
+    expect(formatProjectile("alpha")).toBe("α");
+    expect(formatProjectile("gamma")).toBe("γ");
+  });
+
+  it("maps he3 variants to ³He", () => {
+    expect(formatProjectile("he3")).toBe("³He");
+    expect(formatProjectile("he-3")).toBe("³He");
+    expect(formatProjectile("3he")).toBe("³He");
+  });
+
+  it("passes unknown through", () => {
+    expect(formatProjectile("xx")).toBe("xx");
+    expect(formatProjectile("")).toBe("");
+  });
+});
+
+describe("formatReaction", () => {
+  it("maps (p,2n) unchanged (no Greek particles)", () => {
+    expect(formatReaction("(p,2n)")).toBe("(p,2n)");
+  });
+
+  it("maps (alpha,gamma) to (α,γ)", () => {
+    expect(formatReaction("(alpha,gamma)")).toBe("(α,γ)");
+  });
+
+  it("maps (d,p) and (alpha,n)", () => {
+    expect(formatReaction("(d,p)")).toBe("(d,p)");
+    expect(formatReaction("(alpha,n)")).toBe("(α,n)");
+  });
+
+  it("preserves multiplier prefixes like 2n, 3alpha", () => {
+    expect(formatReaction("(p,2alpha)")).toBe("(p,2α)");
+  });
+
+  it("is idempotent on already-Greek input", () => {
+    expect(formatReaction("(α,γ)")).toBe("(α,γ)");
+    expect(formatReaction("²⁷Al(p,αn)²²Na")).toBe("²⁷Al(p,αn)²²Na");
+  });
+
+  it("maps decay-arrow notation", () => {
+    expect(formatReaction("²²Mg →beta+→ ²²Na")).toBe("²²Mg →β⁺→ ²²Na");
+    expect(formatReaction("⁹⁹Mo →β-→ ⁹⁹Tc")).toBe("⁹⁹Mo →β⁻→ ⁹⁹Tc");
+  });
+
+  it("returns empty for empty input", () => {
+    expect(formatReaction("")).toBe("");
+  });
+});
+
+describe("reactionFilterMatches (round-trip aliases)", () => {
+  it("ASCII filter input 'beta+' matches a row whose text is 'β⁺'", () => {
+    expect(reactionFilterMatches("²²Na (β⁺)", "beta+")).toBe(true);
+  });
+
+  it("Greek filter input 'β⁺' matches a row whose text contains 'beta+'", () => {
+    expect(reactionFilterMatches("Na-22 (beta+)", "β⁺")).toBe(true);
+  });
+
+  it("plain substring match still works", () => {
+    expect(reactionFilterMatches("(p,2n)", "p,2n")).toBe(true);
+    expect(reactionFilterMatches("²²Na (β⁺)", "β⁺")).toBe(true);
+  });
+
+  it("alpha alias works both directions", () => {
+    expect(reactionFilterMatches("²⁷Al(p,α)²⁴Na", "alpha")).toBe(true);
+    expect(reactionFilterMatches("(p,alpha)", "α")).toBe(true);
+  });
+
+  it("non-matching needle returns false", () => {
+    expect(reactionFilterMatches("(p,2n)", "alpha")).toBe(false);
+  });
+
+  it("empty needle matches anything", () => {
+    expect(reactionFilterMatches("anything", "")).toBe(true);
+  });
+});

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,116 @@
+/**
+ * Render-time formatters for decay modes, projectiles, and reaction notation.
+ *
+ * Wire format stays ASCII (e.g. "beta_plus", "alpha"); these helpers map onto
+ * Greek symbols only at the display layer. CSV/parquet exports must keep the
+ * raw identifier.
+ */
+
+const DECAY_MODE_MAP: Record<string, string> = {
+  "beta_plus": "β⁺",
+  "beta+": "β⁺",
+  "b+": "β⁺",
+  "positron": "β⁺",
+  "ec/beta+": "EC/β⁺",
+  "beta+/ec": "β⁺/EC",
+  "beta_minus": "β⁻",
+  "beta-": "β⁻",
+  "b-": "β⁻",
+  "β-": "β⁻",
+  "β+": "β⁺",
+  "electron": "β⁻",
+  "alpha": "α",
+  "a": "α",
+  "gamma": "γ",
+  "g": "γ",
+};
+
+const PROJECTILE_MAP: Record<string, string> = {
+  "alpha": "α",
+  "a": "α",
+  "gamma": "γ",
+  "g": "γ",
+  "he3": "³He",
+  "he-3": "³He",
+  "3he": "³He",
+  "³he": "³He",
+  "p": "p",
+  "n": "n",
+  "d": "d",
+  "t": "t",
+};
+
+/** Map a decay-mode identifier to its render form (Greek where applicable). */
+export function formatDecayMode(mode: string): string {
+  if (!mode) return mode;
+  const key = mode.trim().toLowerCase();
+  return DECAY_MODE_MAP[key] ?? mode;
+}
+
+/** Map a projectile/particle identifier to its render form. */
+export function formatProjectile(p: string): string {
+  if (!p) return p;
+  const key = p.trim().toLowerCase();
+  return PROJECTILE_MAP[key] ?? p;
+}
+
+/**
+ * Replace particle codes inside a reaction notation string. Handles forms like
+ * `(p,2n)`, `(α,γ)`, `(d,p)`, and the decay-arrow form `X →β+→ Y`. Idempotent
+ * on already-Greek input.
+ */
+export function formatReaction(reaction: string): string {
+  if (!reaction) return reaction;
+  let out = reaction.replace(/\(([^()]*)\)/g, (_m, inner: string) => {
+    const parts = inner.split(",").map((tok) => mapParticleToken(tok));
+    return `(${parts.join(",")})`;
+  });
+  out = out.replace(/→\s*([A-Za-z+\-0-9³αβγ]+)\s*→/g, (_m, tok: string) => {
+    return `→${mapParticleToken(tok)}→`;
+  });
+  return out;
+}
+
+/** Token mapper for reaction-internal particle codes (preserves multiplier prefix). */
+function mapParticleToken(token: string): string {
+  const trimmed = token.trim();
+  const m = trimmed.match(/^(\d*)(.+)$/);
+  if (!m) return trimmed;
+  const [, prefix, rest] = m;
+  const mapped = formatProjectile(rest) !== rest
+    ? formatProjectile(rest)
+    : formatDecayMode(rest) !== rest
+      ? formatDecayMode(rest)
+      : rest;
+  return `${prefix}${mapped}`;
+}
+
+/**
+ * Bidirectional alias map for filter matching. Maps Greek render forms back
+ * to their ASCII identifiers and vice-versa so a user typing "beta+" still
+ * matches a row whose displayed text is "β⁺".
+ */
+const FILTER_ALIASES: Array<[string, string]> = [
+  ["β⁺", "beta+"],
+  ["β⁻", "beta-"],
+  ["α", "alpha"],
+  ["γ", "gamma"],
+  ["³he", "he3"],
+];
+
+/** Expand a haystack with both Greek and ASCII aliases for case-insensitive substring match. */
+export function reactionFilterMatches(haystack: string, needle: string): boolean {
+  if (!needle) return true;
+  const hayLc = haystack.toLowerCase();
+  const needLc = needle.trim().toLowerCase();
+  if (hayLc.includes(needLc)) return true;
+  for (const [greek, ascii] of FILTER_ALIASES) {
+    if (needLc.includes(ascii) && hayLc.includes(greek)) return true;
+    if (needLc.includes(greek) && hayLc.includes(ascii)) return true;
+    const needSwapped = needLc.replace(ascii, greek);
+    if (needSwapped !== needLc && hayLc.includes(needSwapped)) return true;
+    const needSwappedRev = needLc.replace(greek, ascii);
+    if (needSwappedRev !== needLc && hayLc.includes(needSwappedRev)) return true;
+  }
+  return false;
+}

--- a/frontend/src/lib/stores/isotope-filter.svelte.ts
+++ b/frontend/src/lib/stores/isotope-filter.svelte.ts
@@ -2,6 +2,22 @@
  * Shared isotope filter state — consumed by activity plot, table, and production depth.
  */
 
+/** Map Greek render forms back to the ASCII identifier used in extracted
+ * reaction-mechanism keys, so a filter chip showing "β⁻" toggles the same
+ * Set entry that the mechanism extractor produced from the wire data. */
+const MECHANISM_ALIAS: Record<string, string> = {
+  "β⁺": "β+",
+  "β⁻": "β-",
+};
+
+function canonicalizeMechanism(mech: string): string {
+  let out = mech;
+  for (const [greek, ascii] of Object.entries(MECHANISM_ALIAS)) {
+    out = out.split(greek).join(ascii);
+  }
+  return out;
+}
+
 export interface IsotopeFilter {
   text: string;              // name substring match
   layers: Set<number>;       // empty = all layers
@@ -51,8 +67,9 @@ export function clearFilterLayers(): void {
 }
 
 export function toggleFilterReaction(mech: string): void {
+  const key = canonicalizeMechanism(mech);
   const next = new Set(filter.reactions);
-  if (next.has(mech)) next.delete(mech); else next.add(mech);
+  if (next.has(key)) next.delete(key); else next.add(key);
   filter.reactions = next;
 }
 


### PR DESCRIPTION
## Summary
- β⁺ / β⁻ / α / γ rendered for decay modes per #131
- Reaction notation `(p,2n)`, `(α,γ)` etc. uses Greek for relevant particles
- Filter inputs accept both ASCII and Greek forms
- Wire format / export unchanged — ASCII identifiers preserved

Closes #131.

## Test plan
- [ ] CI green
- [ ] Manual: result table reaction column shows β⁺/α/γ
- [ ] Manual: type "beta+" into filter — β⁺ rows still match
- [ ] Manual: parquet export contains "beta_plus" not "β⁺"