### PR TITLE
fix(frontend/143): clear stale result on compute error

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -18,6 +18,7 @@
   } from "./lib/stores/config.svelte";
   import {
     getResult,
+    getResultError,
     getStatus,
     getProgress,
     getComputeError,
@@ -79,6 +80,7 @@
   let status = $derived(getStatus());
   let result = $derived(getResult());
   let computeError = $derived(getComputeError());
+  let resultError = $derived(getResultError());
   let historyOpen = $derived(getHistoryOpen());
 
   // Popup state
@@ -398,6 +400,10 @@
           <IsotopeFilterBar {result} />
           <PlotActivityCurve {result} />
           <ActivityTableEnhanced {result} onisotopeclick={openIsotopePopup} />
+        {:else if resultError}
+          <p class="compute-error-placeholder">
+            Compute failed: <code>{String(resultError)}</code>
+          </p>
         {/if}
       {:else}
         <WelcomeScreen onstart={forceRun} />

--- a/frontend/src/lib/components/BugReportModal.svelte
+++ b/frontend/src/lib/components/BugReportModal.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { getConfig, getSerializableConfig } from "../stores/config.svelte";
-  import { getResult } from "../stores/results.svelte";
+  import { getResult, getResultError } from "../stores/results.svelte";
+  import { buildBugReportBody } from "./bug-report-body";
   import { getShareableUrl } from "../config-url";
   import { getBugReportOpen, closeBugReport } from "../stores/bugreport.svelte";
   import { isTauri } from "../utils/platform";
   import { openExternalUrl } from "../utils/open-url";
-  import { buildIssueTitle, bodyTitleHeader } from "./bug-report-title";
+  import { buildIssueTitle } from "./bug-report-title";
 
   let open = $derived(getBugReportOpen());
 
@@ -212,42 +213,23 @@
   }
 
   function buildBody(screenshotUrl?: string): string {
-    const config = getConfig();
-    const result = getResult();
     // getShareableUrl requires SerializableConfig (with `items`, group-aware);
     // getConfig returns SimulationConfig (flat `layers`). Use the right shape
     // for the URL, keep the flat shape for the human-readable debug summary.
-    const configUrl = getShareableUrl(getSerializableConfig());
-
-    const sections: string[] = [];
-
-    sections.push(reportType === "bug" ? `## Bug Report` : `## Feature Request`);
-    sections.push(bodyTitleHeader(title, description));
-    sections.push(`**Reporter:** ${name || "Anonymous"}${email ? ` (${email})` : ""}`);
-    sections.push(`## Description\n\n${description}`);
-
-    if (screenshotUrl) {
-      sections.push(`## Screenshot\n\n![screenshot](${screenshotUrl})`);
-    }
-
-    sections.push(`## Debug Context`);
-    sections.push(`**[Reproduce this config](${configUrl})**`);
-    sections.push(`**Beam:** ${config.beam?.projectile ?? "?"} @ ${config.beam?.energy_MeV ?? "?"} MeV, ${config.beam?.current_mA ?? "?"} mA`);
-    const layerNames = (config.layers ?? []).map((l: any) => l.material).join(" → ");
-    sections.push(`**Stack:** ${layerNames || "empty"} (${config.layers?.length ?? 0} layers)`);
-
-    if (result) {
-      const nIso = result.layers.reduce((n: number, l: any) => n + (l.isotopes?.length ?? 0), 0);
-      sections.push(`**Result:** ${nIso} isotopes produced`);
-    } else {
-      sections.push(`**Result:** No simulation result available`);
-    }
-
-    sections.push(`**Version:** ${__APP_VERSION__}`);
-    sections.push(`**Browser:** ${navigator.userAgent}`);
-    sections.push(`**Timestamp:** ${new Date().toISOString()}`);
-
-    return sections.join("\n\n");
+    return buildBugReportBody({
+      reportType,
+      title,
+      name,
+      email,
+      description,
+      screenshotUrl,
+      config: getConfig(),
+      configUrl: getShareableUrl(getSerializableConfig()),
+      result: getResult(),
+      computeError: getResultError(),
+      appVersion: __APP_VERSION__,
+      userAgent: navigator.userAgent,
+    });
   }
 
   /** Submit via worker (requires email + Turnstile). */

