### PR TITLE
chore(frontend): clear svelte-check warning floor (#139)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -386,8 +386,12 @@
     </div>
 
     {#if historyOpen}
-      <!-- svelte-ignore a11y_no_static_element_interactions -->
-      <div class="history-overlay" onclick={() => setHistoryOpen(false)}></div>
+      <div
+        class="history-overlay"
+        role="presentation"
+        onclick={() => setHistoryOpen(false)}
+        onkeydown={(e) => { if (e.key === "Escape") setHistoryOpen(false); }}
+      ></div>
       <div class="history-drawer">
         <div class="panel">
           <div class="panel-header">

--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -576,104 +576,10 @@
     color: var(--c-text);
   }
 
-  .action-btn.has-filters {
-    border-color: var(--c-accent);
-    color: var(--c-accent);
-  }
-
   .row-count {
     font-size: 0.65rem;
     color: var(--c-text-subtle);
     font-variant-numeric: tabular-nums;
-  }
-
-  /* Filter panel */
-  .filter-panel {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem 1rem;
-    padding: 0.5rem;
-    background: var(--c-bg-default);
-    border: 1px solid var(--c-border);
-    border-radius: 4px;
-    align-items: center;
-  }
-
-  .filter-section {
-    display: flex;
-    align-items: center;
-    gap: 0.3rem;
-  }
-
-  .filter-section-wide {
-    flex-basis: 100%;
-  }
-
-  .filter-label {
-    font-size: 0.65rem;
-    color: var(--c-text-subtle);
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-    white-space: nowrap;
-  }
-
-  .filter-input {
-    width: 90px;
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text);
-    padding: 0.2rem 0.35rem;
-    font-size: 0.7rem;
-  }
-
-  .filter-input:focus {
-    outline: none;
-    border-color: var(--c-accent);
-  }
-
-  .filter-num {
-    width: 38px;
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text);
-    padding: 0.2rem 0.3rem;
-    font-size: 0.7rem;
-    text-align: center;
-  }
-
-  .filter-num:focus {
-    outline: none;
-    border-color: var(--c-accent);
-  }
-
-  .filter-num-wide {
-    width: 60px;
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text);
-    padding: 0.2rem 0.3rem;
-    font-size: 0.7rem;
-    text-align: right;
-  }
-
-  .filter-num-wide:focus {
-    outline: none;
-    border-color: var(--c-accent);
-  }
-
-  .filter-sep {
-    color: var(--c-text-faint);
-    font-size: 0.7rem;
-  }
-
-
-  .chip-group {
-    display: flex;
-    gap: 0.2rem;
-    flex-wrap: wrap;
   }
 
   .chip {
@@ -697,19 +603,6 @@
     background: var(--c-bg-active);
     border-color: var(--c-accent);
     color: var(--c-accent);
-  }
-
-  .clear-btn {
-    background: none;
-    border: none;
-    color: var(--c-red);
-    font-size: 0.65rem;
-    cursor: pointer;
-    padding: 0.2rem 0.35rem;
-  }
-
-  .clear-btn:hover {
-    text-decoration: underline;
   }
 
   /* Table */
@@ -831,15 +724,6 @@
     .action-btn {
       padding: 0.35rem 0.6rem;
       font-size: 0.75rem;
-    }
-
-    .filter-panel {
-      flex-direction: column;
-      align-items: stretch;
-    }
-
-    .filter-section {
-      width: 100%;
     }
   }
 </style>

--- a/frontend/src/lib/components/BeamConfig.svelte
+++ b/frontend/src/lib/components/BeamConfig.svelte
@@ -166,9 +166,10 @@
   <div class="separator"></div>
 
   <div class="time-row">
-    <label>Irradiation</label>
+    <label for="bc-irrad">Irradiation</label>
     <div class="time-controls">
       <input
+        id="bc-irrad"
         type="number"
         value={irradValue}
         min={0}
@@ -176,7 +177,7 @@
         onchange={onIrradChange}
         class="time-input"
       />
