### PR TITLE
fix(core/#150): residual stopping-power lookups propagate typed Err instead of panic

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -139,13 +139,25 @@ fn compute_layer(
 
     let sp_sources = get_stopping_sources(db, projectile, &composition)?;
 
-    // Validated above via `compute_thickness_from_energy` / `compute_energy_out`,
-    // so the inner `dedx_mev_per_cm` cannot return an error for this layer's
-    // source/target combo. Use the panicking _scalar/_unchecked helper inside
-    // the closure to keep the existing `Fn(&[f64]) -> Vec<f64>` shape.
+    // Validate the FULL energy range the layer's grid will query — both ends.
+    // `compute_energy_out` only checks the entrance energy; if integration
+    // brings residual below the table_min for the chosen catima source, the
+    // downstream `linspace(energy_out.max(0.01), energy_in)` will produce
+    // points below table_min and the closure's `.expect()` would panic mid-
+    // loop. Surfacing here propagates a typed StoppingError::EnergyOutOfRange
+    // to the frontend recovery card. See #150 (panic-class follow-up to #142).
+    let layer_e_low_for_validate = energy_out.max(0.01);
+    dedx_mev_per_cm(
+        db,
+        projectile,
+        &composition,
+        density,
+        &[layer_e_low_for_validate, energy_in],
+    )?;
+
     let dedx_fn = |energies: &[f64]| -> Vec<f64> {
         dedx_mev_per_cm(db, projectile, &composition, density, energies)
-            .expect("dedx_fn: layer-level prevalidation should have caught any miss")
+            .expect("dedx_fn: layer-level prevalidation above guarantees coverage")
     };
     let _ = dedx_mev_per_cm_scalar; // silence unused-import noise on some build configs
 

--- a/core/src/stopping.rs
+++ b/core/src/stopping.rs
@@ -396,8 +396,12 @@ pub fn compute_energy_out(
     let mut energy = energy_in_mev;
 
     for _ in 0..n_points {
-        let loss = dedx_mev_per_cm_scalar(db, projectile, composition, density_g_cm3, energy) * dx;
-        energy -= loss;
+        // Use the Result variant so a mid-loop drop below table_min surfaces
+        // as typed Err(EnergyOutOfRange) instead of panicking via _scalar.
+        // See #150 — without this, heavy-ion stacks that bring residual
+        // energy below the catima table-min crash compute opaquely.
+        let dedx = dedx_mev_per_cm(db, projectile, composition, density_g_cm3, &[energy])?;
+        energy -= dedx[0] * dx;
         if energy <= 0.0 {
             return Ok(0.0);
         }

--- a/core/tests/projectile_matrix.rs
+++ b/core/tests/projectile_matrix.rs
@@ -141,3 +141,59 @@ fn unsupported_heavy_ion_returns_typed_error_not_panic() {
         Ok(_) => panic!("expected error for unsupported Cl-35, got Ok"),
     }
 }
+
+#[test]
+#[ignore = "requires bundled nucl-parquet data; run with --include-ignored after submodule init"]
+fn thick_target_residual_below_table_min_returns_typed_error_not_panic() {
+    // Regression for #150. compute_energy_out used dedx_mev_per_cm_scalar
+    // (panicking) inside its integration loop, and compute_layer's downstream
+    // closure also `.expect()`'d on a layer-grid linspace that could land
+    // below catima table_min. A thick Cu foil with a heavy-ion projectile
+    // brings residual energy below 0.012 MeV (catima_C12 table_min) — must
+    // surface as Err(EnergyOutOfRange), not a panic.
+    let Some(mut db) = make_db("tendl-2025") else {
+        eprintln!("skipping: no nucl-parquet data dir found");
+        return;
+    };
+    let Some(proj) = ProjectileType::from_str("C-12") else {
+        eprintln!("skipping: C-12 not parseable in this build");
+        return;
+    };
+    let _ = db.load_xs("C-12", 29);
+
+    // 100 µm Cu (ρ=8.96 g/cm³ → 0.0896 g/cm² areal) at only 5 MeV is
+    // intentionally too thick — the integration WILL drive residual energy
+    // through the table_min boundary.
+    let cu = resolve_material(&db, "Cu", None);
+    let layer = Layer {
+        density_g_cm3: cu.density,
+        elements: cu.elements.clone(),
+        thickness_cm: Some(100.0e-4),
+        areal_density_g_cm2: None,
+        energy_out_mev: None,
+        is_monitor: false,
+        computed_energy_in: 0.0,
+        computed_energy_out: 0.0,
+        computed_thickness: 0.0,
+    };
+    let mut stack = TargetStack {
+        beam: Beam::new(proj, 5.0, 0.04),
+        layers: vec![layer],
+        irradiation_time_s: 1.0,
+        cooling_time_s: 0.0,
+        area_cm2: 1.0,
+        current_profile: None,
+    };
+
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        compute_stack(&db, &mut stack, true)
+    }));
+    let inner = outcome.expect(
+        "compute_stack PANICKED on residual-below-table_min — must return typed Err (#150)",
+    );
+    match inner {
+        Err(StoppingError::EnergyOutOfRange { .. }) => {} // expected
+        Err(other) => panic!("expected EnergyOutOfRange, got {other:?}"),
+        Ok(_) => panic!("expected EnergyOutOfRange for thick C-12 stack, got Ok"),
+    }
+}


### PR DESCRIPTION
## Summary
Two surviving panic sites bypassed #142's typed-error contract:
- \`stopping.rs::compute_energy_out\` integration loop used the panicking \`_scalar\` variant
- \`compute.rs::dedx_fn\` closure \`.expect()\`'d on a layer grid that could land below \`table_min\` after \`energy_out\` was computed

Both fixed with \`?\`-propagation; closure-side prevalidation now covers the full layer grid range, not just source/target existence.

Discovered during agent landing of #149 (Tier 1 projectile matrix) — see issue #150 for the full diagnosis.

## Test plan
- [ ] CI green (lint + test 3.12 + supplier-catalog + rust-projectile-matrix + build)
- [ ] New regression: \`thick_target_residual_below_table_min_returns_typed_error_not_panic\` (100 µm Cu + C-12 @ 5 MeV) returns \`Err(EnergyOutOfRange)\` not panic
- [ ] Existing matrix still passes (no regression on supported projectiles)
- [ ] Manual: load /hyrr/ with a heavy-ion thick-stack config, see the recovery card render with the EnergyOutOfRange variant + actionable info, instead of a silent stale table

Closes #150