### PR TITLE
test(core/148): projectile-matrix smoke test (Tier 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,27 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest tests/ --cov --benchmark-disable --ignore=tests/integration
 
+  rust-projectile-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: false
+      - name: Init nucl-parquet submodule (sparse)
+        run: |
+          git submodule update --init --depth 1 --filter=blob:none nucl-parquet
+          cd nucl-parquet
+          git sparse-checkout set data/meta data/stopping data/tendl-2025/xs
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: core
+      - name: Run projectile matrix (#148 Tier 1)
+        working-directory: core
+        env:
+          HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
+        run: cargo test --test projectile_matrix -- --include-ignored
+
   supplier-catalog-freshness:
     runs-on: ubuntu-latest
     steps:

--- a/core/tests/projectile_matrix.rs
+++ b/core/tests/projectile_matrix.rs
@@ -1,0 +1,103 @@
+//! Tier 1 of #148: smoke-test compute_stack against every supported projectile.
+//!
+//! Catches the #137 class of bug where a single projectile has the wrong
+//! lookup key (catima dash-strip) and explodes at compute time. The bundled
+//! catima parquet set is C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56.
+
+use hyrr_core::compute::compute_stack;
+use hyrr_core::db::ParquetDataStore;
+use hyrr_core::materials::resolve_material;
+use hyrr_core::types::*;
+
+/// Resolve the bundled nucl-parquet directory. Honour `HYRR_DATA` first
+/// (matches the rest of the test/example surface), then fall back to the
+/// sibling submodule path so a fresh checkout works without env wiring.
+fn data_dir() -> Option<String> {
+    let candidates = [
+        std::env::var("HYRR_DATA").ok(),
+        Some("../nucl-parquet/data".to_string()),
+        Some("nucl-parquet/data".to_string()),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|p| std::path::Path::new(p).exists())
+}
+
+fn make_db(library: &str) -> Option<ParquetDataStore> {
+    let dir = data_dir()?;
+    ParquetDataStore::new(&dir, library).ok()
+}
+
+/// Build a trivial single-layer Cu stack. Cu (Z=29) is well inside the catima
+/// Z range and well-tabulated in PSTAR/ASTAR, so a failure here means the
+/// lookup machinery itself is broken — exactly what #137 was. Energy + areal
+/// density are picked so heavy ions don't stop short of the back of the layer
+/// (sub-MeV outgoing energy trips the catima table-min at 0.012 MeV).
+fn trivial_cu_stack(db: &ParquetDataStore, projectile: ProjectileType, energy_mev: f64) -> TargetStack {
+    let cu = resolve_material(db, "Cu", None);
+    let layer = Layer {
+        density_g_cm3: cu.density,
+        elements: cu.elements.clone(),
+        thickness_cm: None,
+        areal_density_g_cm2: Some(1.0e-4),
+        energy_out_mev: None,
+        is_monitor: false,
+        computed_energy_in: 0.0,
+        computed_energy_out: 0.0,
+        computed_thickness: 0.0,
+    };
+    TargetStack {
+        beam: Beam::new(projectile, energy_mev, 0.04),
+        layers: vec![layer],
+        irradiation_time_s: 1.0,
+        cooling_time_s: 0.0,
+        area_cm2: 1.0,
+        current_profile: None,
+    }
+}
+
+const PROJECTILES: &[&str] = &[
+    "p", "d", "t", "h", "a",
+    "C-12", "O-16", "Ne-20", "Si-28", "Ar-40", "Fe-56",
+];
+
+#[test]
+#[ignore = "requires bundled nucl-parquet data; run with --include-ignored after submodule init"]
+fn every_supported_projectile_computes_without_panic() {
+    let Some(mut db) = make_db("tendl-2025") else {
+        eprintln!("skipping: no nucl-parquet data dir found (set HYRR_DATA or init the submodule)");
+        return;
+    };
+    let _ = db.load_xs("p", 29);
+    let _ = db.load_xs("d", 29);
+    let _ = db.load_xs("a", 29);
+
+    let mut failures: Vec<String> = vec![];
+    for proj_str in PROJECTILES {
+        let Some(proj) = ProjectileType::from_str(proj_str) else {
+            failures.push(format!("{proj_str}: from_str returned None"));
+            continue;
+        };
+        let _ = db.load_xs(proj_str, 29);
+        // Heavy ions need a higher per-particle energy than light ions to avoid
+        // the catima table-min trip; pick generously per the projectile mass.
+        let energy = if proj.z() <= 2 { 10.0 } else { 50.0 * proj.a() as f64 };
+        let stack = trivial_cu_stack(&db, proj, energy);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut s = stack;
+            compute_stack(&db, &mut s, true)
+        }));
+        match outcome {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => failures.push(format!("{proj_str}: {e}")),
+            Err(_) => failures.push(format!("{proj_str}: compute_stack PANICKED")),
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "projectile matrix had failures:\n  - {}",
+        failures.join("\n  - ")
+    );
+}

