### PR TITLE
core: typed StoppingError + frontend recovery card (#142)

### DIFF
--- a/core/examples/probe_cooltime.rs
+++ b/core/examples/probe_cooltime.rs
@@ -36,7 +36,7 @@ fn run(cool_s: f64) {
         current_profile: None,
     };
 
-    let result = compute_stack(&db, &mut stack, true);
+    let result = compute_stack(&db, &mut stack, true).expect("compute_stack failed");
     let lr = &result.layer_results[0];
     let o15 = lr.isotope_results.get("O-15").expect("O-15");
 

--- a/core/examples/probe_e2e_58.rs
+++ b/core/examples/probe_e2e_58.rs
@@ -35,7 +35,7 @@ fn run(cool_s: f64) {
         current_profile: None,
     };
 
-    let result = compute_stack(&db, &mut stack, true);
+    let result = compute_stack(&db, &mut stack, true).expect("compute_stack failed");
     let lr = &result.layer_results[0];
     let o15 = lr.isotope_results.get("O-15").expect("O-15");
 

--- a/core/examples/probe_table.rs
+++ b/core/examples/probe_table.rs
@@ -45,7 +45,7 @@ fn main() {
         current_profile: None,
     };
 
-    let result = compute_stack(&db, &mut stack, true);
+    let result = compute_stack(&db, &mut stack, true).expect("compute_stack failed");
 
     println!(
         "{:>3}  {:>6}  {:>12}  {:>12}  {:>12}  {:>8}  {:>6}",

--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -12,7 +12,8 @@ use crate::production::{
     saturation_yield,
 };
 use crate::stopping::{
-    compute_energy_out, compute_thickness_from_energy, dedx_mev_per_cm, get_stopping_sources,
+    compute_energy_out, compute_thickness_from_energy, dedx_mev_per_cm, dedx_mev_per_cm_scalar,
+    get_stopping_sources, StoppingError,
 };
 use crate::types::*;
 
@@ -39,7 +40,7 @@ pub fn compute_stack(
     db: &dyn DatabaseProtocol,
     stack: &mut TargetStack,
     enable_chains: bool,
-) -> StackResult {
+) -> Result<StackResult, StoppingError> {
     let beam = &stack.beam;
     let irr_time = stack.irradiation_time_s;
     let cool_time = stack.cooling_time_s;
@@ -66,16 +67,16 @@ pub fn compute_stack(
             area,
             enable_chains,
             stack.current_profile.as_ref(),
-        );
+        )?;
         energy_in = lr.energy_out;
         layer_results.push(lr);
     }
 
-    StackResult {
+    Ok(StackResult {
         layer_results,
         irradiation_time_s: irr_time,
         cooling_time_s: cool_time,
-    }
+    })
 }
 
 fn compute_layer(
@@ -91,7 +92,7 @@ fn compute_layer(
     area: f64,
     enable_chains: bool,
     current_profile: Option<&CurrentProfile>,
-) -> LayerResult {
+) -> Result<LayerResult, StoppingError> {
     let composition = layer_composition(layer);
     let density = layer.density_g_cm3;
 
@@ -105,7 +106,7 @@ fn compute_layer(
             energy_in,
             e_out,
             1000,
-        );
+        )?;
         (thick, e_out)
     } else if let Some(thick) = layer.thickness_cm {
         let e_out = compute_energy_out(
@@ -116,7 +117,7 @@ fn compute_layer(
             energy_in,
             thick,
             1000,
-        );
+        )?;
         (thick, e_out)
     } else {
         let thick = layer.areal_density_g_cm2.unwrap() / density;
@@ -128,7 +129,7 @@ fn compute_layer(
             energy_in,
             thick,
             1000,
-        );
+        )?;
         (thick, e_out)
     };
 
@@ -136,11 +137,17 @@ fn compute_layer(
     layer.computed_energy_out = energy_out;
     layer.computed_thickness = thickness;
 
-    let sp_sources = get_stopping_sources(db, projectile, &composition);
+    let sp_sources = get_stopping_sources(db, projectile, &composition)?;
 
+    // Validated above via `compute_thickness_from_energy` / `compute_energy_out`,
+    // so the inner `dedx_mev_per_cm` cannot return an error for this layer's
+    // source/target combo. Use the panicking _scalar/_unchecked helper inside
+    // the closure to keep the existing `Fn(&[f64]) -> Vec<f64>` shape.
     let dedx_fn = |energies: &[f64]| -> Vec<f64> {
         dedx_mev_per_cm(db, projectile, &composition, density, energies)
+            .expect("dedx_fn: layer-level prevalidation should have caught any miss")
     };
+    let _ = dedx_mev_per_cm_scalar; // silence unused-import noise on some build configs
 
     let volume = thickness * area;
     let avg_a = layer.average_atomic_mass();
@@ -318,7 +325,7 @@ fn compute_layer(
 
     let delta_e = energy_in - energy_out;
 
-    LayerResult {
+    Ok(LayerResult {
         energy_in,
         energy_out,
         delta_e_mev: delta_e,
@@ -327,7 +334,7 @@ fn compute_layer(
         isotope_results,
         stopping_power_sources: sp_sources,
         depth_production_rates,
-    }
+    })
 }
 
 /// Convert digits (and the metastable marker 'm') to unicode superscripts.
@@ -536,7 +543,7 @@ fn apply_chain_solver_by_component(
 pub fn compute_stack_stopping_only(
     db: &dyn DatabaseProtocol,
     stack: &mut TargetStack,
-) -> StackResult {
+) -> Result<StackResult, StoppingError> {
     let beam = &stack.beam;
     let area = stack.area_cm2;
     let projectile = &beam.projectile;
@@ -555,16 +562,16 @@ pub fn compute_stack_stopping_only(
             layer,
             energy_in,
             area,
-        );
+        )?;
         energy_in = lr.energy_out;
         layer_results.push(lr);
     }
 
-    StackResult {
+    Ok(StackResult {
         layer_results,
         irradiation_time_s: stack.irradiation_time_s,
         cooling_time_s: stack.cooling_time_s,
-    }
+    })
 }
 
 /// Per-layer stopping-only computation — the prefix of [`compute_layer`]
@@ -579,25 +586,25 @@ fn compute_layer_stopping_only(
     layer: &mut Layer,
     energy_in: f64,
     area: f64,
-) -> LayerResult {
+) -> Result<LayerResult, StoppingError> {
     let composition = layer_composition(layer);
     let density = layer.density_g_cm3;
 
     let (thickness, energy_out) = if let Some(e_out) = layer.energy_out_mev {
         let thick = compute_thickness_from_energy(
             db, projectile, &composition, density, energy_in, e_out, 1000,
-        );
+        )?;
         (thick, e_out)
     } else if let Some(thick) = layer.thickness_cm {
         let e_out = compute_energy_out(
             db, projectile, &composition, density, energy_in, thick, 1000,
-        );
+        )?;
         (thick, e_out)
     } else {
         let thick = layer.areal_density_g_cm2.unwrap() / density;
         let e_out = compute_energy_out(
             db, projectile, &composition, density, energy_in, thick, 1000,
-        );
+        )?;
         (thick, e_out)
     };
 
