### PR TITLE
feat(core+cli/121): hyrr fetch-data --gc to prune old cache versions

### DIFF
--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -555,6 +555,98 @@ pub fn install_from_tarball(archive: &Path) -> Result<()> {
     install_tarball_atomic(archive, &["data"])
 }
 
+/// Parse a `v{N}.{N}.{N}` directory name into a sortable tuple. Returns
+/// `None` for anything that doesn't match — the directory is treated as
+/// not-a-version-cache and left alone.
+///
+/// We roll our own rather than pull in `semver` because the cache layout
+/// only ever produces strict 3-part numeric versions (the data tarballs
+/// are pinned to nucl-parquet's pyproject version, which is a 3-tuple).
+fn parse_version_dir(name: &str) -> Option<(u64, u64, u64)> {
+    let s = name.strip_prefix('v')?;
+    let mut parts = s.split('.');
+    let major = parts.next()?.parse::<u64>().ok()?;
+    let minor = parts.next()?.parse::<u64>().ok()?;
+    let patch = parts.next()?.parse::<u64>().ok()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    Some((major, minor, patch))
+}
+
+/// Prune older `v{N.N.N}/` cache directories, keeping only the `keep`
+/// most recent (by semver order) plus the current `DATA_VERSION` dir.
+///
+/// Returns the number of directories removed. Idempotent: a second call
+/// with the same `keep` returns `0`.
+///
+/// The cache lock is held for the whole sweep so a concurrent
+/// `ensure_library` cannot promote a partial dir we're about to delete,
+/// and we cannot delete a sibling that another process is mid-extracting.
+///
+/// `v{V}.partial-*` partial dirs and any non-version entries (`.lock`,
+/// `.tmp` tarballs, the user's stray notes) are ignored.
+pub fn prune_old_versions(keep: usize) -> Result<usize> {
+    let _lock = acquire_lock()?;
+    let root = cache_root()?;
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    let current = parse_version_dir(&format!("v{DATA_VERSION}"));
+
+    let mut versioned: Vec<(PathBuf, (u64, u64, u64))> = Vec::new();
+    for entry in fs::read_dir(&root)? {
+        let entry = entry?;
+        // Don't follow symlinks — a chmod / move accident could otherwise
+        // wipe data outside the cache.
+        let ft = entry.file_type()?;
+        if !ft.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if let Some(ver) = parse_version_dir(&name_str) {
+            versioned.push((entry.path(), ver));
+        }
+    }
+
+    // Newest first.
+    versioned.sort_by(|a, b| b.1.cmp(&a.1));
+
+    // Keep set = {current} ∪ {`keep` most recent versions not equal to current}.
+    // The current pin is always preserved (the user might be mid-fetch);
+    // `keep` controls how many historical siblings to preserve on top of
+    // that. So `keep=2` with current=v0.10.0 and siblings v0.0.1..v0.0.5
+    // preserves {v0.10.0, v0.0.5, v0.0.4} = 3 dirs.
+    let mut kept: std::collections::HashSet<(u64, u64, u64)> =
+        std::collections::HashSet::new();
+    if let Some(c) = current {
+        kept.insert(c);
+    }
+    let mut historical_taken = 0usize;
+    for (_, ver) in &versioned {
+        if historical_taken == keep {
+            break;
+        }
+        if Some(*ver) == current {
+            continue;
+        }
+        kept.insert(*ver);
+        historical_taken += 1;
+    }
+
+    let mut removed = 0usize;
+    for (path, ver) in &versioned {
+        if kept.contains(ver) {
+            continue;
+        }
+        fs::remove_dir_all(path)?;
+        removed += 1;
+    }
+    Ok(removed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -788,5 +880,105 @@ mod tests {
 
         assert!(!stale.exists(), "stale partial-99999 was not swept");
         assert!(is_cache_complete());
+    }
+
+    /// Plant `v0.1.0..v0.5.0` directories with `.complete` sentinels.
+    /// `prune_old_versions(2)` keeps the 2 newest plus the current
+    /// DATA_VERSION pin. Idempotency: a second call returns 0. A keep
+    /// value larger than the population removes nothing.
+    fn plant_version_dirs(root: &Path, versions: &[&str]) {
+        for v in versions {
+            let dir = root.join(format!("v{v}"));
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join(".complete"), v).unwrap();
+        }
+    }
+
+    #[test]
+    fn prune_keeps_newest_n_plus_current() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let root = cache_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+
+        // Plant 5 ancient versions all guaranteed strictly older than
+        // any plausible DATA_VERSION. This keeps the test invariant
+        // independent of the actual current pin.
+        let planted = ["0.0.1", "0.0.2", "0.0.3", "0.0.4", "0.0.5"];
+        plant_version_dirs(&root, &planted);
+        // Plant the current DATA_VERSION dir too.
+        plant_version_dirs(&root, &[DATA_VERSION]);
+
+        let removed = prune_old_versions(2).unwrap();
+
+        // Expected: keep v0.0.5, v0.0.4 (newest 2 of the planted set;
+        // DATA_VERSION sorts newer than all of them and is also kept by
+        // the current-pin rule). 5 planted + 1 current = 6 dirs total,
+        // minus 3 kept = 3 removed.
+        assert_eq!(removed, 3);
+        assert!(root.join("v0.0.5").exists());
+        assert!(root.join("v0.0.4").exists());
+        assert!(root.join(format!("v{DATA_VERSION}")).exists());
+        assert!(!root.join("v0.0.1").exists());
+        assert!(!root.join("v0.0.2").exists());
+        assert!(!root.join("v0.0.3").exists());
+
+        // Idempotency.
+        let removed2 = prune_old_versions(2).unwrap();
+        assert_eq!(removed2, 0);
+    }
+
+    #[test]
+    fn prune_with_large_keep_removes_nothing() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let root = cache_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+        plant_version_dirs(&root, &["0.1.0", "0.2.0", "0.3.0"]);
+
+        let removed = prune_old_versions(10).unwrap();
+        assert_eq!(removed, 0);
+        for v in &["0.1.0", "0.2.0", "0.3.0"] {
+            assert!(root.join(format!("v{v}")).exists());
+        }
+    }
+
+    /// Non-version directories (e.g. `data/`, `notes/`) and stray files
+    /// are left untouched by prune.
+    #[test]
+    fn prune_ignores_non_version_entries() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let root = cache_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+        plant_version_dirs(&root, &["0.1.0", "0.2.0"]);
+        fs::create_dir_all(root.join("not-a-version")).unwrap();
+        fs::create_dir_all(root.join(format!("v{DATA_VERSION}.partial-1234"))).unwrap();
+        fs::write(root.join(".lock"), b"").unwrap();
+
+        let _ = prune_old_versions(0).unwrap();
+        assert!(root.join("not-a-version").exists());
+        assert!(
+            root.join(format!("v{DATA_VERSION}.partial-1234")).exists(),
+            "partial dirs are install_tarball_atomic's responsibility, not prune's"
+        );
+        assert!(root.join(".lock").exists());
+    }
+
+    /// `prune_old_versions` must acquire the cache lock; verify it doesn't
+    /// deadlock against itself when called sequentially in the same test.
+    #[test]
+    fn prune_is_lock_safe_when_called_sequentially() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+        let root = cache_root().unwrap();
+        fs::create_dir_all(&root).unwrap();
+        plant_version_dirs(&root, &["0.1.0", "0.2.0", "0.3.0", "0.4.0"]);
+
+        // Two sequential calls — the lock guard from the first call must
+        // be dropped before the second acquires.
+        let _ = prune_old_versions(1).unwrap();
+        let removed = prune_old_versions(1).unwrap();
+        assert_eq!(removed, 0);
     }
 }

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -304,6 +304,16 @@ fn py_data_version() -> &'static str {
     data_fetch::DATA_VERSION
 }
 