--- a/core/tests/projectile_matrix.rs
+++ b/core/tests/projectile_matrix.rs
@@ -2,11 +2,14 @@
 //!
 //! Catches the #137 class of bug where a single projectile has the wrong
 //! lookup key (catima dash-strip) and explodes at compute time. The bundled
-//! catima parquet set is C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56.
+//! catima parquet set is C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56 — anything
+//! outside that (e.g. Cl-35) must produce a typed `StoppingError::NoSourceTable`
+//! rather than panicking.
 
 use hyrr_core::compute::compute_stack;
 use hyrr_core::db::ParquetDataStore;
 use hyrr_core::materials::resolve_material;
+use hyrr_core::stopping::StoppingError;
 use hyrr_core::types::*;
 
 /// Resolve the bundled nucl-parquet directory. Honour `HYRR_DATA` first
@@ -40,7 +43,7 @@ fn trivial_cu_stack(db: &ParquetDataStore, projectile: ProjectileType, energy_me
         density_g_cm3: cu.density,
         elements: cu.elements.clone(),
         thickness_cm: None,
-        areal_density_g_cm2: Some(1.0e-4),
+        areal_density_g_cm2: Some(1.0e-4), // ~0.1 µm Cu equivalent
         energy_out_mev: None,
         is_monitor: false,
         computed_energy_in: 0.0,
@@ -100,4 +103,41 @@ fn every_supported_projectile_computes_without_panic() {
         "projectile matrix had failures:\n  - {}",
         failures.join("\n  - ")
     );
+}
+
+#[test]
+#[ignore = "requires bundled nucl-parquet data; run with --include-ignored after submodule init"]
+fn unsupported_heavy_ion_returns_typed_error_not_panic() {
+    let Some(mut db) = make_db("tendl-2025") else {
+        eprintln!("skipping: no nucl-parquet data dir found");
+        return;
+    };
+
+    // Cl-35 is NOT in the bundled catima set (C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56).
+    // It must surface as a typed Err, not a panic.
+    let Some(proj) = ProjectileType::from_str("Cl-35") else {
+        eprintln!("skipping: Cl-35 not parseable in this build");
+        return;
+    };
+    let _ = db.load_xs("Cl-35", 29);
+    let energy = 10.0 * proj.a() as f64;
+    let stack = trivial_cu_stack(&db, proj, energy);
+
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut s = stack;
+        compute_stack(&db, &mut s, true)
+    }));
+    let inner = outcome.expect("compute_stack PANICKED on unsupported projectile — should return typed Err");
+
+    match inner {
+        Err(StoppingError::NoSourceTable { source_name, projectile, .. }) => {
+            assert!(
+                source_name.contains("Cl"),
+                "expected source_name to mention Cl, got {source_name}"
+            );
+            assert_eq!(projectile, "Cl-35");
+        }
+        Err(other) => panic!("expected NoSourceTable, got {other:?}"),
+        Ok(_) => panic!("expected error for unsupported Cl-35, got Ok"),
+    }
 }

