### PR TITLE
feat(frontend): display-layer value clamping with configurable thresholds

### DIFF
--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
   import type { SimulationResult } from "../types";
   import { formatHalfLife } from "../plotting/plotly-helpers";
-  import { fmtActivity, fmtYield, fmtDoseRate, nucHtml } from "@hyrr/compute";
+  import { nucHtml } from "@hyrr/compute";
   import { getDoseConstant, type DoseSource } from "../utils/dose-constants";
   import { toggleIsotope, isSelected, clearSelection, getSelectedIsotopes } from "../stores/selection.svelte";
   import { getIsotopeFilter } from "../stores/isotope-filter.svelte";
   import { formatReaction } from "../format";
+  import {
+    getDisplayMode,
+    setDisplayMode,
+    getThresholds,
+    type DisplayMode,
+  } from "../stores/display-thresholds.svelte";
+  import { formatWithThresholdEx } from "../utils/threshold-format";
+  import SettingsModal from "./SettingsModal.svelte";
 
   interface Props {
     result: SimulationResult;
@@ -50,6 +58,19 @@
   /** Default: one row per isotope across all layers. Toggle expands to per-layer rows. */
   let groupByIsotope = $state<boolean>(true);
   let saveOpen = $state(false);
+  let settingsOpen = $state(false);
+
+  let displayMode = $derived(getDisplayMode());
+  let thresholds = $derived(getThresholds());
+  function fmtAct(v: number) { return formatWithThresholdEx(v, "activity", displayMode, thresholds); }
+  function fmtRate(v: number) { return formatWithThresholdEx(v, "activity_rate", displayMode, thresholds); }
+  function fmtDose(v: number) { return formatWithThresholdEx(v, "dose_rate", displayMode, thresholds); }
+
+  const MODE_LABELS: Array<{ id: DisplayMode; label: string; title: string }> = [
+    { id: "indicator", label: "~0", title: "Below threshold: render compact indicator (e.g. '< 1 nBq')" },
+    { id: "zero", label: "0", title: "Below threshold: collapse to 0" },
+    { id: "all", label: "all", title: "No clamping — render every value" },
+  ];
 
   function getEobActivity(iso: { time_grid_s?: number[]; activity_vs_time_Bq?: number[]; activity_Bq: number }, irrS: number): number {
     if (!iso.time_grid_s || !iso.activity_vs_time_Bq || iso.time_grid_s.length === 0) {
@@ -344,6 +365,31 @@
 <div class="activity-table-enhanced">
   <div class="toolbar">
     <span class="row-count">{rows.length}/{allRows.length} isotopes</span>
+    <div class="mode-chip-group" role="radiogroup" aria-label="Below-threshold display">
+      {#each MODE_LABELS as opt}
+        <button
+          type="button"
+          role="radio"
+          aria-checked={displayMode === opt.id}
+          class="chip"
+          class:active={displayMode === opt.id}
+          title={opt.title}
+          onclick={() => setDisplayMode(opt.id)}
+        >{opt.label}</button>
+      {/each}
+      <button
+        type="button"
+        class="chip chip-gear"
+        title="Threshold settings…"
+        aria-label="Threshold settings"
+        onclick={() => (settingsOpen = true)}
+      >
+        <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 4.754a3.246 3.246 0 100 6.492 3.246 3.246 0 000-6.492zM5.754 8a2.246 2.246 0 114.492 0 2.246 2.246 0 01-4.492 0z"/>
+          <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 01-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 01-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 01.52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 011.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 011.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 01.52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 01-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 01-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 002.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 001.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 00-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 00-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 00-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 001.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 003.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 002.692-1.115l.094-.319z"/>
+        </svg>
+      </button>
+    </div>
     <div class="toolbar-actions">
       <button
         class="action-btn"
@@ -403,6 +449,12 @@
       </thead>
       <tbody>
         {#each rows as row}
+          {@const eob = fmtAct(row.activity_eob_Bq)}
+          {@const eoc = fmtAct(row.activity_Bq)}
+          {@const direct = fmtAct(row.activity_direct_Bq)}
+          {@const ingrowth = fmtAct(row.activity_ingrowth_Bq)}
+          {@const sat = fmtRate(row.saturation_yield_Bq_uA)}
+          {@const dose = row.dose_uSv_h !== null ? fmtDose(row.dose_uSv_h) : null}
           <tr
             class:zero={row.activity_Bq === 0}
             class:selected={isSelected(row.name)}
@@ -433,14 +485,14 @@
               {#each [...row.reactions, ...row.decayNotations] as rxn, i}{#if i > 0}, {/if}{formatReaction(rxn)}{/each}
               {#if row.reactions.length === 0 && row.decayNotations.length === 0 && row.source === "daughter"}decay{/if}
             </td>
-            <td class="col-act">{fmtActivity(row.activity_eob_Bq)}</td>
-            <td class="col-act">{fmtActivity(row.activity_Bq)}</td>
-            <td class="col-act">{fmtActivity(row.activity_direct_Bq)}</td>
-            <td class="col-act">{fmtActivity(row.activity_ingrowth_Bq)}</td>
-            <td class="col-yield">{row.source === "daughter" ? "—" : fmtYield(row.saturation_yield_Bq_uA)}</td>
+            <td class="col-act" class:clamped={eob.clamped}>{eob.text}</td>
+            <td class="col-act" class:clamped={eoc.clamped}>{eoc.text}</td>
+            <td class="col-act" class:clamped={direct.clamped}>{direct.text}</td>
+            <td class="col-act" class:clamped={ingrowth.clamped}>{ingrowth.text}</td>
+            <td class="col-yield" class:clamped={row.source !== "daughter" && sat.clamped}>{row.source === "daughter" ? "—" : sat.text}</td>
             <td class="col-rnp">{row.rnp_eob_pct < 0.01 ? "<0.01" : row.rnp_eob_pct.toFixed(2)}%</td>
             <td class="col-rnp">{row.rnp_pct < 0.01 ? "<0.01" : row.rnp_pct.toFixed(2)}%</td>
-            <td class="col-dose" class:dose-approx={row.dose_source === "it-approx"}>{#if row.dose_uSv_h !== null}{row.dose_source === "it-approx" ? "~" : ""}{fmtDoseRate(row.dose_uSv_h)}{:else}&mdash;{/if}</td>
+            <td class="col-dose" class:dose-approx={row.dose_source === "it-approx"} class:clamped={dose?.clamped ?? false}>{#if dose !== null}{row.dose_source === "it-approx" ? "~" : ""}{dose.text}{:else}&mdash;{/if}</td>
           </tr>
         {/each}
       </tbody>
@@ -451,6 +503,8 @@
 <svelte:window onclick={(e: MouseEvent) => {
   if (saveOpen && !(e.target as HTMLElement)?.closest?.(".save-wrap")) saveOpen = false;
 }} />
+
+<SettingsModal open={settingsOpen} onclose={() => (settingsOpen = false)} />
 
 <style>
   .save-wrap { position: relative; display: inline-flex; }
@@ -711,6 +765,18 @@
   tr.selected td { border-left: 2px solid var(--c-accent); }
   tr.selected td:first-child { border-left: 3px solid var(--c-accent); }
   tr.zero td { opacity: 0.35; }
+  td.clamped { color: var(--c-text-faint); font-style: italic; }
+
+  .mode-chip-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
+    margin-left: 0.4rem;
+  }
+  .mode-chip-group .chip-gear {
+    padding: 0.15rem 0.3rem;
+    line-height: 0;
+  }
 
   .isotope-link {
     background: none;

--- a/frontend/src/lib/components/HeaderBar.svelte
+++ b/frontend/src/lib/components/HeaderBar.svelte
@@ -8,6 +8,7 @@
   import { cycleTheme, getThemeMode, getResolvedTheme } from "../stores/theme.svelte";
   import { getResult, setResult } from "../stores/results.svelte";
   import { buildSessionFile, downloadSessionFile, pickSessionFile } from "../session-io";
+  import { getDisplayThresholds, setDisplayThresholds } from "../stores/display-thresholds.svelte";
   import { openExternalUrl } from "../utils/open-url";
   import logoUrl from "/logo.svg?url";
 
@@ -31,7 +32,7 @@
     saveMenuOpen = false;
     const cfg = getSerializableConfig();
     const res = includeResult ? getResult() : null;
-    const file = buildSessionFile(cfg, res);
+    const file = buildSessionFile(cfg, res, undefined, getDisplayThresholds());
     downloadSessionFile(file);
   }
 
@@ -43,6 +44,7 @@
       if (f.result) {
         setResult(f.result);
       }
+      if (f.display) setDisplayThresholds(f.display);
     } catch (e: any) {
       if (!/No file selected/.test(String(e?.message ?? e))) {
         // eslint-disable-next-line no-alert

--- a/frontend/src/lib/components/PlotActivityCurve.svelte
+++ b/frontend/src/lib/components/PlotActivityCurve.svelte
@@ -9,6 +9,7 @@
   import { getSelectedIsotopes, clearSelection } from "../stores/selection.svelte";
   import { getIsotopeFilter } from "../stores/isotope-filter.svelte";
   import { aggregateByIsotopeName } from "../plotting/aggregate-isotopes";
+  import { getThresholds } from "../stores/display-thresholds.svelte";
 
   interface Props {
     result: SimulationResult;
@@ -323,6 +324,17 @@
         title: `Activity (${actLabel})`,
         gridcolor: tc.border,
         type: logY ? "log" : "linear",
+        // On log scale, clamp the lower bound to the activity threshold
+        // (in plot units) so a single 1e-15 Bq straggler doesn't dominate
+        // the y-range. See #130 P1. Display-only; trace data is unmodified.
+        ...(logY
+          ? {
+              range: [
+                Math.log10(Math.max(getThresholds().activity / actDiv, 1e-30)),
+                Math.log10(Math.max(globalMax / actDiv, getThresholds().activity / actDiv * 10)),
+              ],
+            }
+          : {}),
       },
       shapes,
       annotations,

--- a/frontend/src/lib/components/SettingsModal.svelte
+++ b/frontend/src/lib/components/SettingsModal.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+  import Modal from "./Modal.svelte";
+  import {
+    getThresholds,
+    setThreshold,
+    resetThresholds,
+    defaults,
+    type Thresholds,
+  } from "../stores/display-thresholds.svelte";
+
+  interface Props {
+    open: boolean;
+    onclose: () => void;
+  }
+
+  let { open, onclose }: Props = $props();
+
+  let thresholds = $derived(getThresholds());
+
+  interface Field {
+    key: keyof Thresholds;
+    label: string;
+    unit: string;
+    hint: string;
+  }
+
+  const FIELDS: Field[] = [
+    { key: "activity", label: "Activity", unit: "Bq", hint: "Default 1e-9 (1 nBq)" },
+    { key: "activity_rate", label: "Saturation yield / activity rate", unit: "Bq/µA", hint: "Default 1e-9 (1 nBq/µA)" },
+    { key: "dose_rate", label: "Dose rate", unit: "µSv/h", hint: "Default 1e-3 (1 nSv/h)" },
+    { key: "fraction", label: "Atom / mass fraction", unit: "—", hint: "Default 1e-9" },
+    { key: "energy", label: "Residual energy", unit: "MeV", hint: "Default 1e-6 (1e-3 keV)" },
+  ];
+
+  function onInput(key: keyof Thresholds, e: Event) {
+    const val = parseFloat((e.target as HTMLInputElement).value);
+    if (isFinite(val) && val >= 0) setThreshold(key, val);
+  }
+</script>
+
+<Modal {open} {onclose} title="Display thresholds">
+  <p class="intro">
+    Below these floors, table cells render as <code>~0</code> / <code>0</code> / <code>&lt; 1 nBq</code>
+    (per the chip on the result panel). Compute and exports keep the raw values.
+  </p>
+  <div class="grid">
+    {#each FIELDS as f}
+      <label class="row">
+        <span class="label">
+          {f.label}
+          <span class="hint">{f.hint}</span>
+        </span>
+        <span class="input-wrap">
+          <input
+            type="number"
+            min="0"
+            step="any"
+            value={thresholds[f.key]}
+            oninput={(e) => onInput(f.key, e)}
+          />
+          <span class="unit">{f.unit}</span>
+        </span>
+      </label>
+    {/each}
+  </div>
+  <div class="actions">
+    <button class="btn-reset" onclick={resetThresholds} title="Reset to defaults">
+      Reset to defaults ({Object.entries(defaults).length})
+    </button>
+  </div>
+</Modal>
+
+<style>
+  .intro { font-size: 0.8rem; color: var(--c-text-muted); margin: 0 0 0.75rem; }
+  .intro code {
+    background: var(--c-bg-default);
+    padding: 0 0.2rem;
+    border-radius: 3px;
+    font-size: 0.75rem;
+  }
+  .grid { display: flex; flex-direction: column; gap: 0.5rem; }
+  .row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--c-border);
+  }
+  .row:last-child { border-bottom: none; }
+  .label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    font-size: 0.85rem;
+    color: var(--c-text);
+  }
+  .hint { font-size: 0.7rem; color: var(--c-text-faint); }
+  .input-wrap {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+  input {
+    width: 110px;
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    color: var(--c-text);
+    padding: 0.25rem 0.4rem;
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    text-align: right;
+  }
+  input:focus { outline: none; border-color: var(--c-accent); }
+  .unit { font-size: 0.75rem; color: var(--c-text-muted); min-width: 3.2em; }
+  .actions { margin-top: 0.75rem; display: flex; justify-content: flex-end; }
+  .btn-reset {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    color: var(--c-text-muted);
+    padding: 0.3rem 0.6rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+  }
+  .btn-reset:hover { border-color: var(--c-accent); color: var(--c-text); }
+</style>

--- a/frontend/src/lib/session-io.test.ts
+++ b/frontend/src/lib/session-io.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { buildSessionFile, parseSessionJson, SESSION_SCHEMA_VERSION } from "./session-io";
+import type { SerializableConfig } from "./stores/config.svelte";
+import type { SimulationResult } from "./types";
+
+const cfg = {} as SerializableConfig;
+
+describe("session-io display-thresholds round-trip", () => {
+  it("includes display state when provided", () => {
+    const file = buildSessionFile(cfg, null, undefined, {
+      mode: "indicator",
+      thresholds: {
+        activity: 1e-9,
+        activity_rate: 1e-9,
+        dose_rate: 1e-3,
+        fraction: 1e-9,
+        energy: 1e-6,
+      },
+    });
+    expect(file.schema_version).toBe(SESSION_SCHEMA_VERSION);
+    expect(file.display?.mode).toBe("indicator");
+    expect(file.display?.thresholds.activity).toBe(1e-9);
+
+    const parsed = parseSessionJson(JSON.stringify(file));
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.file.display?.mode).toBe("indicator");
+      expect(parsed.file.display?.thresholds.dose_rate).toBe(1e-3);
+    }
+  });
+
+  it("loads v1 files (no display field) without error", () => {
+    const v1 = JSON.stringify({
+      $schema: "hyrr-session",
+      schema_version: 1,
+      hyrr_version: "0.7.0",
+      saved_at: new Date().toISOString(),
+      config: cfg,
+      result: null,
+    });
+    const parsed = parseSessionJson(v1);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) expect(parsed.file.display).toBeUndefined();
+  });
+});
+
+describe("session-io must NOT clamp result values", () => {
+  // Issue #130 invariant: tiny values pass through the JSON model
+  // unmodified. Display clamping is applied after deserialisation, only
+  // when rendering — never to `result.layers[i].isotopes[j].activity_Bq`.
+  it("preserves a 1e-15 Bq isotope activity through serialise/parse", () => {
+    const tiny = 1.234e-15;
+    const result = {
+      config: { irradiation_s: 60 },
+      layers: [
+        {
+          layer_index: 0,
+          isotopes: [
+            {
+              name: "Co-58",
+              Z: 27,
+              A: 58,
+              state: "",
+              half_life_s: 6.1e6,
+              activity_Bq: tiny,
+              saturation_yield_Bq_uA: tiny,
+              source: "direct",
+              activity_direct_Bq: tiny,
+              activity_ingrowth_Bq: 0,
+              reactions: [],
+              decay_notations: [],
+              time_grid_s: [60],
+              activity_vs_time_Bq: [tiny],
+            },
+          ],
+        },
+      ],
+    } as unknown as SimulationResult;
+
+    const file = buildSessionFile(cfg, result);
+    const json = JSON.stringify(file);
+    const parsed = parseSessionJson(json);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const isoActivity =
+      (parsed.file.result as any).layers[0].isotopes[0].activity_Bq;
+    expect(isoActivity).toBe(tiny);
+    expect(isoActivity).toBeLessThan(1e-9); // below default threshold
+  });
+});

--- a/frontend/src/lib/session-io.ts
+++ b/frontend/src/lib/session-io.ts
@@ -10,8 +10,10 @@
 
 import type { SimulationResult } from "./types";
 import type { SerializableConfig } from "./stores/config.svelte";
+import type { DisplayThresholdsState } from "./stores/display-thresholds.svelte";
 
-export const SESSION_SCHEMA_VERSION = 1;
+/** v1 → v2 added optional `display` (issue #130). v1 files load fine. */
+export const SESSION_SCHEMA_VERSION = 2;
 /** MIME-sensible marker that the file was produced by HYRR. */
 export const SESSION_SCHEMA_ID = "hyrr-session";
 
@@ -25,6 +27,8 @@ export interface SessionFile {
   result: SimulationResult | null;
   /** Optional free-form user text. */
   notes?: string;
+  /** Optional UI prefs (display-layer only — never affects the result). */
+  display?: DisplayThresholdsState;
 }
 
 declare const __APP_VERSION__: string;
@@ -33,6 +37,7 @@ export function buildSessionFile(
   config: SerializableConfig,
   result: SimulationResult | null,
   notes?: string,
+  display?: DisplayThresholdsState,
 ): SessionFile {
   return {
     $schema: SESSION_SCHEMA_ID,
@@ -42,6 +47,7 @@ export function buildSessionFile(
     config,
     result,
     notes,
+    display,
   };
 }
 
@@ -102,6 +108,7 @@ export function parseSessionJson(raw: string): ParseResult {
       config: obj.config,
       result: obj.result ?? null,
       notes: typeof obj.notes === "string" ? obj.notes : undefined,
+      display: obj.display && typeof obj.display === "object" ? obj.display : undefined,
     },
   };
 }

--- a/frontend/src/lib/stores/display-thresholds.svelte.ts
+++ b/frontend/src/lib/stores/display-thresholds.svelte.ts
@@ -1,0 +1,121 @@
+/**
+ * Display-layer thresholds for clamping negligible values in tables / tooltips.
+ *
+ * Compute output is the source of truth — these thresholds are applied at
+ * render time only. Never clamp inside `@hyrr/compute` or any backend; raw
+ * values must reach parquet / JSON exports unmodified. See issue #130.
+ */
+
+const STORAGE_KEY = "hyrr-display-thresholds";
+
+export type DisplayMode = "all" | "zero" | "indicator";
+
+export interface Thresholds {
+  /** Activity floor in Bq. */
+  activity: number;
+  /** Saturation / activity-rate floor in Bq/µA. */
+  activity_rate: number;
+  /** Dose rate floor in µSv/h (matches the unit used by `fmtDoseRate`). */
+  dose_rate: number;
+  /** Atom / mass fraction floor (dimensionless). */
+  fraction: number;
+  /** Residual energy floor in MeV. */
+  energy: number;
+}
+
+/** Defaults from issue #130. Dose default is 1 nSv/h = 1e-3 µSv/h. */
+export const defaults: Readonly<Thresholds> = Object.freeze({
+  activity: 1e-9,
+  activity_rate: 1e-9,
+  dose_rate: 1e-3,
+  fraction: 1e-9,
+  energy: 1e-6,
+});
+
+interface Persisted {
+  mode: DisplayMode;
+  thresholds: Thresholds;
+}
+
+function loadFromStorage(): Persisted {
+  if (typeof localStorage === "undefined") return { mode: "indicator", thresholds: { ...defaults } };
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { mode: "indicator", thresholds: { ...defaults } };
+    const parsed = JSON.parse(raw);
+    return {
+      mode: validMode(parsed?.mode) ? parsed.mode : "indicator",
+      thresholds: { ...defaults, ...sanitiseThresholds(parsed?.thresholds) },
+    };
+  } catch {
+    return { mode: "indicator", thresholds: { ...defaults } };
+  }
+}
+
+function validMode(m: unknown): m is DisplayMode {
+  return m === "all" || m === "zero" || m === "indicator";
+}
+
+function sanitiseThresholds(t: unknown): Partial<Thresholds> {
+  if (!t || typeof t !== "object") return {};
+  const out: Partial<Thresholds> = {};
+  for (const k of Object.keys(defaults) as (keyof Thresholds)[]) {
+    const v = (t as Record<string, unknown>)[k];
+    if (typeof v === "number" && isFinite(v) && v >= 0) out[k] = v;
+  }
+  return out;
+}
+
+const initial = loadFromStorage();
+let mode = $state<DisplayMode>(initial.mode);
+let thresholds = $state<Thresholds>(initial.thresholds);
+
+function persist(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ mode, thresholds }));
+  } catch {
+    /* quota / private mode — ignore */
+  }
+}
+
+export function getDisplayMode(): DisplayMode {
+  return mode;
+}
+
+export function setDisplayMode(m: DisplayMode): void {
+  mode = m;
+  persist();
+}
+
+export function getThresholds(): Thresholds {
+  return thresholds;
+}
+
+export function setThreshold<K extends keyof Thresholds>(quantity: K, value: number): void {
+  if (!isFinite(value) || value < 0) return;
+  thresholds = { ...thresholds, [quantity]: value };
+  persist();
+}
+
+export function resetThresholds(): void {
+  thresholds = { ...defaults };
+  persist();
+}
+
+/** Snapshot for session save. */
+export interface DisplayThresholdsState {
+  mode: DisplayMode;
+  thresholds: Thresholds;
+}
+
+export function getDisplayThresholds(): DisplayThresholdsState {
+  return { mode, thresholds: { ...thresholds } };
+}
+
+export function setDisplayThresholds(state: Partial<DisplayThresholdsState> | null | undefined): void {
+  if (!state || typeof state !== "object") return;
+  if (validMode(state.mode)) mode = state.mode;
+  thresholds = { ...defaults, ...sanitiseThresholds(state.thresholds) };
+  persist();
+}

