### PR TITLE
feat(frontend/144): bug-report modal — Title field + Name relabel

### DIFF
--- a/frontend/src/lib/components/BugReportModal.svelte
+++ b/frontend/src/lib/components/BugReportModal.svelte
@@ -5,11 +5,13 @@
   import { getBugReportOpen, closeBugReport } from "../stores/bugreport.svelte";
   import { isTauri } from "../utils/platform";
   import { openExternalUrl } from "../utils/open-url";
+  import { buildIssueTitle, bodyTitleHeader } from "./bug-report-title";
 
   let open = $derived(getBugReportOpen());
 
   let name = $state("");
   let email = $state("");
+  let title = $state("");
   let description = $state("");
   let screenshot = $state<Blob | null>(null);
   let screenshotPreview = $state<string | null>(null);
@@ -62,8 +64,7 @@
 
   function openMailto() {
     if (!canOpenGitHub) return;
-    const prefix = reportType === "bug" ? "[Bug]" : "[Feature]";
-    const subj = `${prefix} ${description.slice(0, 70)}`;
+    const subj = buildIssueTitle(reportType, title, description);
     const body = buildBody();
     const qs = new URLSearchParams({ subject: subj, body }).toString();
     const to = MAILTO_TARGET;
@@ -221,6 +222,7 @@
     const sections: string[] = [];
 
     sections.push(reportType === "bug" ? `## Bug Report` : `## Feature Request`);
+    sections.push(bodyTitleHeader(title, description));
     sections.push(`**Reporter:** ${name || "Anonymous"}${email ? ` (${email})` : ""}`);
     sections.push(`## Description\n\n${description}`);
 
@@ -259,8 +261,7 @@
     // Get Turnstile token (renders widget on demand, waits for challenge)
     const token = await getTurnstileToken();
 
-    const prefix = reportType === "bug" ? "[Bug]" : "[Feature]";
-    const title = `${prefix} ${description.slice(0, 70)}`;
+    const issueTitle = buildIssueTitle(reportType, title, description);
 
     try {
       let screenshotUrl: string | undefined;
@@ -274,7 +275,7 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          title,
+          title: issueTitle,
           body,
           labels: [reportType === "bug" ? "bug" : "enhancement"],
           email,
@@ -299,12 +300,11 @@
   /** Open on GitHub directly (user authenticates via their GH session). */
   function openOnGitHub() {
     if (!canOpenGitHub) return;
-    const prefix = reportType === "bug" ? "[Bug]" : "[Feature]";
-    const title = `${prefix} ${description.slice(0, 70)}`;
+    const issueTitle = buildIssueTitle(reportType, title, description);
     const body = buildBody();
 
     const url = `https://github.com/${REPO}/issues/new?` + new URLSearchParams({
-      title,
+      title: issueTitle,
       body,
       labels: reportType === "bug" ? "bug" : "enhancement",
     }).toString();
@@ -336,9 +336,8 @@
       if (!reportPath) { submitting = false; return; }
 
       const body = buildBody();
-      const prefix = reportType === "bug" ? "[Bug]" : "[Feature]";
-      const title = `${prefix} ${description.slice(0, 70)}`;
-      const content = `# ${title}\n\n${body}`;
+      const issueTitle = buildIssueTitle(reportType, title, description);
+      const content = `# ${issueTitle}\n\n${body}`;
       await writeTextFile(reportPath, content);
 
       // Save screenshot alongside the report if present
@@ -359,6 +358,7 @@
   }
 
   function resetForm() {
+    title = "";
     description = "";
     screenshot = null;
     screenshotPreview = null;
@@ -410,6 +410,17 @@
           {/if}
         </div>
       {/if}
+
+      <div class="field">
+        <label for="bug-title">Title <span class="optional">(optional — auto-generated from description if blank)</span></label>
+        <input
+          id="bug-title"
+          type="text"
+          bind:value={title}
+          placeholder="Short summary, e.g. 'Heavy ions crash compute'"
+          maxlength="70"
+        />
+      </div>
 
       <div class="field">
         <label for="bug-desc">Description <span class="required">*</span></label>

--- a/frontend/src/lib/components/BugReportModal.svelte
+++ b/frontend/src/lib/components/BugReportModal.svelte
@@ -391,8 +391,8 @@
       </div>
 
       <div class="field">
-        <label for="bug-name">Name <span class="optional">(optional)</span></label>
-        <input id="bug-name" type="text" bind:value={name} placeholder="Your name" />
+        <label for="bug-name">Your name <span class="optional">(optional, for follow-up — leave blank for anonymous)</span></label>
+        <input id="bug-name" type="text" bind:value={name} placeholder="leave blank for anonymous" />
       </div>
 
       {#if !desktop}

--- a/frontend/src/lib/components/BugReportModal.test.ts
+++ b/frontend/src/lib/components/BugReportModal.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildIssueTitle, bodyTitleHeader, TITLE_MAX_LEN } from "./bug-report-title";
+
+describe("buildIssueTitle", () => {
+  it("uses the user-supplied title when set", () => {
+    const got = buildIssueTitle("bug", "Heavy ions crash compute", "long description text");
+    expect(got).toBe("[Bug] Heavy ions crash compute");
+  });
+
+  it("falls back to truncated description when title is blank", () => {
+    const desc = "x".repeat(120);
+    const got = buildIssueTitle("bug", "", desc);
+    expect(got).toBe(`[Bug] ${"x".repeat(70)}`);
+  });
+
+  it("falls back to truncated description when title is whitespace-only", () => {
+    const desc = "no depth profile, stopping profile, power, no cross sections viewable in foo bar";
+    const got = buildIssueTitle("bug", "   ", desc);
+    expect(got).toBe(`[Bug] ${desc.slice(0, 70)}`);
+  });
+
+  it("slices a too-long user title to the cap", () => {
+    const longTitle = "y".repeat(120);
+    const got = buildIssueTitle("bug", longTitle, "anything");
+    expect(got).toBe(`[Bug] ${"y".repeat(TITLE_MAX_LEN)}`);
+  });
+
+  it("uses [Feature] prefix for feature requests", () => {
+    const got = buildIssueTitle("feature", "Add streaming", "");
+    expect(got).toBe("[Feature] Add streaming");
+  });
+});
+
+describe("bodyTitleHeader", () => {
+  it("renders the user title as a section header", () => {
+    expect(bodyTitleHeader("My title", "ignored desc")).toBe("## My title");
+  });
+
+  it("renders the truncated description when title is blank", () => {
+    const desc = "z".repeat(100);
+    expect(bodyTitleHeader("", desc)).toBe(`## ${"z".repeat(70)}`);
+  });
+});

--- a/frontend/src/lib/components/bug-report-title.ts
+++ b/frontend/src/lib/components/bug-report-title.ts
@@ -1,0 +1,16 @@
+export const TITLE_MAX_LEN = 70;
+
+export function buildIssueTitle(
+  reportType: "bug" | "feature",
+  title: string,
+  description: string,
+): string {
+  const prefix = reportType === "bug" ? "[Bug]" : "[Feature]";
+  const userTitle = title.trim() || description.slice(0, TITLE_MAX_LEN);
+  return `${prefix} ${userTitle.slice(0, TITLE_MAX_LEN)}`;
+}
+
+export function bodyTitleHeader(title: string, description: string): string {
+  const t = title.trim() || description.slice(0, TITLE_MAX_LEN);
+  return `## ${t}`;
+}


### PR DESCRIPTION
## Summary

Pure UI fix in `BugReportModal.svelte` — separates a real Title field from the (now-clarified) optional Reporter Name field.

- New **Title** `<input>` placed above Description, max 70 chars; empty Title falls back to the existing `description.slice(0, 70)` heuristic so behaviour is backward-compatible.
- Title flows into all three submission paths: `openOnGitHub`, `submitViaWorker`, `saveToFile`, and `openMailto` (subject line).
- `buildBody` now emits a `## <title>` section header so the markdown stays readable in email / saved-file form.
- The **Name** field is relabeled "Your name (optional, for follow-up — leave blank for anonymous)" with a matching placeholder. The body's `**Reporter:**` line is unchanged for backward compatibility (per the issue's pitfall list).
- Title-building logic extracted to `bug-report-title.ts` so it's unit-testable without mounting the Svelte component.

Closes #144.

## Scope guards

- Doesn't touch result store, scheduler, core, or layout/CSS classes.
- Description still gets focus on open — Title is a non-autofocus sibling.
- 70-char cap preserved (and applied to user-supplied Title too).

## Test plan

- [x] `npm run check` (frontend) — 0 errors
- [x] `npm test` (frontend) — 430/430 pass, including the new 7 in `BugReportModal.test.ts`
- [ ] Manual: open the bug-report modal, fill Title + Description, click "Open on GitHub", verify the URL's `title=` param is the user's title (not the description-slice).
- [ ] Manual: leave Title blank, fill Description, click "Open on GitHub", verify the URL's `title=` param is `[Bug] <description-truncated-to-70>` (regression check).
- [ ] Manual: paste a >70-char Title, verify it's sliced to 70.