--- a/frontend/src/lib/components/bug-report-body.test.ts
+++ b/frontend/src/lib/components/bug-report-body.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { buildBugReportBody, type BugReportBodyInput } from "./bug-report-body";
+import type { SimulationConfig, SimulationResult } from "@hyrr/compute";
+
+const FIXED_NOW = new Date("2026-01-01T00:00:00Z");
+
+const BASE_CONFIG: SimulationConfig = {
+  beam: { projectile: "p", energy_MeV: 16, current_mA: 0.15 },
+  layers: [{ material: "Cu", thickness_cm: 0.5 }],
+  irradiation_s: 86400,
+  cooling_s: 0,
+};
+
+const FAKE_RESULT = {
+  config: BASE_CONFIG,
+  layers: [
+    { isotopes: [{ name: "Cu-64" }, { name: "Cu-67" }] },
+    { isotopes: [{ name: "Zn-65" }] },
+  ],
+} as unknown as SimulationResult;
+
+function baseInput(over: Partial<BugReportBodyInput> = {}): BugReportBodyInput {
+  return {
+    reportType: "bug",
+    name: "alice",
+    email: "a@b.c",
+    description: "it broke",
+    config: BASE_CONFIG,
+    configUrl: "https://example.test/#config=abc",
+    result: null,
+    computeError: null,
+    appVersion: "0.7.1",
+    userAgent: "vitest",
+    now: FIXED_NOW,
+    ...over,
+  };
+}
+
+describe("buildBugReportBody (#143)", () => {
+  it("includes the result-summary line when a result is present and no error", () => {
+    const body = buildBugReportBody(baseInput({ result: FAKE_RESULT }));
+    expect(body).toContain("**Result:** 3 isotopes produced");
+    expect(body).not.toContain("**Compute error:**");
+  });
+
+  it("falls back to 'no result' line when result is null and no error", () => {
+    const body = buildBugReportBody(baseInput());
+    expect(body).toContain("**Result:** No simulation result available");
+    expect(body).not.toContain("**Compute error:**");
+  });
+
+  it("appends the compute-error section when an error is present", () => {
+    const body = buildBugReportBody(
+      baseInput({ computeError: new Error("StoppingError: O-16 unsupported") }),
+    );
+    expect(body).toContain("**Compute error:** Error: StoppingError: O-16 unsupported");
+  });
+
+  it("includes BOTH the stale-result line and the error when both happen to be set", () => {
+    // This combo is unusual after #143's fix (setResultErrored clears result),
+    // but the body builder must still honour what it's given.
+    const body = buildBugReportBody(
+      baseInput({ result: FAKE_RESULT, computeError: "kaboom" }),
+    );
+    expect(body).toContain("**Result:** 3 isotopes produced");
+    expect(body).toContain("**Compute error:** kaboom");
+  });
+
+  it("stringifies non-Error compute errors", () => {
+    const body = buildBugReportBody(
+      baseInput({ computeError: { kind: "StoppingError", isotope: "O-16" } }),
+    );
+    expect(body).toMatch(/\*\*Compute error:\*\*.*StoppingError|object Object/);
+  });
+});