--- a/frontend/src/lib/utils/threshold-format.test.ts
+++ b/frontend/src/lib/utils/threshold-format.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatWithThreshold,
+  formatWithThresholdEx,
+  isAboveThreshold,
+} from "./threshold-format";
+import type { Thresholds } from "../stores/display-thresholds.svelte";
+
+const T: Thresholds = {
+  activity: 1e-9,
+  activity_rate: 1e-9,
+  dose_rate: 1e-3,
+  fraction: 1e-9,
+  energy: 1e-6,
+};
+
+describe("isAboveThreshold", () => {
+  it("returns true above threshold", () => {
+    expect(isAboveThreshold(1, 1e-9)).toBe(true);
+    expect(isAboveThreshold(2e-9, 1e-9)).toBe(true);
+  });
+
+  it("returns true at exact threshold (>=)", () => {
+    expect(isAboveThreshold(1e-9, 1e-9)).toBe(true);
+  });
+
+  it("returns false below threshold", () => {
+    expect(isAboveThreshold(1e-15, 1e-9)).toBe(false);
+    expect(isAboveThreshold(0, 1e-9)).toBe(false);
+  });
+
+  it("compares on absolute value (negative residuals)", () => {
+    expect(isAboveThreshold(-1e-15, 1e-9)).toBe(false);
+    expect(isAboveThreshold(-2, 1e-9)).toBe(true);
+  });
+
+  it("passes NaN and Infinity through (never clamp)", () => {
+    expect(isAboveThreshold(NaN, 1e-9)).toBe(true);
+    expect(isAboveThreshold(Infinity, 1e-9)).toBe(true);
+    expect(isAboveThreshold(-Infinity, 1e-9)).toBe(true);
+  });
+});
+
+describe("formatWithThreshold — mode='all'", () => {
+  it("never clamps, regardless of magnitude", () => {
+    const tiny = formatWithThresholdEx(1e-15, "activity", "all", T);
+    expect(tiny.clamped).toBe(false);
+    expect(tiny.text).toMatch(/Bq/);
+    const negTiny = formatWithThresholdEx(-2.7e-21, "activity", "all", T);
+    expect(negTiny.clamped).toBe(false);
+    expect(negTiny.text).toMatch(/Bq/);
+  });
+});
+
+describe("formatWithThreshold — mode='zero'", () => {
+  it("collapses below threshold to a unit-aware 0", () => {
+    const r = formatWithThresholdEx(1e-15, "activity", "zero", T);
+    expect(r.clamped).toBe(true);
+    expect(r.text).toBe("0");
+  });
+
+  it("collapses negative tiny activity to 0", () => {
+    expect(formatWithThreshold(-2.7e-21, "activity", "zero", T)).toBe("0");
+  });
+
+  it("passes through above-threshold values", () => {
+    const r = formatWithThresholdEx(1e3, "activity", "zero", T);
+    expect(r.clamped).toBe(false);
+    expect(r.text).toMatch(/kBq/);
+  });
+});
+
+describe("formatWithThreshold — mode='indicator'", () => {
+  it("renders compact indicator below threshold", () => {
+    expect(formatWithThreshold(1e-15, "activity", "indicator", T)).toBe("< 1 nBq");
+    expect(formatWithThreshold(1e-15, "activity_rate", "indicator", T)).toBe("< 1 nBq/µA");
+    expect(formatWithThreshold(1e-15, "dose_rate", "indicator", T)).toBe("< 1 nSv/h");
+    expect(formatWithThreshold(1e-15, "fraction", "indicator", T)).toBe("~0");
+    expect(formatWithThreshold(1e-15, "energy", "indicator", T)).toBe("~0 MeV");
+  });
+
+  it("flags clamped result for the CSS hook", () => {
+    const r = formatWithThresholdEx(1e-15, "activity", "indicator", T);
+    expect(r.clamped).toBe(true);
+  });
+
+  it("does not clamp at exact threshold", () => {
+    const r = formatWithThresholdEx(1e-9, "activity", "indicator", T);
+    expect(r.clamped).toBe(false);
+    expect(r.text).not.toBe("< 1 nBq");
+  });
+
+  it("clamps just below threshold", () => {
+    const r = formatWithThresholdEx(0.999e-9, "activity", "indicator", T);
+    expect(r.clamped).toBe(true);
+  });
+});
+
+describe("formatWithThreshold — exceptional values", () => {
+  it("passes NaN through unclamped in every mode", () => {
+    for (const m of ["all", "zero", "indicator"] as const) {
+      const r = formatWithThresholdEx(NaN, "activity", m, T);
+      expect(r.clamped).toBe(false);
+    }
+  });
+
+  it("passes Infinity through unclamped in every mode", () => {
+    for (const m of ["all", "zero", "indicator"] as const) {
+      const r = formatWithThresholdEx(Infinity, "activity", m, T);
+      expect(r.clamped).toBe(false);
+    }
+  });
+
+  it("treats exact zero as below threshold (collapses / indicates)", () => {
+    expect(formatWithThresholdEx(0, "activity", "indicator", T).clamped).toBe(true);
+    expect(formatWithThresholdEx(0, "activity", "zero", T).text).toBe("0");
+  });
+});
+
+describe("export paths must NOT clamp — direct invariant", () => {
+  // Belt-and-suspenders: tiny raw values must round-trip through pure JS
+  // without going through formatWithThreshold. This guards against
+  // accidental wiring of the helper into the export pipeline.
+  it("a raw 1e-15 Bq value remains 1e-15 when serialised by toExponential", () => {
+    const v = 1e-15;
+    expect(v.toExponential(4)).toBe("1.0000e-15");
+  });
+});