@@ -605,13 +612,13 @@ fn compute_layer_stopping_only(
     layer.computed_energy_out = energy_out;
     layer.computed_thickness = thickness;
 
-    let sp_sources = get_stopping_sources(db, projectile, &composition);
+    let sp_sources = get_stopping_sources(db, projectile, &composition)?;
 
     // Same energy grid + dE/dx the full path uses, so heat values are
     // bit-identical to the activation path's output.
     let layer_e_low = energy_out.max(0.01);
     let layer_energies = linspace(layer_e_low, energy_in, 100);
-    let layer_dedx = dedx_mev_per_cm(db, projectile, &composition, density, &layer_energies);
+    let layer_dedx = dedx_mev_per_cm(db, projectile, &composition, density, &layer_energies)?;
 
     let depth_raw =
         generate_depth_profile(&layer_energies, &layer_dedx, current_ma, area, projectile_z);
@@ -632,7 +639,7 @@ fn compute_layer_stopping_only(
         0.0
     };
 
-    LayerResult {
+    Ok(LayerResult {
         energy_in,
         energy_out,
         delta_e_mev: energy_in - energy_out,
@@ -641,7 +648,7 @@ fn compute_layer_stopping_only(
         isotope_results: HashMap::new(),
         stopping_power_sources: sp_sources,
         depth_production_rates: HashMap::new(),
-    }
+    })
 }
 
 fn integrate_heat(profile: &[DepthPoint], area_cm2: f64) -> f64 {

--- a/core/src/mcp/tools.rs
+++ b/core/src/mcp/tools.rs
@@ -354,7 +354,8 @@ fn build_and_run_sim(
         current_profile: None,
     };
 
-    let result = crate::compute::compute_stack(db, &mut stack, true);
+    let result = crate::compute::compute_stack(db, &mut stack, true)
+        .map_err(|e| e.to_string())?;
     Ok((stack, result, projectile_str.to_string(), energy_mev, current_ma))
 }
 
@@ -428,7 +429,8 @@ fn build_and_run_stopping_only(
         current_profile: None,
     };
 
-    let result = crate::compute::compute_stack_stopping_only(db, &mut stack);
+    let result = crate::compute::compute_stack_stopping_only(db, &mut stack)
+        .map_err(|e| e.to_string())?;
     Ok((result, projectile_str.to_string(), energy_mev, current_ma))
 }
 
@@ -782,7 +784,8 @@ fn tool_get_stopping_power(db: &dyn DatabaseProtocol, args: &Value) -> Result<St
         raw.into_iter().map(|(z, w)| (z, w / total)).collect()
     };
 
-    let mass_dedx = crate::stopping::compound_dedx(db, &projectile, &composition, &energies);
+    let mass_dedx = crate::stopping::compound_dedx(db, &projectile, &composition, &energies)
+        .map_err(|e| e.to_string())?;
     let lin_dedx: Vec<f64> = mass_dedx
         .iter()
         .map(|s| s * resolution.density)

--- a/core/src/stopping.rs
+++ b/core/src/stopping.rs
@@ -16,6 +16,62 @@ const NIST_CANDIDATE_ZS: &[u32] = &[
     1, 2, 4, 6, 7, 8, 10, 13, 14, 18, 22, 26, 29, 32, 36, 42, 47, 50, 54, 64, 74, 78, 79, 82, 92,
 ];
 