--- a/frontend/src/lib/components/bug-report-body.ts
+++ b/frontend/src/lib/components/bug-report-body.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure helper extracted from BugReportModal.svelte so the body-assembly
+ * logic is unit-testable without spinning up a Svelte component.
+ *
+ * #143 added the compute-error section: bug reports were silently embedding
+ * the previous successful run's stats when the latest compute had failed
+ * (root cause of #137).
+ */
+
+import type { SimulationConfig, SimulationResult } from "@hyrr/compute";
+
+export interface BugReportBodyInput {
+  reportType: "bug" | "feature";
+  /** Optional one-line summary from the form's Title input (#144).
+   *  When absent, the helper falls back to a description slice. */
+  title?: string;
+  name: string;
+  email: string;
+  description: string;
+  screenshotUrl?: string;
+  config: SimulationConfig;
+  configUrl: string;
+  result: SimulationResult | null;
+  computeError: unknown | null;
+  appVersion: string;
+  userAgent: string;
+  /** Defaults to `new Date()` for testability. */
+  now?: Date;
+}
+
+export function buildBugReportBody(input: BugReportBodyInput): string {
+  const sections: string[] = [];
+
+  sections.push(input.reportType === "bug" ? `## Bug Report` : `## Feature Request`);
+  const titleLine = (input.title ?? "").trim() || input.description.slice(0, 70);
+  if (titleLine) sections.push(`## ${titleLine}`);
+  sections.push(
+    `**Reporter:** ${input.name || "Anonymous"}${input.email ? ` (${input.email})` : ""}`,
+  );
+  sections.push(`## Description\n\n${input.description}`);
+
+  if (input.screenshotUrl) {
+    sections.push(`## Screenshot\n\n![screenshot](${input.screenshotUrl})`);
+  }
+
+  sections.push(`## Debug Context`);
+  sections.push(`**[Reproduce this config](${input.configUrl})**`);
+  sections.push(
+    `**Beam:** ${input.config.beam?.projectile ?? "?"} @ ${input.config.beam?.energy_MeV ?? "?"} MeV, ${input.config.beam?.current_mA ?? "?"} mA`,
+  );
+  const layerNames = (input.config.layers ?? []).map((l: any) => l.material).join(" → ");
+  sections.push(`**Stack:** ${layerNames || "empty"} (${input.config.layers?.length ?? 0} layers)`);
+
+  if (input.result) {
+    const nIso = input.result.layers.reduce(
+      (n: number, l: any) => n + (l.isotopes?.length ?? 0),
+      0,
+    );
+    sections.push(`**Result:** ${nIso} isotopes produced`);
+  } else {
+    sections.push(`**Result:** No simulation result available`);
+  }
+
+  if (input.computeError != null) {
+    sections.push(`**Compute error:** ${String(input.computeError)}`);
+  }
+
+  sections.push(`**Version:** ${input.appVersion}`);
+  sections.push(`**Browser:** ${input.userAgent}`);
+  sections.push(`**Timestamp:** ${(input.now ?? new Date()).toISOString()}`);
+
+  return sections.join("\n\n");
+}

--- a/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
+++ b/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
@@ -12,10 +12,10 @@ import {
   setResult,
   setLoading,
   setRunning,
-  setError,
   setIdle,
   setComputeError,
   clearResult,
+  setResultErrored,
   type SimStatus,
 } from "../stores/results.svelte";
 import { parseComputeError } from "../compute/parse-error";
@@ -153,12 +153,12 @@ async function runSimulation(hash: string): Promise<void> {
     if (cancelled) return;
     state = "error";
     const parsed = parseComputeError(e);
-    // Sibling #143 owns the result-clearing path; if its store API is in
-    // place use that, otherwise fall back to the legacy clearResult here.
-    // Either way the typed error must land in `computeError` so the
-    // recovery card renders.
+    // #143 clears the stale result + captures the raw error for the
+    // bug-report fallback; #142 layers the typed error for the recovery
+    // card on top. Both fields are read by different consumers, so set
+    // both atomically.
+    setResultErrored(e);
     setComputeError(parsed);
-    setError(parsed.message);
   }
 }
 

--- a/frontend/src/lib/stores/results.svelte.test.ts
+++ b/frontend/src/lib/stores/results.svelte.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getResult,
+  getResultError,
+  setResult,
+  setResultError,
+  setResultErrored,
+  clearResult,
+} from "./results.svelte";
+import type { SimulationResult } from "../types";
+
+const FAKE_RESULT = {
+  config: { irradiation_s: 0, cooling_s: 0 },
+  layers: [],
+} as unknown as SimulationResult;
+
+describe("results store — error handling (#143)", () => {
+  beforeEach(() => {
+    clearResult();
+  });
+
+  it("setResultErrored clears any stale result and stamps the error", () => {
+    setResult(FAKE_RESULT);
+    expect(getResult()).not.toBeNull();
+
+    const boom = new Error("compute exploded");
+    setResultErrored(boom);
+
+    expect(getResult()).toBeNull();
+    expect(getResultError()).toBe(boom);
+  });
+
+  it("setResult clears a previously captured error", () => {
+    setResultErrored(new Error("previous failure"));
+    expect(getResultError()).not.toBeNull();
+
+    setResult(FAKE_RESULT);
+
+    expect(getResult()).toBe(FAKE_RESULT);
+    expect(getResultError()).toBeNull();
+  });
+
+  it("setResultError accepts non-Error payloads (forward-compat with #142)", () => {
+    const structured = { kind: "StoppingError", isotope: "O-16" };
+    setResultError(structured);
+    expect(getResultError()).toBe(structured);
+
+    setResultError(null);
+    expect(getResultError()).toBeNull();
+  });
+
+  it("clearResult also wipes the error", () => {
+    setResultErrored(new Error("x"));
+    clearResult();
+    expect(getResult()).toBeNull();
+    expect(getResultError()).toBeNull();
+  });
+});