+/// Prune old `v{N.N.N}/` cache siblings, keeping only the current
+/// `DATA_VERSION` plus the `keep` most-recent historical versions.
+/// Returns the number of directories removed.
+#[pyfunction]
+#[pyo3(signature = (keep=2))]
+fn py_prune_old_versions(keep: usize) -> PyResult<usize> {
+    data_fetch::prune_old_versions(keep)
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))
+}
+
 // ---------------------------------------------------------------------------
 // Internal types for JSON deserialization
 // ---------------------------------------------------------------------------
@@ -376,5 +386,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_cache_data_dir, m)?)?;
     m.add_function(wrap_pyfunction!(py_cache_is_complete, m)?)?;
     m.add_function(wrap_pyfunction!(py_data_version, m)?)?;
+    m.add_function(wrap_pyfunction!(py_prune_old_versions, m)?)?;
     Ok(())
 }

--- a/src/hyrr/cli.py
+++ b/src/hyrr/cli.py
@@ -102,6 +102,22 @@ def main(argv: list[str] | None = None) -> int:
         metavar="PATH",
         help="Install from a local .tar.zst (use after --offline-bundle on a connected machine)",
     )
+    fd_group.add_argument(
+        "--gc",
+        action="store_true",
+        help=(
+            "Garbage-collect older v{V}/ siblings in the cache. Keeps the current "
+            "DATA_VERSION + the N most recent historical versions (default N=2; "
+            "override with --keep). Opt-in only — never runs automatically."
+        ),
+    )
+    fd_parser.add_argument(
+        "--keep",
+        type=int,
+        default=2,
+        metavar="N",
+        help="With --gc: number of historical versions to retain (default: 2)",
+    )
 
     # hyrr download-data — deprecated alias retained for legacy docs
     dl_parser = subparsers.add_parser(
@@ -521,6 +537,15 @@ def _cmd_fetch_data(args: argparse.Namespace) -> int:
         return 1
 
     try:
+        if getattr(args, "gc", False):
+            keep = max(0, int(getattr(args, "keep", 2)))
+            removed = _native.py_prune_old_versions(keep)
+            print(
+                f"Pruned {removed} old cache version(s) "
+                f"(kept current v{_native.py_data_version()} + up to {keep} historical)."
+            )
+            return 0
+
         if args.from_tarball is not None:
             print(f"Installing from {args.from_tarball} ...")
             _native.py_fetch_data(from_tarball=str(args.from_tarball))
@@ -576,6 +601,8 @@ def _cmd_download_data(args: argparse.Namespace) -> int:
         library=None,
         offline_bundle=None,
         from_tarball=None,
+        gc=False,
+        keep=2,
     )
     return _cmd_fetch_data(new_args)
 


