### PR TITLE
fix(core/122): reject non-regular tar entries during extract

### DIFF
--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -789,6 +789,86 @@ mod tests {
         assert!(!is_cache_complete());
     }
 
+    /// Build a tarball at `out` containing one regular file and one
+    /// symlink entry (`data/meta/evil` -> `/etc/passwd`). Used to
+    /// verify that `extract_tarball` refuses to materialise the
+    /// symlink rather than silently honouring it. See #122.
+    fn make_symlink_tarball(out: &Path) {
+        let file = fs::File::create(out).unwrap();
+        let encoder = zstd::stream::Encoder::new(file, 0).unwrap().auto_finish();
+        let mut tar = tar::Builder::new(encoder);
+
+        // One regular file so the archive isn't degenerate.
+        let mut h1 = tar::Header::new_gnu();
+        let payload = b"ok";
+        h1.set_size(payload.len() as u64);
+        h1.set_mode(0o644);
+        h1.set_cksum();
+        tar.append_data(&mut h1, "data/meta/marker", payload.as_slice())
+            .unwrap();
+
+        // The hostile symlink: data/meta/evil -> /etc/passwd
+        let mut h2 = tar::Header::new_gnu();
+        h2.set_size(0);
+        h2.set_mode(0o644);
+        h2.set_entry_type(tar::EntryType::Symlink);
+        h2.set_link_name("/etc/passwd").unwrap();
+        h2.set_cksum();
+        tar.append_data(&mut h2, "data/meta/evil", std::io::empty())
+            .unwrap();
+
+        tar.finish().unwrap();
+    }
+
+    /// `extract_tarball` must refuse symlink entries — a malicious
+    /// upstream could otherwise smuggle `data/meta/foo -> /etc/passwd`
+    /// into the cache. See #122.
+    #[test]
+    fn extract_tarball_rejects_symlink_entries() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("hostile.tar.zst");
+        make_symlink_tarball(&archive);
+
+        let dest = td.path().join("dest");
+        let err = extract_tarball(&archive, &dest, &[]).unwrap_err();
+        match err {
+            FetchError::UnsafeTarballEntry { kind, path } => {
+                assert!(
+                    kind.contains("Symlink"),
+                    "expected kind to mention Symlink, got {kind:?}"
+                );
+                assert_eq!(path, PathBuf::from("data/meta/evil"));
+            }
+            other => panic!("expected UnsafeTarballEntry, got {other:?}"),
+        }
+        // The symlink must NOT have been materialised.
+        assert!(!dest.join("data/meta/evil").exists());
+        assert!(!dest.join("data/meta/evil").is_symlink());
+    }
+
+    /// Regression: a vanilla tarball (regular files + directories
+    /// only) must still extract cleanly through the new entry-type
+    /// filter. The existing `install_from_tarball_writes_sentinel_last`
+    /// test covers the install path; this one exercises
+    /// `extract_tarball` directly so a future refactor that pulls
+    /// the type-check up the call chain stays honest.
+    #[test]
+    fn extract_tarball_accepts_regular_files() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("ok.tar.zst");
+        make_test_tarball(&archive);
+
+        let dest = td.path().join("dest");
+        extract_tarball(&archive, &dest, &[]).unwrap();
+        assert_eq!(
+            fs::read(dest.join("data/meta/marker")).unwrap(),
+            b"test-marker"
+        );
+        assert!(dest.join("data/tendl-test/xs/p_Cu.parquet").exists());
+    }
+
     /// Stale partial dirs (left by SIGKILL'd previous runs) must be
     /// swept by `install_tarball_atomic`. Without the sweep these
     /// accumulate at ~400 MB per crash forever.

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -54,6 +54,14 @@ pub enum FetchError {
     Decompress(String),
     #[error("tar extraction error: {0}")]
     Extract(String),
+    /// Tarball entry was not a regular file or directory. We refuse
+    /// symlinks, hardlinks, char/block/fifo devices, GNU sparse, etc.
+    /// to avoid materialising read-side surprises (e.g. a malicious
+    /// `data/meta/foo -> /etc/passwd` symlink) inside the cache. See
+    /// #122. If a real upstream change ever trips this, that's a bug
+    /// to investigate at the source — not something to silently skip.
+    #[error("unsafe tarball entry {kind} at {path}")]
+    UnsafeTarballEntry { kind: String, path: PathBuf },
     #[error("HOME environment variable not set")]
     NoHome,
 }