--- a/frontend/src/lib/utils/threshold-format.ts
+++ b/frontend/src/lib/utils/threshold-format.ts
@@ -1,0 +1,80 @@
+/**
+ * Display-layer threshold helpers (issue #130).
+ *
+ * Wraps the raw `fmt*` formatters from `@hyrr/compute` with a clamp pass that
+ * collapses noise / Bateman residuals below a per-quantity floor. Pure —
+ * never call from compute, export, or session-save paths. The `SimulationResult`
+ * keeps full precision; only rendered cells / tooltip text go through here.
+ */
+
+import { fmtActivity, fmtYield, fmtDoseRate } from "@hyrr/compute";
+import type { DisplayMode, Thresholds } from "../stores/display-thresholds.svelte";
+
+export type Quantity = keyof Thresholds;
+
+/** Compact below-threshold labels. Match unit conventions used by `fmt*`. */
+const INDICATOR_LABEL: Record<Quantity, string> = {
+  activity: "< 1 nBq",
+  activity_rate: "< 1 nBq/µA",
+  dose_rate: "< 1 nSv/h",
+  fraction: "~0",
+  energy: "~0 MeV",
+};
+
+/** Strict-zero collapse renders unit-aware "0" so columns stay readable. */
+const ZERO_LABEL: Record<Quantity, string> = {
+  activity: "0",
+  activity_rate: "0",
+  dose_rate: "0",
+  fraction: "0",
+  energy: "0 MeV",
+};
+
+const RAW_FORMATTERS: Record<Quantity, (v: number) => string> = {
+  activity: fmtActivity,
+  activity_rate: fmtYield,
+  dose_rate: fmtDoseRate,
+  fraction: (v) => v.toExponential(2),
+  energy: (v) => `${v.toPrecision(4)} MeV`,
+};
+
+/**
+ * Pure threshold check. Returns true when the raw formatter should render
+ * verbatim (NaN / Infinity are passed through so users see the bug).
+ */
+export function isAboveThreshold(value: number, threshold: number): boolean {
+  if (typeof value !== "number") return true;
+  if (!isFinite(value)) return true; // NaN, ±Infinity — never clamp
+  return Math.abs(value) >= threshold;
+}
+
+export interface FormatResult {
+  text: string;
+  /** True when rendering a `< 1 nBq` style indicator — caller can de-emphasise. */
+  clamped: boolean;
+}
+
+/** Threshold-aware formatter result with a CSS hook for de-emphasis. */
+export function formatWithThresholdEx(
+  value: number,
+  quantity: Quantity,
+  mode: DisplayMode,
+  thresholds: Thresholds,
+): FormatResult {
+  const raw = RAW_FORMATTERS[quantity];
+  if (mode === "all" || isAboveThreshold(value, thresholds[quantity])) {
+    return { text: raw(value), clamped: false };
+  }
+  if (mode === "zero") return { text: ZERO_LABEL[quantity], clamped: true };
+  return { text: INDICATOR_LABEL[quantity], clamped: true };
+}
+
+/** Convenience wrapper returning just the text. */
+export function formatWithThreshold(
+  value: number,
+  quantity: Quantity,
+  mode: DisplayMode,
+  thresholds: Thresholds,
+): string {
+  return formatWithThresholdEx(value, quantity, mode, thresholds).text;
+}


### PR DESCRIPTION
## Summary
- Display-layer clamping for negligible activities / doses / fractions per #130
- Three-mode chip in result-panel header: Show all / Collapse to 0 / ~0 indicator (default)
- Per-quantity thresholds in Settings; defaults: 1 nBq, 1 nBq/µA, 1 nSv/h, 1e-9 fraction, 1e-3 keV
- Activity log-plot y-range clamped to activity threshold so a 1e-15 Bq straggler can't dominate the axis
- Compute / export paths unchanged — raw values preserved end-to-end

Closes #130.

## Test plan
- [ ] CI green
- [ ] Manual: result table with a 1e-15 Bq isotope row collapses to "< 1 nBq" in default mode
- [ ] Manual: parquet export still has the unclamped 1e-15 value (verify via Python)
- [ ] Manual: settings persist across save/load session
- [ ] Manual: activity plot in log mode no longer auto-zooms to noise floor