### PR TITLE
fix(core/#137): catima stopping-power lookup for heavy ions

### DIFF
--- a/core/src/stopping.rs
+++ b/core/src/stopping.rs
@@ -110,8 +110,15 @@ pub fn elemental_dedx(
         let (result, _) = get_interpolated_dedx(db, SOURCE_ASTAR, target_z, &lookup);
         result
     } else {
-        // Heavy ion: look up pre-generated catima table from nucl-parquet
-        let source = format!("{}{}", SOURCE_CATIMA_PREFIX, projectile.symbol_string());
+        // Heavy ion: look up pre-generated catima table from nucl-parquet.
+        // `symbol_string()` returns "O-16"; the bundled parquet is named
+        // `catima_O16.parquet` (no dash). Strip the dash so the source key
+        // matches the on-disk filename. Reported in #137.
+        let source = format!(
+            "{}{}",
+            SOURCE_CATIMA_PREFIX,
+            projectile.symbol_string().replace('-', "")
+        );
         let (result, _) = get_interpolated_dedx(db, &source, target_z, energies_mev);
         result
     }
@@ -139,7 +146,11 @@ pub fn get_stopping_source(
     } else if proj.z == 2 {
         SOURCE_ASTAR.to_string()
     } else {
-        format!("{}{}", SOURCE_CATIMA_PREFIX, projectile.symbol_string())
+        format!(
+            "{}{}",
+            SOURCE_CATIMA_PREFIX,
+            projectile.symbol_string().replace('-', "")
+        )
     };
     let (_, label) = get_interpolated_dedx(db, &source, target_z, &[10.0]);
     label


### PR DESCRIPTION
## Summary
- Heavy-ion projectiles (O-16, C-12, Ne-20, Si-28, Ar-40, Fe-56) crashed compute via a Rust panic in \`stopping.rs\`.
- Cause: \`symbol_string()\` returns \`"O-16"\` with a dash; the catima parquet is \`catima_O16.parquet\` without one. The lookup key never matched, the fallback Z-interpolation found no data, and the function panicked.
- Fix: strip the dash when building the catima source key. Two call-sites (\`elemental_dedx\`, \`get_stopping_source\`).

Triage details + sibling issues (panic→Result, stale-result, bug-report UX, more-detailed missing-data error) in #137 comments.

## Test plan
- [ ] CI green
- [ ] Manual: load https://exoma-ch.github.io/hyrr/ (or local vite) with config \`O-16, 10 MeV, 0.04 mA, havar→Li\` (URL hash from the bug report) — compute should succeed and produce a stopping curve / depth profile.
- [ ] Manual: same with C-12, Ne-20 — also working.

Refs: #137