### PR DESCRIPTION
## Summary

- Add `prune_old_versions(keep: usize) -> Result<usize>` in `core/src/data_fetch.rs`. Walks `cache_root()` under the cache lock, parses each `v{N.N.N}/` sibling, keeps the current `DATA_VERSION` plus the `keep` most-recent historical versions, removes the rest. Idempotent; non-version entries (`.lock`, partial dirs, stray files) and symlinks are left untouched.
- Surface as `hyrr fetch-data --gc [--keep N]` via a new `py_prune_old_versions` PyO3 binding. `--gc` is mutually exclusive with the existing fetch operations (`--library`, `--all`, `--offline-bundle`, `--from`); `--keep` defaults to **2**.
- Opt-in only — never runs automatically. Closes #121.

## API

```rust
pub fn prune_old_versions(keep: usize) -> Result<usize>
```

CLI surface (Python):

```
hyrr fetch-data --gc            # keep current + 2 newest historical (default)
hyrr fetch-data --gc --keep 0   # nuke every sibling, keep only current
hyrr fetch-data --gc --keep 5   # generous retention
```

## Test plan

- [x] `cargo test -p hyrr-core data_fetch` — 14 passed (4 new GC tests + the 10 pre-existing fetch tests)
- [x] `cargo test --test projectile_matrix -- --include-ignored` — 3 passed
- [x] `cd frontend && npm run check` — 0 errors / 0 warnings
- [x] `cd frontend && npm test` — 446 passed
- [x] CLI `--help` renders the new flags