--- a/docs/maintainers/TESTING.md
+++ b/docs/maintainers/TESTING.md
@@ -1,0 +1,44 @@
+# Testing
+
+## Projectile matrix smoke test (Tier 1 of #148)
+
+`core/tests/projectile_matrix.rs` loops every supported `ProjectileType`
+through `compute_stack` against a trivial Cu stack. It exists to catch
+the #137 class of bug where one projectile has a bad lookup key and
+silently breaks the per-projectile compute path.
+
+The matrix currently covers: `p`, `d`, `t`, `h`, `a`, `C-12`, `O-16`,
+`Ne-20`, `Si-28`, `Ar-40`, `Fe-56`. A sibling test asserts that an
+unsupported heavy ion (`Cl-35`) returns a typed
+`StoppingError::NoSourceTable` instead of panicking.
+
+### Adding a new projectile
+
+When you add a variant to `ProjectileType` (or extend the bundled
+catima set in `nucl-parquet/data/stopping/`), add a row to the
+`PROJECTILES` constant in `core/tests/projectile_matrix.rs`. The test
+will not auto-discover new variants — that's intentional, the matrix
+is the forcing function for coverage.
+
+### Running locally
+
+The test is `#[ignore]` by default because it needs the bundled
+nucl-parquet data on disk. Run it explicitly:
+
+```bash
+HYRR_DATA=../nucl-parquet/data cargo test \
+    --test projectile_matrix -- --include-ignored
+```
+
+Without `HYRR_DATA`, the test falls back to `../nucl-parquet/data`
+relative to the cargo manifest (the standard sibling-submodule layout).
+If neither path resolves, the test prints a skip message and exits
+green — so a fresh `cargo test` on a checkout without the submodule
+keeps working.
+
+### CI
+
+CI initialises the nucl-parquet submodule with sparse-checkout for
+`data/meta`, `data/stopping`, and `data/tendl-2025/xs`, then runs
+`cargo test --test projectile_matrix -- --include-ignored` from
+`core/`. See `.github/workflows/ci.yml`.


### PR DESCRIPTION
## Summary

- Tier 1 of #148: Rust projectile-matrix smoke test.
- Loops every supported `ProjectileType` (`p`, `d`, `t`, `h`, `a`, `C-12`, `O-16`, `Ne-20`, `Si-28`, `Ar-40`, `Fe-56`) through `compute_stack` against a trivial 0.1-µm-Cu-equivalent foil and asserts no failures.
- Sibling test asserts that an unsupported `Cl-35` returns the typed `StoppingError::NoSourceTable` rather than panicking, locking in the contract from #142.
- Adds a `rust-projectile-matrix` CI job that sparse-checks-out `nucl-parquet/data/{meta,stopping,tendl-2025/xs}` and runs the matrix with `--include-ignored`.
- Adds `docs/maintainers/TESTING.md` documenting the matrix and how to extend it.

Tier 2 (Playwright) and Tier 3 (tauri-driver) remain open in #148.

## Pre-#141 verification

Reproduced locally on this branch by reverting the dash-strip in `core/src/stopping.rs::source_for` (so it formats `catima_C-12` instead of `catima_C12`), then running the matrix:

```
running 1 test

thread 'every_supported_projectile_computes_without_panic' panicked at tests/projectile_matrix.rs:101:5:
projectile matrix had failures:
  - C-12: No catima_C-12 stopping table — projectile C-12 not in bundled set. ...
  - O-16: No catima_O-16 stopping table — projectile O-16 not in bundled set. ...
  - Ne-20: No catima_Ne-20 stopping table — projectile Ne-20 not in bundled set. ...
  - Si-28: No catima_Si-28 stopping table — projectile Si-28 not in bundled set. ...
  - Ar-40: No catima_Ar-40 stopping table — projectile Ar-40 not in bundled set. ...
  - Fe-56: No catima_Fe-56 stopping table — projectile Fe-56 not in bundled set. ...
```

Reverted the revert and the matrix is green again.

## Test plan

- [ ] CI green (new `rust-projectile-matrix` job)
- [ ] Reverting #141's catima dash-strip on a scratch branch makes the matrix fail with all 6 heavy ions (verified locally — see above)
- [ ] Adding a new `ProjectileType` variant without updating `PROJECTILES` in `core/tests/projectile_matrix.rs` is the forcing function for coverage (the test won't auto-discover variants — intentional)

## Constraints honoured

- No production code touched.
- Matrix is `#[ignore]` so default `cargo test` keeps working without the submodule.
- Test runs offline against bundled nucl-parquet.