--- a/frontend/src/lib/stores/results.svelte.ts
+++ b/frontend/src/lib/stores/results.svelte.ts
@@ -9,7 +9,11 @@ export type SimStatus = "idle" | "loading" | "running" | "ready" | "error";
 let result = $state<SimulationResult | null>(null);
 let status = $state<SimStatus>("idle");
 let error = $state<string | null>(null);
+// Typed compute-backend error (#142) — drives ComputeErrorCard.
 let computeError = $state<ComputeError | null>(null);
+// Raw, untyped error captured when compute throws — fallback for callers
+// that didn't go through the typed path (#143).
+let resultError = $state<unknown | null>(null);
 let progress = $state<string>("");
 
 export function getResult(): SimulationResult | null {
@@ -29,6 +33,10 @@ export function getComputeError(): ComputeError | null {
   return computeError;
 }
 
+export function getResultError(): unknown | null {
+  return resultError;
+}
+
 export function getProgress(): string {
   return progress;
 }
@@ -38,6 +46,20 @@ export function setResult(r: SimulationResult): void {
   status = "ready";
   error = null;
   computeError = null;
+  resultError = null;
+  progress = "";
+}
+
+export function setResultError(e: unknown | null): void {
+  resultError = e;
+}
+
+/** Atomic "compute failed": clear any stale result and capture the error. */
+export function setResultErrored(e: unknown): void {
+  result = null;
+  resultError = e;
+  status = "error";
+  error = e instanceof Error ? e.message : String(e);
   progress = "";
 }
 
@@ -86,5 +108,6 @@ export function clearResult(): void {
   status = "idle";
   error = null;
   computeError = null;
+  resultError = null;
   progress = "";
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hyrr-116",
+  "name": "agent-aadd92b3c110fc886",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Summary

When `runSimulation` errors, the result store used to keep the previous run's output. The result table rendered that, and users (and the bug-report form) would silently report stale data — root cause of the misleading "20 isotopes produced" complaint in #137.

This PR fixes that mechanically, in four small steps:

1. **`stores/results.svelte.ts`** — adds an `unknown`-typed `resultError` field alongside the existing string `error`. New API: `getResultError()`, `setResultError(e)`, `setResultErrored(e)` (atomic clear-result + capture-error).
2. **`scheduler/sim-scheduler.svelte.ts`** — replaces the `setError(msg)` in the WASM/Tauri `catch` with `setResultErrored(e)`. Compute failures now wipe stale result + capture the error in one step.
3. **`App.svelte`** — when `result === null && resultError != null`, renders a minimal `Compute failed: <msg>` placeholder where `ActivityTableEnhanced` would have been. Intentionally bare; #142's `ComputeErrorCard` will replace it.
4. **`BugReportModal.svelte`** — `buildBody` now also reads `getResultError()` and appends `**Compute error:** <msg>` when present, so the issue body captures real failure state.

## File-overlap note

#142 is in flight. Per its design we're each adding a separate error field; maintainer will consolidate at merge time.

## Test plan

- [x] `npm run check` (frontend): 0 errors
- [x] `npx vitest run --root frontend`: 432 passed, including new tests in `results.svelte.test.ts` and `bug-report-body.test.ts`
- [ ] Manual: load app, deliberately break compute (e.g. unsupported projectile via URL hash), confirm result panel shows `Compute failed: …` instead of stale rows
- [ ] Manual: open the bug-report modal in that state, confirm body markdown contains the `**Compute error:**` line

Closes #143