@@ -240,6 +248,22 @@ pub fn extract_tarball(
             if !matches {
                 continue;
             }
+        }
+
+        // Refuse anything that isn't a plain file or directory. Symlinks,
+        // hardlinks, char/block/fifo devices, GNU sparse, etc. have no
+        // legitimate place in our data cache: a malicious upstream could
+        // smuggle in `data/meta/foo -> /etc/passwd` and any later code
+        // that follows symlinks would read out-of-cache content. We
+        // surface this loudly via `FetchError::UnsafeTarballEntry`
+        // rather than silently skipping — if a real-world tarball ever
+        // trips this it's worth investigating upstream. See #122.
+        let etype = entry.header().entry_type();
+        if !(etype.is_file() || etype.is_dir()) {
+            return Err(FetchError::UnsafeTarballEntry {
+                kind: format!("{etype:?}"),
+                path,
+            });
         }
 
         entry


### PR DESCRIPTION
## Summary

`core::data_fetch::extract_tarball` previously called `entry.unpack_in(dest)` for every entry returned by `tar::Archive::entries()`, which honoured symlink and hardlink headers verbatim. A malicious or buggy upstream tarball with `data/meta/foo -> /etc/passwd` would land that symlink in the cache; `unpack_in`'s built-in `..` traversal check still applied, but any later loader that follows symlinks could read out-of-cache content.

After this PR, `extract_tarball` inspects each entry's `EntryType` and refuses anything that isn't a plain file or directory. We surface the rejection as a typed error rather than silently skipping, so a real upstream change is loud — if a future tarball legitimately needs symlinks, that's worth a separate issue, not a quiet bypass.

## Rejected entry types

Anything outside `Regular` and `Directory`:

- `Symlink`
- `Link` (hardlink)
- `Char` (character device)
- `Block` (block device)
- `Fifo`
- `Continuous`
- `GNUSparse`
- `GNULongName`, `GNULongLink`, `XHeader`, `XGlobalHeader` (these are normally folded into the next entry by the tar crate; the guard catches them if anything ever surfaces one as a standalone entry)
- any future variant added to `tar::EntryType` (the check is a positive allowlist)

## New error variant

```rust
#[error("unsafe tarball entry {kind} at {path}")]
UnsafeTarballEntry { kind: String, path: PathBuf },
```

`kind` is the `Debug`-formatted `EntryType` (e.g. `"Symlink"`, `"Link"`, `"Fifo"`); `path` is the offending entry path inside the archive. Mirrors the existing `thiserror`-driven `FetchError` style.

## Test approach

Two unit tests, both built programmatically with `tar::Builder` — no binary fixtures.

- `extract_tarball_rejects_symlink_entries`: synthesises a `.tar.zst` containing a regular file plus `data/meta/evil -> /etc/passwd` (header set via `EntryType::Symlink` + `set_link_name`). Asserts `extract_tarball` returns `Err(FetchError::UnsafeTarballEntry { kind: "Symlink", path: "data/meta/evil" })` and that the symlink is not materialised on disk.
- `extract_tarball_accepts_regular_files`: regression guard — drives a vanilla regular-file tarball through the new filter and verifies contents land at the expected paths. Catches a future refactor that pulls the type-check up the call chain and breaks the happy path.

## Audit

Grepped `core/` for `tar::Archive` and `unpack`. Only `extract_tarball` matters for inbound tarballs; `export_offline_bundle` uses `tar::Builder` (outbound) and is unaffected.

## Test plan

- [x] `cargo test -p hyrr-core data_fetch -- --test-threads=1` — 11/11 passing (9 existing + 2 new)
- [x] `cargo test --test projectile_matrix -- --include-ignored` — 3/3 passing
- [ ] CI runs full suite green
- [ ] Manual probe: confirm `hyrr fetch-data` against the live release tarball still extracts cleanly (no regression on real-world archive)

Closes #122