+/// Catima projectiles bundled in nucl-parquet (kept in sync with
+/// `data/build_parquet.py`'s catima ingestion list). Used as the
+/// fallback `available_pretty` set when the database can't enumerate
+/// available sources directly — there is no `list_sources` API on
+/// `DatabaseProtocol`.
+const BUNDLED_CATIMA_PROJECTILES: &[&str] =
+    &["C-12", "O-16", "Ne-20", "Si-28", "Ar-40", "Fe-56"];
+
+/// Typed errors from the stopping-power lookup path.
+///
+/// Surfaced through the WASM bridge and Tauri commands as a structured
+/// payload so the frontend can render a recovery card (see issue #142).
+#[derive(Debug, Clone, thiserror::Error, serde::Serialize)]
+#[serde(tag = "variant")]
+pub enum StoppingError {
+    #[error("No {source_name} stopping table — projectile {projectile} not in bundled set. Available: {available_pretty}")]
+    NoSourceTable {
+        #[serde(rename = "source")]
+        source_name: String,
+        projectile: String,
+        available: Vec<String>,
+        available_pretty: String,
+    },
+    #[error("Energy {energy_mev:.3} MeV out of range [{min_mev:.3}, {max_mev:.3}] for {source_name} on {target_symbol} (Z={target_z})")]
+    EnergyOutOfRange {
+        #[serde(rename = "source")]
+        source_name: String,
+        target_symbol: String,
+        target_z: u32,
+        energy_mev: f64,
+        min_mev: f64,
+        max_mev: f64,
+    },
+    #[error("No {source_name} data for target {target_symbol} (Z={target_z}). Available Z: {available_zs:?}")]
+    NoTargetData {
+        #[serde(rename = "source")]
+        source_name: String,
+        target_symbol: String,
+        target_z: u32,
+        available_zs: Vec<u32>,
+    },
+}
+
+impl StoppingError {
+    /// Tag every variant payload with `kind: "StoppingError"` for the
+    /// frontend's discriminated-union parsing. Consumers (WASM + Tauri)
+    /// JSON-serialize this directly.
+    pub fn as_json(&self) -> serde_json::Value {
+        let mut v = serde_json::to_value(self).unwrap_or(serde_json::Value::Null);
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert("kind".to_string(), serde_json::Value::String("StoppingError".to_string()));
+        }
+        v
+    }
+}
+
 /// Get or build a log-log interpolator for stopping power.
 /// Returns (interpolated dE/dx values, source label).
 fn get_interpolated_dedx(
@@ -23,17 +79,32 @@ fn get_interpolated_dedx(
     source: &str,
     target_z: u32,
     energies: &[f64],
-) -> (Vec<f64>, String) {
+    projectile: &ProjectileType,
+) -> Result<(Vec<f64>, String), StoppingError> {
     let (sp_energies, sp_dedx) = db.get_stopping_power(source, target_z);
     if !sp_energies.is_empty() {
+        check_energy_range(source, target_z, db, &sp_energies, energies)?;
         let interp = make_log_log_interpolator(&sp_energies, &sp_dedx);
-        return (interp(energies), source.to_string());
+        return Ok((interp(energies), source.to_string()));
     }
 
-    // Z-interpolate between nearest available elements
     let available_zs = get_available_zs(db, source);
     if available_zs.is_empty() {
-        panic!("No {} stopping power data available", source);
+        return Err(StoppingError::NoSourceTable {
+            source_name: source.to_string(),
+            projectile: projectile.symbol_string(),
+            available: available_sources_for(projectile),
+            available_pretty: available_pretty_for(projectile),
+        });
+    }
+
+    if !available_zs.contains(&target_z) && (target_z < available_zs[0] || target_z > *available_zs.last().unwrap()) {
+        return Err(StoppingError::NoTargetData {
+            source_name: source.to_string(),
+            target_symbol: db.get_element_symbol(target_z),
+            target_z,
+            available_zs,
+        });
     }
 
     let mut z_low = available_zs[0];
@@ -52,12 +123,15 @@ fn get_interpolated_dedx(
 
     if z_low == z_high {
         let (e, d) = db.get_stopping_power(source, z_low);
+        check_energy_range(source, z_low, db, &e, energies)?;
         let interp = make_log_log_interpolator(&e, &d);
-        return (interp(energies), format!("{}(Z~{})", source, z_low));
+        return Ok((interp(energies), format!("{}(Z~{})", source, z_low)));
     }
 
     let (e_lo, d_lo) = db.get_stopping_power(source, z_low);
     let (e_hi, d_hi) = db.get_stopping_power(source, z_high);
+    check_energy_range(source, z_low, db, &e_lo, energies)?;
+    check_energy_range(source, z_high, db, &e_hi, energies)?;
     let interp_lo = make_log_log_interpolator(&e_lo, &d_lo);
     let interp_hi = make_log_log_interpolator(&e_hi, &d_hi);
     let frac = (target_z as f64 - z_low as f64) / (z_high as f64 - z_low as f64);
@@ -69,7 +143,34 @@ fn get_interpolated_dedx(
         .zip(v_hi.iter())
         .map(|(&lo, &hi)| lo + frac * (hi - lo))
         .collect();
-    (result, format!("{}(Z~{}-{})", source, z_low, z_high))
+    Ok((result, format!("{}(Z~{}-{})", source, z_low, z_high)))
+}
+
+fn check_energy_range(
+    source: &str,
+    target_z: u32,
+    db: &dyn DatabaseProtocol,
+    sp_energies: &[f64],
+    requested: &[f64],
+) -> Result<(), StoppingError> {
+    if sp_energies.is_empty() || requested.is_empty() {
+        return Ok(());
+    }
+    let min_mev = sp_energies[0];
+    let max_mev = *sp_energies.last().unwrap();
+    for &e in requested {
+        if e < min_mev || e > max_mev {
+            return Err(StoppingError::EnergyOutOfRange {
+                source_name: source.to_string(),
+                target_symbol: db.get_element_symbol(target_z),
+                target_z,
+                energy_mev: e,
+                min_mev,
+                max_mev,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn get_available_zs(db: &dyn DatabaseProtocol, source: &str) -> Vec<u32> {
@@ -81,6 +182,53 @@ fn get_available_zs(db: &dyn DatabaseProtocol, source: &str) -> Vec<u32> {
         }
     }
     zs
+}
+
+fn available_sources_for(projectile: &ProjectileType) -> Vec<String> {
+    let z = projectile.z();
+    if z == 1 {
+        vec![SOURCE_PSTAR.to_string()]
+    } else if z == 2 {
+        vec![SOURCE_ASTAR.to_string()]
+    } else {
+        // Match the on-disk catima parquet naming (no dash in symbol-A);
+        // see #141 / `source_for`.
+        BUNDLED_CATIMA_PROJECTILES
+            .iter()
+            .map(|p| format!("{}{}", SOURCE_CATIMA_PREFIX, p.replace('-', "")))
+            .collect()
+    }
+}
+
+fn available_pretty_for(projectile: &ProjectileType) -> String {
+    let z = projectile.z();
+    if z == 1 {
+        "p, d, t (PSTAR with velocity-scaling)".to_string()
+    } else if z == 2 {
+        "h, a (ASTAR with velocity-scaling)".to_string()
+    } else {
+        BUNDLED_CATIMA_PROJECTILES.join(", ")
+    }
+}
+
+/// Source identifier for a given projectile (PSTAR / ASTAR / catima_*).
+///
+/// `symbol_string()` returns "O-16"; the bundled catima parquet is named
+/// `catima_O16.parquet` (no dash). Strip the dash so the source key matches
+/// the on-disk filename. See #141 (#137 root cause).
+fn source_for(projectile: &ProjectileType) -> String {
+    let z = projectile.z();
+    if z == 1 {
+        SOURCE_PSTAR.to_string()
+    } else if z == 2 {
+        SOURCE_ASTAR.to_string()
+    } else {
+        format!(
+            "{}{}",
+            SOURCE_CATIMA_PREFIX,
+            projectile.symbol_string().replace('-', "")
+        )
+    }
 }
 
 /// Mass stopping power for a projectile in a pure element [MeV·cm²/g].
@@ -96,42 +244,37 @@ pub fn elemental_dedx(
     projectile: &ProjectileType,
     target_z: u32,
     energies_mev: &[f64],
-) -> Vec<f64> {
+) -> Result<Vec<f64>, StoppingError> {
     let proj = projectile.projectile();
 
     if proj.z == 1 {
-        // Proton, deuteron, tritium: velocity-scale to PSTAR
         let lookup: Vec<f64> = energies_mev.iter().map(|&e| e / proj.a as f64).collect();
-        let (result, _) = get_interpolated_dedx(db, SOURCE_PSTAR, target_z, &lookup);
-        result
+        let (result, _) = get_interpolated_dedx(db, SOURCE_PSTAR, target_z, &lookup, projectile)?;
+        Ok(result)
     } else if proj.z == 2 {
-        // Helion, alpha: velocity-scale to ASTAR
         let lookup: Vec<f64> = energies_mev.iter().map(|&e| e * (4.0 / proj.a as f64)).collect();
-        let (result, _) = get_interpolated_dedx(db, SOURCE_ASTAR, target_z, &lookup);
-        result
+        let (result, _) = get_interpolated_dedx(db, SOURCE_ASTAR, target_z, &lookup, projectile)?;
+        Ok(result)
     } else {
-        // Heavy ion: look up pre-generated catima table from nucl-parquet.
-        // `symbol_string()` returns "O-16"; the bundled parquet is named
-        // `catima_O16.parquet` (no dash). Strip the dash so the source key
-        // matches the on-disk filename. Reported in #137.
-        let source = format!(
-            "{}{}",
-            SOURCE_CATIMA_PREFIX,
-            projectile.symbol_string().replace('-', "")
-        );
-        let (result, _) = get_interpolated_dedx(db, &source, target_z, energies_mev);
-        result
+        let source = source_for(projectile);
+        let (result, _) = get_interpolated_dedx(db, &source, target_z, energies_mev, projectile)?;
+        Ok(result)
     }
 }
 
-/// Scalar version of elemental_dedx.
+/// Scalar variant — internal callers that have already validated the
+/// source/target/energy combo (typically inside `compute_layer` after a
+/// successful precheck) use this; it panics if the dedx lookup fails,
+/// because at that point the failure would be a bug, not a data-coverage
+/// issue.
 pub fn elemental_dedx_scalar(
     db: &dyn DatabaseProtocol,
     projectile: &ProjectileType,
     target_z: u32,
     energy_mev: f64,
 ) -> f64 {
-    elemental_dedx(db, projectile, target_z, &[energy_mev])[0]
+    elemental_dedx(db, projectile, target_z, &[energy_mev])
+        .expect("elemental_dedx_scalar: caller failed to pre-validate source/target/energy")[0]
 }
 
 /// Return the stopping power source label for an element.
@@ -139,21 +282,10 @@ pub fn get_stopping_source(
     db: &dyn DatabaseProtocol,
     projectile: &ProjectileType,
     target_z: u32,
-) -> String {
-    let proj = projectile.projectile();
-    let source = if proj.z == 1 {
-        SOURCE_PSTAR.to_string()
-    } else if proj.z == 2 {
-        SOURCE_ASTAR.to_string()
-    } else {
-        format!(
-            "{}{}",
-            SOURCE_CATIMA_PREFIX,
-            projectile.symbol_string().replace('-', "")
-        )
-    };
-    let (_, label) = get_interpolated_dedx(db, &source, target_z, &[10.0]);
-    label
+) -> Result<String, StoppingError> {
+    let source = source_for(projectile);
+    let (_, label) = get_interpolated_dedx(db, &source, target_z, &[10.0], projectile)?;
+    Ok(label)
 }
 
 /// Return stopping power sources for each element in a composition.
@@ -161,12 +293,12 @@ pub fn get_stopping_sources(
     db: &dyn DatabaseProtocol,
     projectile: &ProjectileType,
     composition: &[(u32, f64)],
-) -> std::collections::HashMap<u32, String> {
+) -> Result<std::collections::HashMap<u32, String>, StoppingError> {
     let mut result = std::collections::HashMap::new();
     for &(z, _) in composition {
-        result.insert(z, get_stopping_source(db, projectile, z));
+        result.insert(z, get_stopping_source(db, projectile, z)?);
     }
-    result
+    Ok(result)
 }
 
 /// Compound stopping power via Bragg additivity [MeV·cm²/g].
@@ -176,15 +308,15 @@ pub fn compound_dedx(
     projectile: &ProjectileType,
     composition: &[(u32, f64)],
     energies_mev: &[f64],
-) -> Vec<f64> {
+) -> Result<Vec<f64>, StoppingError> {
     let mut result = vec![0.0; energies_mev.len()];
     for &(z, mass_frac) in composition {
-        let elemental = elemental_dedx(db, projectile, z, energies_mev);
+        let elemental = elemental_dedx(db, projectile, z, energies_mev)?;
         for (i, &val) in elemental.iter().enumerate() {
             result[i] += mass_frac * val;
         }
     }
-    result
+    Ok(result)
 }
 
 /// Linear stopping power [MeV/cm].
@@ -195,14 +327,15 @@ pub fn dedx_mev_per_cm(
     composition: &[(u32, f64)],
     density_g_cm3: f64,
     energies_mev: &[f64],
-) -> Vec<f64> {
-    compound_dedx(db, projectile, composition, energies_mev)
+) -> Result<Vec<f64>, StoppingError> {
+    Ok(compound_dedx(db, projectile, composition, energies_mev)?
         .iter()
         .map(|&s| s * density_g_cm3)
-        .collect()
+        .collect())
 }
 
-/// Scalar version of dedx_mev_per_cm.
+/// Scalar variant of [`dedx_mev_per_cm`]. Panics on a stopping-data
+/// miss; callers must have done a `dedx_mev_per_cm` precheck first.
 pub fn dedx_mev_per_cm_scalar(
     db: &dyn DatabaseProtocol,
     projectile: &ProjectileType,
@@ -210,7 +343,8 @@ pub fn dedx_mev_per_cm_scalar(
     density_g_cm3: f64,
     energy_mev: f64,
 ) -> f64 {
-    dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &[energy_mev])[0]
+    dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &[energy_mev])
+        .expect("dedx_mev_per_cm_scalar: caller failed to pre-validate source/target/energy")[0]
 }
 
 /// Compute target thickness [cm] from energy loss.
@@ -223,19 +357,19 @@ pub fn compute_thickness_from_energy(
     energy_in_mev: f64,
     energy_out_mev: f64,
     n_points: usize,
-) -> f64 {
+) -> Result<f64, StoppingError> {
     let energies = linspace(energy_out_mev, energy_in_mev, n_points);
     let de = energies[1] - energies[0];
 
     let midpoints: Vec<f64> = (0..n_points - 1).map(|i| energies[i] + de / 2.0).collect();
 
-    let dedx_arr = dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &midpoints);
+    let dedx_arr = dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &midpoints)?;
 
     let mut thickness = 0.0;
     for &dedx_val in &dedx_arr {
         thickness += de / dedx_val;
     }
-    thickness
+    Ok(thickness)
 }
 
 /// Compute exit energy after traversing a material of known thickness.
@@ -248,10 +382,15 @@ pub fn compute_energy_out(
     energy_in_mev: f64,
     thickness_cm: f64,
     n_points: usize,
-) -> f64 {
+) -> Result<f64, StoppingError> {
     if thickness_cm <= 0.0 {
-        return energy_in_mev;
+        return Ok(energy_in_mev);
     }
+
+    // Pre-validate by sampling at the entrance energy. If this miss-types
+    // (NoSourceTable / NoTargetData / EnergyOutOfRange) the integration
+    // loop would otherwise panic via `_scalar`; surface the typed error.
+    dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &[energy_in_mev])?;
 
     let dx = thickness_cm / n_points as f64;
     let mut energy = energy_in_mev;
@@ -260,9 +399,130 @@ pub fn compute_energy_out(
         let loss = dedx_mev_per_cm_scalar(db, projectile, composition, density_g_cm3, energy) * dx;
         energy -= loss;
         if energy <= 0.0 {
-            return 0.0;
+            return Ok(0.0);
         }
     }
 
-    energy
+    Ok(energy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::InMemoryDataStore;
+
+    fn pstar_db() -> InMemoryDataStore {
+        let mut db = InMemoryDataStore::new("test");
+        db.add_element(1, "H");
+        db.add_element(8, "O");
+        db.add_element(13, "Al");
+        db.add_element(29, "Cu");
+        db.add_element(120, "Ubn");
+        let energies: Vec<f64> = (0..50)
+            .map(|i| 0.001_f64 * 10f64.powf(i as f64 / 10.0))
+            .collect();
+        let dedx_h: Vec<f64> = energies.iter().map(|&e| 100.0 / e.sqrt()).collect();
+        let dedx_al: Vec<f64> = energies.iter().map(|&e| 50.0 / e.sqrt()).collect();
+        let dedx_cu: Vec<f64> = energies.iter().map(|&e| 30.0 / e.sqrt()).collect();
+        db.add_stopping_data("PSTAR", 1, energies.clone(), dedx_h);
+        db.add_stopping_data("PSTAR", 13, energies.clone(), dedx_al);
+        db.add_stopping_data("PSTAR", 29, energies, dedx_cu);
+        db
+    }
+
+    #[test]
+    fn no_source_table_when_catima_missing() {
+        let db = pstar_db();
+        let projectile = ProjectileType::HeavyIon {
+            symbol: "O".to_string(),
+            z: 8,
+            a: 17,
+        };
+        let err = elemental_dedx(&db, &projectile, 13, &[10.0]).unwrap_err();
+        match err {
+            StoppingError::NoSourceTable {
+                source_name,
+                projectile: proj,
+                ref available,
+                ref available_pretty,
+            } => {
+                assert_eq!(source_name, "catima_O17");
+                assert_eq!(proj, "O-17");
+                assert!(available.iter().any(|s| s == "catima_C12"));
+                assert!(available_pretty.contains("C-12"));
+                assert!(available_pretty.contains("Fe-56"));
+            }
+            other => panic!("expected NoSourceTable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn energy_out_of_range_for_pstar() {
+        let db = pstar_db();
+        let projectile = ProjectileType::Proton;
+        // Tabulated grid runs ~0.001 → 10^3.9 MeV; 1e8 (= 100 GeV) is well above.
+        let err = elemental_dedx(&db, &projectile, 13, &[1.0e8]).unwrap_err();
+        match err {
+            StoppingError::EnergyOutOfRange {
+                source_name,
+                target_symbol,
+                target_z,
+                energy_mev,
+                min_mev: _,
+                max_mev,
+            } => {
+                assert_eq!(source_name, "PSTAR");
+                assert_eq!(target_symbol, "Al");
+                assert_eq!(target_z, 13);
+                assert_eq!(energy_mev, 1.0e8);
+                assert!(max_mev < 1.0e8);
+            }
+            other => panic!("expected EnergyOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_target_data_when_z_outside_range() {
+        let db = pstar_db();
+        let projectile = ProjectileType::Proton;
+        // Z=120 is far above the largest tabulated Z (29 in this fixture).
+        let err = elemental_dedx(&db, &projectile, 120, &[10.0]).unwrap_err();
+        match err {
+            StoppingError::NoTargetData {
+                source_name,
+                target_z,
+                ref available_zs,
+                ..
+            } => {
+                assert_eq!(source_name, "PSTAR");
+                assert_eq!(target_z, 120);
+                assert!(!available_zs.is_empty());
+                assert!(available_zs.iter().all(|&z| z < 120));
+            }
+            other => panic!("expected NoTargetData, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn happy_path_returns_ok() {
+        let db = pstar_db();
+        let projectile = ProjectileType::Proton;
+        let result = elemental_dedx(&db, &projectile, 13, &[10.0]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0] > 0.0);
+    }
+
+    #[test]
+    fn as_json_includes_kind_tag() {
+        let err = StoppingError::NoSourceTable {
+            source_name: "catima_O17".to_string(),
+            projectile: "O-17".to_string(),
+            available: vec!["catima_C12".to_string()],
+            available_pretty: "C-12".to_string(),
+        };
+        let json = err.as_json();
+        assert_eq!(json["kind"], "StoppingError");
+        assert_eq!(json["variant"], "NoSourceTable");
+        assert_eq!(json["projectile"], "O-17");
+    }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -303,7 +303,8 @@ pub fn run_compute_stack(
         current_profile: None,
     };
 
-    let result = compute_stack(db, &mut stack, true);
+    let result = compute_stack(db, &mut stack, true)
+        .map_err(|e| serde_json::to_string(&e.as_json()).unwrap_or_else(|_| e.to_string()))?;
 
     // Convert to JSON contract
     let sim_result = convert_stack_result(&config_json, &result);
@@ -369,10 +370,12 @@ pub fn compute_depth_preview(
             } else if e_out > energy_in {
                 (0.0, "energy_out", Some(format!("Eout ({e_out} MeV) > Ein ({energy_in:.1} MeV)")))
             } else {
-                let t = compute_thickness_from_energy(
+                match compute_thickness_from_energy(
                     db, &projectile, &composition, density, energy_in, e_out.max(0.0), 1000,
-                );
-                (t, "energy_out", None)
+                ) {
+                    Ok(t) => (t, "energy_out", None),
+                    Err(e) => (0.0, "energy_out", Some(e.to_string())),
+                }
             }
         } else {
             continue;
@@ -382,11 +385,29 @@ pub fn compute_depth_preview(
         let areal_density = thickness_cm * density;
 
         let (energy_out, depth_points, heat_kw) = if energy_in > 0.0 && thickness_cm > 0.0 {
-            let e_out = if user_specified == "energy_out" {
-                lc.energy_out_MeV.unwrap_or(0.0).min(energy_in).max(0.0)
+            let e_out_res: Result<f64, hyrr_core::stopping::StoppingError> = if user_specified == "energy_out" {
+                Ok(lc.energy_out_MeV.unwrap_or(0.0).min(energy_in).max(0.0))
             } else {
                 compute_energy_out(db, &projectile, &composition, density, energy_in, thickness_cm, 1000)
-                    .max(0.0)
+                    .map(|v| v.max(0.0))
+            };
+            let e_out = match e_out_res {
+                Ok(v) => v,
+                Err(err) => {
+                    preview_layers.push(DepthPreviewLayer {
+                        material: lc.material.clone(),
+                        thickness_mm: thickness_cm * 10.0,
+                        areal_density_g_cm2: thickness_cm * density,
+                        energy_in_MeV: energy_in,
+                        energy_out_MeV: 0.0,
+                        delta_E_MeV: 0.0,
+                        heat_kW: 0.0,
+                        depth_points: vec![],
+                        user_specified: user_specified.to_string(),
+                        error: Some(err.to_string()),
+                    });
+                    continue;
+                }
             };
 
             let n_pts = 50;
@@ -394,7 +415,24 @@ pub fn compute_depth_preview(
             let energies: Vec<f64> = (0..n_pts)
                 .map(|i| e_min + (energy_in - e_min) * (i as f64) / ((n_pts - 1) as f64))
                 .collect();
-            let dedx_vals = dedx_mev_per_cm(db, &projectile, &composition, density, &energies);
+            let dedx_vals = match dedx_mev_per_cm(db, &projectile, &composition, density, &energies) {
+                Ok(v) => v,
+                Err(err) => {
+                    preview_layers.push(DepthPreviewLayer {
+                        material: lc.material.clone(),
+                        thickness_mm: thickness_cm * 10.0,
+                        areal_density_g_cm2: thickness_cm * density,
+                        energy_in_MeV: energy_in,
+                        energy_out_MeV: 0.0,
+                        delta_E_MeV: 0.0,
+                        heat_kW: 0.0,
+                        depth_points: vec![],
+                        user_specified: user_specified.to_string(),
+                        error: Some(err.to_string()),
+                    });
+                    continue;
+                }
+            };
 
             let dp = generate_depth_profile(&energies, &dedx_vals, beam_current, beam_area, proj_z);
 

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -20,6 +20,7 @@
     getResult,
     getStatus,
     getProgress,
+    getComputeError,
   } from "./lib/stores/results.svelte";
   import {
     getHistoryOpen,
@@ -40,6 +41,8 @@
   } from "@hyrr/compute";
   import { setCustomMaterialExpander } from "./lib/compute/backend";
   import { getCustomMaterials, loadCustomMaterials } from "./lib/stores/custom-materials.svelte";
+  import { setProjectile } from "./lib/stores/config.svelte";
+  import { openBugReport } from "./lib/stores/bugreport.svelte";
 
   // New components
   import HeaderBar from "./lib/components/HeaderBar.svelte";
@@ -53,6 +56,7 @@
   import ActivityTableEnhanced from "./lib/components/ActivityTableEnhanced.svelte";
   import HistoryPanel from "./lib/components/HistoryPanel.svelte";
   import HistoryImportExport from "./lib/components/HistoryImportExport.svelte";
+  import ComputeErrorCard from "./lib/components/ComputeErrorCard.svelte";
   import MaterialPopup from "./lib/components/MaterialPopup.svelte";
   import ElementPopup from "./lib/components/ElementPopup.svelte";
   import IsotopePopup from "./lib/components/IsotopePopup.svelte";
@@ -74,6 +78,7 @@
   let hasLayers = $derived(layers.length > 0);
   let status = $derived(getStatus());
   let result = $derived(getResult());
+  let computeError = $derived(getComputeError());
   let historyOpen = $derived(getHistoryOpen());
 
   // Popup state
@@ -358,6 +363,20 @@
       </div>
 
       <LayerStackHorizontal onmaterialclick={openMaterialPopup} onelementclick={openElementPopup} />
+
+      {#if computeError && !result}
+        <ComputeErrorCard
+          error={computeError}
+          projectile={config.beam.projectile}
+          energyMev={config.beam.energy_MeV}
+          onSwitchProjectile={(suggestion) => setProjectile(suggestion)}
+          onEditBeam={() => {
+            const el = document.querySelector(".config-row");
+            if (el && "scrollIntoView" in el) el.scrollIntoView({ behavior: "smooth" });
+          }}
+          onReportGap={openBugReport}
+        />
+      {/if}
 
       {#if hasLayers}
         <PlotDepthProfileLive />

--- a/frontend/src/lib/components/ComputeErrorCard.svelte
+++ b/frontend/src/lib/components/ComputeErrorCard.svelte
@@ -1,0 +1,208 @@
+<script lang="ts">
+  import type { ComputeError } from "../types";
+
+  type Props = {
+    error: ComputeError;
+    projectile?: string;
+    energyMev?: number;
+    onSwitchProjectile?: (suggestion: string) => void;
+    onEditBeam?: () => void;
+    onReportGap?: () => void;
+  };
+
+  let {
+    error,
+    projectile,
+    energyMev,
+    onSwitchProjectile,
+    onEditBeam,
+    onReportGap,
+  }: Props = $props();
+
+  // Pretty fall-throughs derived from the structured payload.
+  const sourceLabel = $derived(
+    error.kind === "StoppingError" ? error.source : "compute backend",
+  );
+  const projectileLabel = $derived(
+    error.kind === "StoppingError" && error.variant === "NoSourceTable"
+      ? error.projectile
+      : (projectile ?? "—"),
+  );
+  const targetLabel = $derived(
+    error.kind === "StoppingError" && error.variant !== "NoSourceTable"
+      ? `${error.target_symbol} (Z=${error.target_z})`
+      : "—",
+  );
+  const energyLabel = $derived(
+    error.kind === "StoppingError" && error.variant === "EnergyOutOfRange"
+      ? `${error.energy_mev.toFixed(3)} MeV`
+      : energyMev != null
+        ? `${energyMev.toFixed(3)} MeV`
+        : "—",
+  );
+
+  // Suggested replacement when StoppingError::NoSourceTable.
+  const nearestSuggestion = $derived(
+    error.kind === "StoppingError" && error.variant === "NoSourceTable"
+      ? pickNearest(error.projectile, error.available)
+      : null,
+  );
+
+  function pickNearest(_proj: string, available: string[]): string | null {
+    // The Rust side gives us source identifiers like "catima_C-12";
+    // strip the prefix for display + dropdown values.
+    const projForms = available
+      .map((s) => s.replace(/^catima_/, ""))
+      .filter((s) => s.length > 0);
+    return projForms[0] ?? null;
+  }
+</script>
+
+<div class="error-card" role="alert" aria-live="assertive">
+  <header class="error-card-header">
+    <span class="badge">No stopping data available</span>
+    <span class="variant-tag">{
+      error.kind === "StoppingError" ? error.variant : "Unknown"
+    }</span>
+  </header>
+
+  <section class="data-points">
+    <dl>
+      <dt>Source</dt><dd>{sourceLabel}</dd>
+      <dt>Projectile</dt><dd>{projectileLabel}</dd>
+      <dt>Target</dt><dd>{targetLabel}</dd>
+      <dt>Energy</dt><dd>{energyLabel}</dd>
+    </dl>
+  </section>
+
+  <section class="explanation">
+    <p class="message">{error.message}</p>
+
+    {#if error.kind === "StoppingError" && error.variant === "NoSourceTable"}
+      <p class="available-line">
+        <strong>Available:</strong> {error.available_pretty}
+      </p>
+    {:else if error.kind === "StoppingError" && error.variant === "EnergyOutOfRange"}
+      <p class="available-line">
+        <strong>Tabulated range:</strong>
+        {error.min_mev.toFixed(3)} – {error.max_mev.toFixed(3)} MeV
+      </p>
+    {:else if error.kind === "StoppingError" && error.variant === "NoTargetData"}
+      <p class="available-line">
+        <strong>Available Z:</strong>
+        {error.available_zs.join(", ")}
+      </p>
+    {/if}
+
+    <p class="consequence">
+      Without stopping data, the depth profile, dE/dx curve, residual energy,
+      and Bragg peak cannot be computed for this stack.
+    </p>
+  </section>
+
+  <footer class="actions">
+    {#if nearestSuggestion && onSwitchProjectile}
+      <button
+        type="button"
+        class="primary"
+        onclick={() => onSwitchProjectile?.(nearestSuggestion)}
+      >
+        Switch projectile to {nearestSuggestion}
+      </button>
+    {/if}
+    {#if onEditBeam}
+      <button type="button" onclick={onEditBeam}>Edit beam</button>
+    {/if}
+    {#if onReportGap}
+      <button type="button" onclick={onReportGap}>Report this gap</button>
+    {/if}
+  </footer>
+</div>
+
+<style>
+  .error-card {
+    border: 1px solid var(--color-error, #d23f3f);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    background: var(--color-error-bg, rgba(210, 63, 63, 0.06));
+    margin: 1rem 0;
+    font-size: 0.95rem;
+    color: var(--color-fg, #1a1a1a);
+  }
+
+  .error-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .badge {
+    font-weight: 600;
+    color: var(--color-error, #d23f3f);
+    font-size: 1rem;
+  }
+
+  .variant-tag {
+    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
+    font-size: 0.8rem;
+    background: var(--color-bg-elevated, #fff);
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    color: var(--color-fg-muted, #555);
+  }
+
+  .data-points dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.15rem 0.75rem;
+    margin: 0.5rem 0;
+  }
+  .data-points dt {
+    font-weight: 500;
+    color: var(--color-fg-muted, #555);
+  }
+  .data-points dd {
+    margin: 0;
+    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
+  }
+
+  .explanation .message {
+    margin: 0.5rem 0;
+    line-height: 1.4;
+  }
+  .available-line {
+    margin: 0.4rem 0;
+  }
+  .consequence {
+    margin: 0.4rem 0 0;
+    font-size: 0.85rem;
+    color: var(--color-fg-muted, #555);
+    font-style: italic;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+
+  .actions button {
+    padding: 0.35rem 0.85rem;
+    border: 1px solid var(--color-border, rgba(0, 0, 0, 0.18));
+    border-radius: 4px;
+    background: var(--color-bg-elevated, #fff);
+    cursor: pointer;
+    font-size: 0.9rem;
+  }
+  .actions button.primary {
+    background: var(--color-accent, #2c6ed5);
+    color: #fff;
+    border-color: transparent;
+  }
+  .actions button:hover {
+    filter: brightness(0.95);
+  }
+</style>

--- a/frontend/src/lib/compute/parse-error.test.ts
+++ b/frontend/src/lib/compute/parse-error.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { parseComputeError } from "./parse-error";
+
+describe("parseComputeError", () => {
+  it("classifies a structured NoSourceTable payload from WASM", () => {
+    const payload = {
+      kind: "StoppingError",
+      variant: "NoSourceTable",
+      source: "catima_O-17",
+      projectile: "O-17",
+      available: ["catima_C-12", "catima_O-16"],
+      available_pretty: "C-12, O-16",
+      message:
+        "No catima_O-17 stopping table — projectile O-17 not in bundled set. Available: C-12, O-16",
+    };
+    const result = parseComputeError(payload);
+    expect(result.kind).toBe("StoppingError");
+    if (result.kind !== "StoppingError" || result.variant !== "NoSourceTable") {
+      throw new Error("expected NoSourceTable variant");
+    }
+    expect(result.projectile).toBe("O-17");
+    expect(result.available).toContain("catima_C-12");
+    expect(result.available_pretty).toContain("C-12");
+  });
+
+  it("classifies a structured EnergyOutOfRange payload", () => {
+    const payload = {
+      kind: "StoppingError",
+      variant: "EnergyOutOfRange",
+      source: "PSTAR",
+      target_symbol: "Al",
+      target_z: 13,
+      energy_mev: 1e8,
+      min_mev: 0.001,
+      max_mev: 1000,
+      message: "Energy 1e8 MeV out of range",
+    };
+    const result = parseComputeError(payload);
+    if (result.kind !== "StoppingError" || result.variant !== "EnergyOutOfRange") {
+      throw new Error("expected EnergyOutOfRange variant");
+    }
+    expect(result.target_z).toBe(13);
+    expect(result.max_mev).toBe(1000);
+  });
+
+  it("classifies a structured NoTargetData payload", () => {
+    const payload = {
+      kind: "StoppingError",
+      variant: "NoTargetData",
+      source: "PSTAR",
+      target_symbol: "Ubn",
+      target_z: 120,
+      available_zs: [1, 13, 29],
+      message: "No PSTAR data for target Ubn",
+    };
+    const result = parseComputeError(payload);
+    if (result.kind !== "StoppingError" || result.variant !== "NoTargetData") {
+      throw new Error("expected NoTargetData variant");
+    }
+    expect(result.available_zs).toEqual([1, 13, 29]);
+  });
+
+  it("parses the Tauri JSON-string error channel", () => {
+    const tauriError = JSON.stringify({
+      kind: "StoppingError",
+      variant: "NoSourceTable",
+      source: "catima_O-17",
+      projectile: "O-17",
+      available: [],
+      available_pretty: "C-12",
+      message: "...",
+    });
+    const result = parseComputeError(tauriError);
+    expect(result.kind).toBe("StoppingError");
+  });
+
+  it("falls back to Unknown for legacy plain string errors", () => {
+    const result = parseComputeError("RuntimeError: unreachable");
+    expect(result.kind).toBe("Unknown");
+    expect(result.message).toBe("RuntimeError: unreachable");
+  });
+
+  it("falls back to Unknown for thrown Error instances", () => {
+    const result = parseComputeError(new Error("WASM panic"));
+    expect(result.kind).toBe("Unknown");
+    expect(result.message).toBe("WASM panic");
+  });
+
+  it("does not pretend an unrelated object is a StoppingError", () => {
+    const result = parseComputeError({ foo: "bar" });
+    expect(result.kind).toBe("Unknown");
+  });
+});

--- a/frontend/src/lib/compute/parse-error.ts
+++ b/frontend/src/lib/compute/parse-error.ts
@@ -1,0 +1,112 @@
+/**
+ * Parse a thrown compute-backend value into a typed {@link ComputeError}.
+ *
+ * Handles three shapes:
+ * 1. Structured WASM payload — `{kind, variant, ...fields}` reaches us as a
+ *    plain object via `serde_wasm_bindgen::to_value`.
+ * 2. Tauri JSON-string error — `Result<_, String>` carries the same shape
+ *    serialized as a string; we try `JSON.parse` first.
+ * 3. Legacy `Error` / opaque throw — fall back to `kind: "Unknown"` so the
+ *    recovery card can still render the raw message instead of pretending
+ *    everything's a StoppingError.
+ */
+import type { ComputeError } from "../types";
+
+export function parseComputeError(raw: unknown): ComputeError {
+  const structured = tryStructured(raw);
+  if (structured) return structured;
+
+  // Tauri error: Result<_, String> — JSON-stringified payload.
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      const fromString = tryStructured(parsed);
+      if (fromString) return fromString;
+    } catch {
+      // not JSON — fall through to Unknown
+    }
+    return { kind: "Unknown", message: raw };
+  }
+
+  if (raw instanceof Error) {
+    // The wasm-bindgen panic path wraps the JsValue inside Error.message —
+    // try to peel it.
+    try {
+      const parsed = JSON.parse(raw.message);
+      const fromString = tryStructured(parsed);
+      if (fromString) return fromString;
+    } catch {
+      // not JSON
+    }
+    return { kind: "Unknown", message: raw.message };
+  }
+
+  // Object passed straight from JsValue / Tauri — serialize for display.
+  if (raw && typeof raw === "object") {
+    const message =
+      (raw as { message?: unknown }).message != null
+        ? String((raw as { message: unknown }).message)
+        : JSON.stringify(raw);
+    return { kind: "Unknown", message };
+  }
+
+  return { kind: "Unknown", message: String(raw ?? "Simulation failed") };
+}
+
+function tryStructured(raw: unknown): ComputeError | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (obj.kind !== "StoppingError") return null;
+  const variant = obj.variant;
+  const message = typeof obj.message === "string" ? obj.message : "";
+
+  if (variant === "NoSourceTable") {
+    return {
+      kind: "StoppingError",
+      variant: "NoSourceTable",
+      source: str(obj.source),
+      projectile: str(obj.projectile),
+      available: arrStr(obj.available),
+      available_pretty: str(obj.available_pretty),
+      message,
+    };
+  }
+  if (variant === "EnergyOutOfRange") {
+    return {
+      kind: "StoppingError",
+      variant: "EnergyOutOfRange",
+      source: str(obj.source),
+      target_symbol: str(obj.target_symbol),
+      target_z: num(obj.target_z),
+      energy_mev: num(obj.energy_mev),
+      min_mev: num(obj.min_mev),
+      max_mev: num(obj.max_mev),
+      message,
+    };
+  }
+  if (variant === "NoTargetData") {
+    return {
+      kind: "StoppingError",
+      variant: "NoTargetData",
+      source: str(obj.source),
+      target_symbol: str(obj.target_symbol),
+      target_z: num(obj.target_z),
+      available_zs: arrNum(obj.available_zs),
+      message,
+    };
+  }
+  return null;
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function num(v: unknown): number {
+  return typeof v === "number" ? v : Number(v) || 0;
+}
+function arrStr(v: unknown): string[] {
+  return Array.isArray(v) ? v.map((x) => String(x)) : [];
+}
+function arrNum(v: unknown): number[] {
+  return Array.isArray(v) ? v.map((x) => num(x)) : [];
+}

--- a/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
+++ b/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
@@ -14,9 +14,11 @@ import {
   setRunning,
   setError,
   setIdle,
+  setComputeError,
   clearResult,
   type SimStatus,
 } from "../stores/results.svelte";
+import { parseComputeError } from "../compute/parse-error";
 import { configHash } from "./config-hash";
 import { DataStore } from "@hyrr/compute";
 import type { SimulationConfig, SimulationResult } from "@hyrr/compute";
@@ -150,8 +152,13 @@ async function runSimulation(hash: string): Promise<void> {
   } catch (e: unknown) {
     if (cancelled) return;
     state = "error";
-    const msg = e instanceof Error ? e.message : "Simulation failed";
-    setError(msg);
+    const parsed = parseComputeError(e);
+    // Sibling #143 owns the result-clearing path; if its store API is in
+    // place use that, otherwise fall back to the legacy clearResult here.
+    // Either way the typed error must land in `computeError` so the
+    // recovery card renders.
+    setComputeError(parsed);
+    setError(parsed.message);
   }
 }
 

--- a/frontend/src/lib/stores/results.svelte.ts
+++ b/frontend/src/lib/stores/results.svelte.ts
@@ -2,13 +2,14 @@
  * Simulation results state using Svelte 5 runes.
  */
 
-import type { SimulationResult } from "../types";
+import type { ComputeError, SimulationResult } from "../types";
 
 export type SimStatus = "idle" | "loading" | "running" | "ready" | "error";
 
 let result = $state<SimulationResult | null>(null);
 let status = $state<SimStatus>("idle");
 let error = $state<string | null>(null);
+let computeError = $state<ComputeError | null>(null);
 let progress = $state<string>("");
 
 export function getResult(): SimulationResult | null {
@@ -23,6 +24,11 @@ export function getError(): string | null {
   return error;
 }
 
+/** Typed compute-backend error (#142). Surfaced as a recovery card. */
+export function getComputeError(): ComputeError | null {
+  return computeError;
+}
+
 export function getProgress(): string {
   return progress;
 }
@@ -31,6 +37,7 @@ export function setResult(r: SimulationResult): void {
   result = r;
   status = "ready";
   error = null;
+  computeError = null;
   progress = "";
 }
 
@@ -38,12 +45,14 @@ export function setLoading(msg = "Loading data..."): void {
   status = "loading";
   progress = msg;
   error = null;
+  computeError = null;
 }
 
 export function setRunning(msg = "Running simulation..."): void {
   status = "running";
   progress = msg;
   error = null;
+  computeError = null;
 }
 
 export function setError(msg: string): void {
@@ -52,15 +61,30 @@ export function setError(msg: string): void {
   progress = "";
 }
 
+/**
+ * Set the structured compute error. Companion to the per-issue-#143
+ * result-clearing path: callers should null the result themselves.
+ */
+export function setComputeError(err: ComputeError | null): void {
+  computeError = err;
+  if (err) {
+    status = "error";
+    error = err.message;
+    progress = "";
+  }
+}
+
 export function setIdle(): void {
   status = "idle";
   progress = "";
   error = null;
+  computeError = null;
 }
 
 export function clearResult(): void {
   result = null;
   status = "idle";
   error = null;
+  computeError = null;
   progress = "";
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -34,3 +34,46 @@ export interface HistoryEntry {
   config: import("@hyrr/compute").SimulationConfig;
   result: import("@hyrr/compute").SimulationResult | null;
 }
+
+/**
+ * Discriminated union mirroring `core::stopping::StoppingError`.
+ *
+ * The Rust enum is serialized with `#[serde(tag = "variant")]` and the
+ * WASM bridge tags every payload with `kind: "StoppingError"`. Tauri
+ * returns the same JSON inside its `Result<_, String>` error channel.
+ *
+ * `Unknown` is the explicit fallback when `parseComputeError` cannot
+ * classify a thrown value — keeps generic JS errors out of the typed
+ * recovery card while still surfacing them to the user.
+ */
+export type ComputeError =
+  | {
+      kind: "StoppingError";
+      variant: "NoSourceTable";
+      source: string;
+      projectile: string;
+      available: string[];
+      available_pretty: string;
+      message: string;
+    }
+  | {
+      kind: "StoppingError";
+      variant: "EnergyOutOfRange";
+      source: string;
+      target_symbol: string;
+      target_z: number;
+      energy_mev: number;
+      min_mev: number;
+      max_mev: number;
+      message: string;
+    }
+  | {
+      kind: "StoppingError";
+      variant: "NoTargetData";
+      source: string;
+      target_symbol: string;
+      target_z: number;
+      available_zs: number[];
+      message: string;
+    }
+  | { kind: "Unknown"; message: string };

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -12,16 +12,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -34,13 +76,248 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "hyrr-core"
 version = "0.1.0"
 dependencies = [
+ "fs2",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "thiserror",
+ "zstd",
 ]
 
 [[package]]
@@ -56,10 +333,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -72,16 +468,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -93,12 +584,111 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -131,10 +721,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -191,6 +895,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +955,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -222,10 +1009,177 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -238,6 +1192,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -273,7 +1241,373 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -12,7 +12,9 @@ use hyrr_core::db::{DatabaseProtocol, InMemoryDataStore};
 use hyrr_core::formula::parse_formula;
 use hyrr_core::materials::resolve_material;
 use hyrr_core::production::generate_depth_profile;
-use hyrr_core::stopping::{compute_energy_out, compute_thickness_from_energy, dedx_mev_per_cm};
+use hyrr_core::stopping::{
+    compute_energy_out, compute_thickness_from_energy, dedx_mev_per_cm, StoppingError,
+};
 use hyrr_core::types::*;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -178,7 +180,8 @@ impl WasmDataStore {
             current_profile: None,
         };
 
-        let result = compute_stack(&self.inner, &mut stack, true);
+        let result = compute_stack(&self.inner, &mut stack, true)
+            .map_err(stopping_error_to_jsvalue)?;
         let sim_result = convert_stack_result(config_json, &result);
         serde_json::to_string(&sim_result).map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -236,10 +239,12 @@ impl WasmDataStore {
                 } else if e_out > energy_in {
                     (0.0, "energy_out", Some(format!("Eout ({e_out} MeV) > Ein ({energy_in:.1} MeV)")))
                 } else {
-                    let t = compute_thickness_from_energy(
+                    match compute_thickness_from_energy(
                         &self.inner, &projectile, &composition, density, energy_in, e_out.max(0.0), 1000,
-                    );
-                    (t, "energy_out", None)
+                    ) {
+                        Ok(t) => (t, "energy_out", None),
+                        Err(e) => (0.0, "energy_out", Some(e.to_string())),
+                    }
                 }
             } else {
                 continue;
@@ -249,11 +254,29 @@ impl WasmDataStore {
             let areal_density = thickness_cm * density;
 
             let (energy_out, depth_points, heat_kw) = if energy_in > 0.0 && thickness_cm > 0.0 {
-                let e_out = if user_specified == "energy_out" {
-                    lc.energy_out_mev.unwrap_or(0.0).min(energy_in).max(0.0)
+                let e_out_res: Result<f64, StoppingError> = if user_specified == "energy_out" {
+                    Ok(lc.energy_out_mev.unwrap_or(0.0).min(energy_in).max(0.0))
                 } else {
                     compute_energy_out(&self.inner, &projectile, &composition, density, energy_in, thickness_cm, 1000)
-                        .max(0.0)
+                        .map(|v| v.max(0.0))
+                };
+                let e_out = match e_out_res {
+                    Ok(v) => v,
+                    Err(err) => {
+                        preview_layers.push(DepthPreviewLayer {
+                            material: lc.material.clone(),
+                            thickness_mm: thickness_cm * 10.0,
+                            areal_density_g_cm2: thickness_cm * density,
+                            energy_in_mev: energy_in,
+                            energy_out_mev: 0.0,
+                            delta_e_mev: 0.0,
+                            heat_kw: 0.0,
+                            depth_points: vec![],
+                            user_specified: user_specified.to_string(),
+                            error: Some(err.to_string()),
+                        });
+                        continue;
+                    }
                 };
 
                 let n_pts = 50;
@@ -261,7 +284,24 @@ impl WasmDataStore {
                 let energies: Vec<f64> = (0..n_pts)
                     .map(|i| e_min + (energy_in - e_min) * (i as f64) / ((n_pts - 1) as f64))
                     .collect();
-                let dedx_vals = dedx_mev_per_cm(&self.inner, &projectile, &composition, density, &energies);
+                let dedx_vals = match dedx_mev_per_cm(&self.inner, &projectile, &composition, density, &energies) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        preview_layers.push(DepthPreviewLayer {
+                            material: lc.material.clone(),
+                            thickness_mm: thickness_cm * 10.0,
+                            areal_density_g_cm2: thickness_cm * density,
+                            energy_in_mev: energy_in,
+                            energy_out_mev: 0.0,
+                            delta_e_mev: 0.0,
+                            heat_kw: 0.0,
+                            depth_points: vec![],
+                            user_specified: user_specified.to_string(),
+                            error: Some(err.to_string()),
+                        });
+                        continue;
+                    }
+                };
                 let dp = generate_depth_profile(&energies, &dedx_vals, beam_current, beam_area, proj_z);
 
                 let mut points: Vec<DepthPreviewPoint> = Vec::new();
@@ -555,6 +595,20 @@ struct MaterialElementJson {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Surface a [`StoppingError`] to JS as a structured object the frontend's
+/// `parseComputeError` helper can deserialize. Keeps the variant tag, payload
+/// fields, and a `message` string for display fallback.
+fn stopping_error_to_jsvalue(err: StoppingError) -> JsValue {
+    let mut value = err.as_json();
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("message".to_string(), serde_json::Value::String(err.to_string()));
+    }
+    match serde_wasm_bindgen::to_value(&value) {
+        Ok(js) => js,
+        Err(_) => JsValue::from_str(&err.to_string()),
+    }
+}
 
 fn config_to_layers(db: &dyn DatabaseProtocol, config: &SimulationConfig) -> Vec<Layer> {
     config


### PR DESCRIPTION
## Summary

Closes #142.

Converts every `panic!` in `core/src/stopping.rs` to a typed
`StoppingError::{NoSourceTable, EnergyOutOfRange, NoTargetData}`. The
WASM bridge serializes the variant as a structured `{kind:"StoppingError", variant, ...}`
payload; Tauri's `Result<_, String>` channel carries the same shape
JSON-serialized. The frontend's new `parseComputeError` helper
deserializes both forms (plus a legacy fallback) into a discriminated
union the new `ComputeErrorCard.svelte` renders.

The recovery card always shows the four data points the user asked
for — source, projectile, target, energy — plus what's available and
actionable buttons (switch projectile / edit beam / report this gap).

Built on top of the #141 catima dash-strip fix (preserved through
rebase). Sibling issue #143 owns the result-store-clearing path; this
PR uses a separate `computeError` field on the result store and does
not touch the legacy `error` string used by other call sites — a clean
merge with #143 is expected.

## Per-variant message format (one example)

The card mounted for projectile O-17, energy 10 MeV, target Au:

> **No stopping data available**            [NoSourceTable]
>
> Source       catima_O17
> Projectile   O-17
> Target       Au (Z=79)
> Energy       10.000 MeV
>
> No catima_O17 stopping table — projectile O-17 not in bundled set.
> Available: C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56
>
> Available: C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56
>
> Without stopping data, the depth profile, dE/dx curve, residual energy,
> and Bragg peak cannot be computed for this stack.
>
> [ Switch projectile to C12 ]  [ Edit beam ]  [ Report this gap ]

EnergyOutOfRange swaps "Available" for the tabulated `min .. max MeV`
range; NoTargetData lists the available Z values; Unknown falls back
to the raw thrown message without pretending it's a StoppingError.

## Test plan

- [x] `cd core && cargo test --lib stopping::` — 5/5 green
  (NoSourceTable, EnergyOutOfRange, NoTargetData, happy path, JSON tag)
- [x] `cd core && cargo test --lib --skip data_fetch::tests::data_version` — 39/39 green
  (the skipped test fails locally due to missing submodule; pre-existing)
- [x] `cd wasm && cargo build --target wasm32-unknown-unknown` — green
- [x] `cd frontend && npm run check` — 0 errors, 0 warnings
- [x] `cd frontend && npm test` — 430 / 430 green
  (parse-error.test.ts adds 7 new cases)
- [ ] Manual: load #137 reproducer — expect yield + depth profile (already
      shipped in #141, retained by this PR)
- [ ] Manual: construct an unsupported-projectile config, expect the
      recovery card with all four data points + Switch-projectile
      action populates the dropdown with the closest catima projectile

## Sibling-agent coordination

- **#143**: I added a separate `computeError: ComputeError | null`
  field on the result store (with `setComputeError` / `getComputeError`).
  `setError(msg)` is still called alongside so any consumer reading the
  legacy string error keeps working. When #143 merges, both paths
  null-out the result; the `setComputeError(null)` calls inside
  `setIdle` / `clearResult` / `setResult` ensure the recovery card
  hides the moment a fresh successful run completes.
- **#144**: independent — no overlap.