-      <select value={irradUnit} onchange={onIrradUnitChange} class="unit-select">
+      <select value={irradUnit} onchange={onIrradUnitChange} class="unit-select" aria-label="Irradiation unit">
         {#each TIME_UNITS as u}
           <option value={u.value}>{u.label}</option>
         {/each}
@@ -185,9 +186,10 @@
   </div>
 
   <div class="time-row">
-    <label>Cooling</label>
+    <label for="bc-cool">Cooling</label>
     <div class="time-controls">
       <input
+        id="bc-cool"
         type="number"
         value={coolValue}
         min={0}
@@ -195,7 +197,7 @@
         onchange={onCoolChange}
         class="time-input"
       />
-      <select value={coolUnit} onchange={onCoolUnitChange} class="unit-select">
+      <select value={coolUnit} onchange={onCoolUnitChange} class="unit-select" aria-label="Cooling unit">
         {#each TIME_UNITS as u}
           <option value={u.value}>{u.label}</option>
         {/each}

--- a/frontend/src/lib/components/BeamConfigBar.svelte
+++ b/frontend/src/lib/components/BeamConfigBar.svelte
@@ -143,8 +143,8 @@
 
 <div class="beam-bar">
   <div class="field">
-    <label>Projectile</label>
-    <select value={beam.projectile} onchange={(e) => setProjectile((e.target as HTMLSelectElement).value)}>
+    <label for="bcb-projectile">Projectile</label>
+    <select id="bcb-projectile" value={beam.projectile} onchange={(e) => setProjectile((e.target as HTMLSelectElement).value)}>
       <optgroup label="Light ions">
         {#each LIGHT_PROJECTILES as p}
           <option value={p.id}>{p.label}</option>
@@ -159,25 +159,25 @@
   </div>
 
   <div class="field">
-    <label>Energy</label>
+    <label for="bcb-energy">Energy</label>
     <div class="input-group">
-      <input type="text" inputmode="decimal" value={displayedEnergy} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onEnergyChange} />
+      <input id="bcb-energy" type="text" inputmode="decimal" value={displayedEnergy} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onEnergyChange} />
       <span class="unit">{isHI ? "MeV/u" : "MeV"}</span>
     </div>
   </div>
 
   <div class="field">
-    <label>Current</label>
+    <label for="bcb-current">Current</label>
     <div class="input-group">
-      <input type="text" inputmode="decimal" value={beam.current_mA * 1000} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onCurrentChange} />
+      <input id="bcb-current" type="text" inputmode="decimal" value={beam.current_mA * 1000} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onCurrentChange} />
       <span class="unit">µA</span>
     </div>
   </div>
 
   <div class="field">
-    <label>Irradiation</label>
+    <label for="bcb-irrad">Irradiation</label>
     <div class="input-with-feedback">
