### PR TITLE
fix(frontend): $state wrapping for non-reactive locals + closure-captured prop

### DIFF
--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -42,10 +42,13 @@
   let depthPlotDiv = $state<HTMLDivElement | null>(null);
   let actPlotDiv = $state<HTMLDivElement | null>(null);
 
-  // CSV export state — updated by each plot's render function.
-  let xsExport: { traces: CsvTrace[]; xLabel: string; yLabel: string } | null = null;
-  let depthExport: { traces: CsvTrace[]; xLabel: string; yLabel: string } | null = null;
-  let actExport: { traces: CsvTrace[]; xLabel: string; yLabel: string } | null = null;
+  // CSV export state — updated by each plot's render function. $state so
+  // the SaveMenu xLabel/yLabel bindings invalidate when render() reruns
+  // (e.g. user changes time-unit or projectile); plain `let` left them
+  // stale on subsequent saves.
+  let xsExport = $state<{ traces: CsvTrace[]; xLabel: string; yLabel: string } | null>(null);
+  let depthExport = $state<{ traces: CsvTrace[]; xLabel: string; yLabel: string } | null>(null);
+  let actExport = $state<{ traces: CsvTrace[]; xLabel: string; yLabel: string } | null>(null);
 
   /** Determine reaction notation, e.g. "(p,n)", "(p,γ)", "(p,2n)" */
   function reactionNotation(proj: string, targetZ: number, targetA: number, residualZ: number, residualA: number): string {

--- a/frontend/src/lib/components/PlotActivityCurve.svelte
+++ b/frontend/src/lib/components/PlotActivityCurve.svelte
@@ -35,9 +35,11 @@
   // When true, fall back to one trace per (layer, isotope) pair. (#54)
   let expandPerLayer = $state<boolean>(false);
 
-  // Populated by render() — captured for CSV/Parquet export. Never read
-  // inside $derived to avoid reactivity loops; only read by save handlers.
-  let lastExport: { traces: CsvTrace[]; xLabel: string; yLabel: string } | null = null;
+  // Populated by render() — captured for CSV/Parquet export. Wrapped in
+  // $state so the SaveMenu's xLabel/yLabel bindings invalidate when the
+  // user toggles RNP / EOB / time-unit; previously a plain `let` left the
+  // export header stale on subsequent saves.
+  let lastExport = $state<{ traces: CsvTrace[]; xLabel: string; yLabel: string } | null>(null);
 
   function toggleRnpIso(name: string) {
     const next = new Set(rnpIsotopes);

--- a/frontend/src/lib/components/PlotProductionDepth.svelte
+++ b/frontend/src/lib/components/PlotProductionDepth.svelte
@@ -24,7 +24,7 @@
   let legendVisibility = new Map<string, boolean | "legendonly">();
   let legendListenersAttached = false;
 
-  let lastExport: { traces: CsvTrace[]; xLabel: string; yLabel: string } | null = null;
+  let lastExport = $state<{ traces: CsvTrace[]; xLabel: string; yLabel: string } | null>(null);
 
   onMount(async () => {
     Plotly = await import("plotly.js-dist-min");

--- a/frontend/src/lib/components/ThicknessInput.svelte
+++ b/frontend/src/lib/components/ThicknessInput.svelte
@@ -20,11 +20,11 @@
         : "energy_out_MeV",
   );
 
-  const MODES: { id: ThicknessMode; label: string; disabled?: boolean }[] = [
+  const MODES = $derived<{ id: ThicknessMode; label: string; disabled?: boolean }[]>([
     { id: "thickness_cm", label: "Thickness" },
     { id: "areal_density_g_cm2", label: "Areal dens." },
     { id: "energy_out_MeV", label: "E<sub>out</sub>", disabled: isInGroup },
-  ];
+  ]);
 
   // --- Smart thickness text input (thickness_cm mode) ---
   let thicknessText = $state("");


### PR DESCRIPTION
## Summary
- Six \`svelte-check\` warnings that translate into real reactivity bugs:
  - 4× export-state \`let\` declarations (\`lastExport\`, \`xsExport\`, \`depthExport\`, \`actExport\`) — wrapped in \`\$state(...)\` so the SaveMenu's xLabel/yLabel bindings invalidate when render() re-runs.
  - 1× \`ThicknessInput.MODES\` was \`const\` evaluated once, capturing \`isInGroup\` at first render — promoted to \`\$derived(...)\`.

Surfaced by digging into \`npm run check\` after the #126/#130/#131 batch landed. Drops the warning count from 47 → 41.

## Test plan
- [ ] CI green (lint + test 3.12 + supplier-catalog)
- [ ] Manual: open a result → toggle RNP / EOB / time-unit on the activity plot → click Save → exported file's header reflects the *current* axis labels (not the first-render ones)
- [ ] Manual: toggle a layer in/out of a group → the Eout mode chip in ThicknessInput becomes correctly enabled/disabled