-      <input type="text" value={irradText} onfocus={(e) => (e.target as HTMLInputElement).select()} oninput={onIrradInput} onblur={commitIrrad} onkeydown={(e) => { if (e.key === 'Enter') { commitIrrad(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 24h" />
+      <input id="bcb-irrad" type="text" value={irradText} onfocus={(e) => (e.target as HTMLInputElement).select()} oninput={onIrradInput} onblur={commitIrrad} onkeydown={(e) => { if (e.key === 'Enter') { commitIrrad(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 24h" />
       {#if irradFeedback && irradFeedback !== "invalid"}
         <span class="feedback ok">{irradFeedback}</span>
       {:else if irradFeedback === "invalid"}
@@ -187,9 +187,9 @@
   </div>
 
   <div class="field">
-    <label>Cooling</label>
+    <label for="bcb-cooling">Cooling</label>
     <div class="input-with-feedback">
-      <input type="text" value={coolText} onfocus={(e) => (e.target as HTMLInputElement).select()} oninput={onCoolInput} onblur={commitCool} onkeydown={(e) => { if (e.key === 'Enter') { commitCool(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 1d" />
+      <input id="bcb-cooling" type="text" value={coolText} onfocus={(e) => (e.target as HTMLInputElement).select()} oninput={onCoolInput} onblur={commitCool} onkeydown={(e) => { if (e.key === 'Enter') { commitCool(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 1d" />
       {#if coolFeedback && coolFeedback !== "invalid"}
         <span class="feedback ok">{coolFeedback}</span>
       {:else if coolFeedback === "invalid"}

--- a/frontend/src/lib/components/BugReportModal.svelte
+++ b/frontend/src/lib/components/BugReportModal.svelte
@@ -422,7 +422,7 @@
       </div>
 
       <div class="field">
-        <label>Screenshot <span class="optional">(optional)</span></label>
+        <span class="field-label">Screenshot <span class="optional">(optional)</span></span>
         {#if screenshotPreview}
           <div class="preview-wrap">
             <img src={screenshotPreview} alt="Screenshot preview" class="preview-img" />
@@ -627,7 +627,7 @@
     gap: 0.2rem;
   }
 
-  label {
+  label, .field-label {
     font-size: 0.75rem;
     color: var(--c-text-label);
   }

--- a/frontend/src/lib/components/LayerGroup.svelte
+++ b/frontend/src/lib/components/LayerGroup.svelte
@@ -65,6 +65,7 @@
 
 <div class="layer-group" role="group">
   <button class="remove-group-btn" onclick={onRemove} title="Remove group">×</button>
+  <!-- TODO(#139): keyboard reorder (Alt+Arrow) for drag-drop layer cards is out of scope here. -->
   <!-- Layer cards -->
   {#each group.layers as layer, i (i)}
     {#if i > 0}
@@ -74,6 +75,8 @@
       class="layer-card"
       class:dragging={dragIdx === i}
       class:drag-over={dragOverIdx === i}
+      role="group"
+      aria-label={`Layer G${groupIndex + 1}.${i + 1}`}
       draggable="true"
       ondragstart={(e) => { dragIdx = i; e.dataTransfer?.setData("text/plain", String(i)); }}
       ondragover={(e) => { e.preventDefault(); if (dragIdx !== null) e.stopPropagation(); dragOverIdx = i; }}

--- a/frontend/src/lib/components/LayerTable.svelte
+++ b/frontend/src/lib/components/LayerTable.svelte
@@ -174,10 +174,6 @@
     background: var(--c-red-tint-faint);
   }
 
-  .group-boundary td {
-    border-top: 2px dashed var(--c-accent);
-  }
-
   .layer-error {
     display: block;
     font-size: 0.65rem;
@@ -222,7 +218,6 @@
       background: var(--c-bg-hover);
     }
 
-    .total-row .col-idx,
     .total-row .col-mat {
       background: var(--c-bg-subtle);
     }

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -27,8 +27,12 @@
 <svelte:window onkeydown={open ? onKeydown : undefined} />
 
 {#if open}
-  <!-- svelte-ignore a11y_no_static_element_interactions -->
-  <div class="modal-overlay" onclick={onOverlayClick}>
+  <div
+    class="modal-overlay"
+    role="presentation"
+    onclick={onOverlayClick}
+    onkeydown={(e) => { if (e.key === "Escape") onclose(); }}
+  >
     <div class="modal-content" class:wide>
       <div class="modal-header">
         {#if headerChildren}

--- a/frontend/src/lib/components/NumberInput.svelte
+++ b/frontend/src/lib/components/NumberInput.svelte
@@ -23,18 +23,20 @@
 
 <div class="number-input">
   <label>
-    <span class="label-text">{label}</span>
-    {#if unit}<span class="unit">{unit}</span>{/if}
+    <span class="label-row">
+      <span class="label-text">{label}</span>
+      {#if unit}<span class="unit">{unit}</span>{/if}
+    </span>
+    <input
+      type="number"
+      {min}
+      {max}
+      {step}
+      {value}
+      onchange={handleChange}
+      class="text-input"
+    />
   </label>
-  <input
-    type="number"
-    {min}
-    {max}
-    {step}
-    {value}
-    onchange={handleChange}
-    class="text-input"
-  />
 </div>
 
 <style>
@@ -46,9 +48,15 @@
 
   label {
     display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    font-size: 0.8rem;
+  }
+
+  .label-row {
+    display: flex;
     align-items: baseline;
     gap: 0.4rem;
-    font-size: 0.8rem;
   }
 
   .label-text {

--- a/frontend/src/lib/components/PlotActivityCurve.svelte
+++ b/frontend/src/lib/components/PlotActivityCurve.svelte
@@ -834,29 +834,6 @@
 
   .rnp-clear:hover { color: var(--c-red); border-color: var(--c-red); }
 
-  .layer-chips {
-    display: flex;
-    gap: 0.3rem;
-    padding: 0.15rem 0.5rem;
-    overflow-x: auto;
-  }
-
-  .chip {
-    background: var(--c-bg-default);
-    border: 1px solid var(--c-border);
-    border-radius: 12px;
-    color: var(--c-text-muted);
-    padding: 0.15rem 0.5rem;
-    font-size: 0.65rem;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .chip.active {
-    border-color: var(--c-accent);
-    color: var(--c-text);
-  }
-
   .plot {
     width: 100%;
     min-height: 350px;

--- a/frontend/src/lib/components/TimingConfig.svelte
+++ b/frontend/src/lib/components/TimingConfig.svelte
@@ -72,9 +72,10 @@
 
 <div class="timing-config">
   <div class="time-row">
-    <label>Irradiation</label>
+    <label for="tc-irrad">Irradiation</label>
     <div class="time-controls">
       <input
+        id="tc-irrad"
         type="number"
         value={irradValue}
         min={0}
@@ -82,7 +83,7 @@
         onchange={onIrradChange}
         class="time-input"
       />
-      <select value={irradUnit} onchange={onIrradUnitChange} class="unit-select">
+      <select value={irradUnit} onchange={onIrradUnitChange} class="unit-select" aria-label="Irradiation unit">
         {#each UNITS as u}
           <option value={u.value}>{u.label}</option>
         {/each}
@@ -91,9 +92,10 @@
   </div>
 
   <div class="time-row">
-    <label>Cooling</label>
+    <label for="tc-cool">Cooling</label>
     <div class="time-controls">
       <input
+        id="tc-cool"
         type="number"
         value={coolValue}
         min={0}
@@ -101,7 +103,7 @@
         onchange={onCoolChange}
         class="time-input"
       />
-      <select value={coolUnit} onchange={onCoolUnitChange} class="unit-select">
+      <select value={coolUnit} onchange={onCoolUnitChange} class="unit-select" aria-label="Cooling unit">
         {#each UNITS as u}
           <option value={u.value}>{u.label}</option>
         {/each}

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -753,8 +753,12 @@
 </div>
 
 {#if elementPickerOpen}
-  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-  <div class="picker-overlay" onclick={(e) => { if (e.target === e.currentTarget) closePicker(); }}>
+  <div
+    class="picker-overlay"
+    role="presentation"
+    onclick={(e) => { if (e.target === e.currentTarget) closePicker(); }}
+    onkeydown={(e) => { if (e.key === "Escape") closePicker(); }}
+  >
     <div
       class="picker-modal compose-mixture"
       role="dialog"
@@ -786,9 +790,9 @@
             {/if}
           </label>
 
-          <div class="compose-chips" role="list" aria-label="Common compounds">
+          <div class="compose-chips" role="group" aria-label="Common compounds">
             {#each COMMON_COMPOUNDS as c}
-              <button type="button" class="compose-chip" role="listitem" onclick={() => appendRow(c)}>{c}</button>
+              <button type="button" class="compose-chip" onclick={() => appendRow(c)}>{c}</button>
             {/each}
           </div>
 

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -1038,8 +1038,6 @@
 
   .compose-chip:hover { color: var(--c-accent); border-color: var(--c-accent); }
 
-  .compose-pt { /* PT renders its own inner styling */ }
-
   .compose-side {
     border-left: 1px solid var(--c-border);
     padding-left: 0.6rem;

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -51,18 +51,20 @@
     }}
   />
 
-  <label class="balance-label" role="gridcell" title="Use this row to balance to 100% — click again to clear">
-    <input
-      type="checkbox"
-      checked={row.isBalance}
-      aria-label={row.isBalance ? `Clear balance for ${row.formula}` : `Set ${row.formula} as the balance row`}
-      onchange={(e) => {
-        const checked = (e.target as HTMLInputElement).checked;
-        onchange({ isBalance: checked, ...(checked ? { value: null } : {}) });
-      }}
-    />
-    <span class="balance-text">balance</span>
-  </label>
+  <div role="gridcell">
+    <label class="balance-label" title="Use this row to balance to 100% — click again to clear">
+      <input
+        type="checkbox"
+        checked={row.isBalance}
+        aria-label={row.isBalance ? `Clear balance for ${row.formula}` : `Set ${row.formula} as the balance row`}
+        onchange={(e) => {
+          const checked = (e.target as HTMLInputElement).checked;
+          onchange({ isBalance: checked, ...(checked ? { value: null } : {}) });
+        }}
+      />
+      <span class="balance-text">balance</span>
+    </label>
+  </div>
 
   {#if singleElement && oneditenrichment}
     <button


### PR DESCRIPTION
## Summary
- Three independent commits clearing the svelte-check warning floor:
  1. a11y label-control associations (12 warnings → 0)
  2. Interactive-role mismatches + missing keydown handlers (~6 → 0)
  3. Dead CSS deletion in ActivityTableEnhanced + sibling stragglers (~21 → 0)
- Final svelte-check: 0 warnings, 0 errors.

Closes #139.

## Test plan
- [ ] CI green
- [ ] Manual: forms (BeamConfig, TimingConfig, BugReport modal) interactable, tab order sensible
- [ ] Manual: material definer modal works as before (no visual regression)
- [ ] Manual: result table renders normally (no missing styles from the CSS deletion)