### PR TITLE
refactor: data-fetch SSoT for #118 recovery card

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set data/meta data/stopping data/tendl-2024/xs
+          git sparse-checkout set data/meta data/stopping data/tendl-2025/xs
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,26 @@ jobs:
           HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
         run: cargo test --test projectile_matrix -- --include-ignored
 
+  data-fetch-ssot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Assert docs do not pin a concrete data tarball version
+        run: |
+          # SSoT: tarball filename pattern lives in core/src/data_fetch.rs.
+          # Concrete `vN.N.N` URLs in markdown drift silently when the
+          # submodule version bumps. Use placeholder `<V>` instead.
+          if grep -RnE 'nucl-parquet-data-v[0-9]+\.[0-9]+\.[0-9]+\.tar\.zst' docs/; then
+            echo "::error::docs hardcodes a concrete data-tarball version. Use <V> placeholder; SSoT is hyrr_core::data_fetch::release_url()."
+            exit 1
+          fi
+      - name: Assert RELEASE_BASE host appears verbatim in data_fetch.rs
+        run: |
+          grep -q '"https://github.com/exoma-ch/nucl-parquet/releases/download"' core/src/data_fetch.rs || {
+            echo "::error::RELEASE_BASE literal in core/src/data_fetch.rs has drifted; CI/docs assertions need updating in lockstep."
+            exit 1
+          }
+
   supplier-catalog-freshness:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set data/meta data/stopping data/tendl-2024/xs
+          git sparse-checkout set data/meta data/stopping data/tendl-2025/xs
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set data/meta data/stopping data/tendl-2024/xs
+          git sparse-checkout set data/meta data/stopping data/tendl-2025/xs
 
       - name: Copy parquet data to frontend public dir
         shell: bash

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -39,7 +39,60 @@ use fs2::FileExt;
 pub const DATA_VERSION: &str = env!("HYRR_DATA_VERSION");
 
 /// GitHub Releases base URL for nucl-parquet data tarballs.
-const RELEASE_BASE: &str = "https://github.com/exoma-ch/nucl-parquet/releases/download";
+///
+/// This is the SSoT for the release host. All other call sites (Tauri
+/// commands, frontend, docs) MUST flow through [`release_base_url`] /
+/// [`release_url`] / [`release_url_for`] rather than re-spelling the
+/// string.
+pub const RELEASE_BASE: &str = "https://github.com/exoma-ch/nucl-parquet/releases/download";
+
+/// Canonical GitHub-Releases base URL. Prefer this over the `RELEASE_BASE`
+/// const when crossing a module/crate/FFI boundary — it pins downstream
+/// callers on a function rather than on the literal.
+pub fn release_base_url() -> &'static str {
+    RELEASE_BASE
+}
+
+/// Canonical [`DATA_VERSION`] accessor. Same SSoT motivation as
+/// [`release_base_url`] — function-shaped so non-Rust callers (Tauri,
+/// pyo3, MCP) can re-export without reaching into a `pub const`.
+pub fn data_version() -> &'static str {
+    DATA_VERSION
+}
+
+/// Tarball filename for the current [`DATA_VERSION`], e.g.
+/// `nucl-parquet-data-v0.10.0.tar.zst`. Single source of truth for the
+/// pattern — `ensure_*` and the install path consume this.
+pub fn tarball_filename() -> String {
+    tarball_filename_for(DATA_VERSION)
+}
+
+/// Tarball filename for an arbitrary version. Exposed for offline-bundle
+/// docs/tooling that need to spell a non-current version.
+pub fn tarball_filename_for(version: &str) -> String {
+    format!("nucl-parquet-data-v{version}.tar.zst")
+}
+
+/// Full release-tarball URL for the current [`DATA_VERSION`].
+pub fn release_url() -> String {
+    release_url_for(DATA_VERSION)
+}
+
+/// Full release-tarball URL for an arbitrary version.
+pub fn release_url_for(version: &str) -> String {
+    format!(
+        "{RELEASE_BASE}/v{version}/{filename}",
+        filename = tarball_filename_for(version),
+    )
+}
+
+/// Human-readable cache-root pattern for diagnostics / UX, e.g.
+/// `~/.hyrr/nucl-parquet/v0.10.0/data`. The literal returned here is
+/// always interpolated against the live [`DATA_VERSION`]; callers that
+/// need an actual filesystem path should use [`cache_dir`] instead.
+pub fn cache_root_pattern() -> String {
+    format!("~/.hyrr/nucl-parquet/v{DATA_VERSION}/data")
+}
 
 /// Errors surfaced by the data-fetch path.
 #[derive(Debug, thiserror::Error)]
@@ -137,9 +190,7 @@ impl Drop for TmpFileGuard {
 ///
 /// Streams the response to disk — does not buffer the full ~400 MB in RAM.
 pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
-    let url = format!(
-        "{RELEASE_BASE}/v{DATA_VERSION}/nucl-parquet-data-v{DATA_VERSION}.tar.zst"
-    );
+    let url = release_url();
     let client = build_http_client().map_err(|e| FetchError::Network(e.to_string()))?;
     let resp = client
         .get(&url)
@@ -369,7 +420,7 @@ pub fn ensure_meta_stopping() -> Result<()> {
         return Ok(());
     }
     require_free_space(1024 * 1024 * 1024)?;
-    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     install_tarball_atomic(&tmp, MANDATORY_PREFIXES)?;
@@ -396,7 +447,7 @@ pub fn ensure_library(library: &str) -> Result<()> {
         return Ok(());
     }
     require_free_space(1024 * 1024 * 1024)?;
-    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     let lib_prefix = format!("data/{library}/");
@@ -417,7 +468,7 @@ pub fn ensure_library(library: &str) -> Result<()> {
 pub fn ensure_all() -> Result<()> {
     let _lock = acquire_lock()?;
     require_free_space(1024 * 1024 * 1024)?;
-    let tmp = cache_root()?.join(format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst"));
+    let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
     fetch_full_tarball_to(&tmp)?;
     install_tarball_atomic(&tmp, &[])?;

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -658,6 +658,32 @@ mod tests {
     /// fallback `"0.0.0-unknown"` ships, which would silently 404 on
     /// every fetch. Catch that in CI by asserting the version parses
     /// as N.N.N. The fallback `0.0.0-unknown` fails the dot-count check.
+    /// SSoT pattern for the release URL. Pins the host/path shape so a
+    /// silent string-edit elsewhere in the tree gets caught here. Don't
+    /// remove without also updating the `data-fetch-meta.ts` consumer
+    /// and any docs/CI that grep for the URL.
+    #[test]
+    fn release_url_pattern_is_canonical() {
+        let url = release_url();
+        assert!(
+            url.starts_with("https://github.com/exoma-ch/nucl-parquet/releases/download/v"),
+            "release_url() = {url:?} drifted from the canonical host/path"
+        );
+        assert!(
+            url.ends_with(".tar.zst"),
+            "release_url() = {url:?} should end with .tar.zst"
+        );
+        let fname = tarball_filename();
+        assert!(
+            fname.starts_with("nucl-parquet-data-v") && fname.ends_with(".tar.zst"),
+            "tarball_filename() = {fname:?} drifted"
+        );
+        assert!(
+            url.ends_with(&fname),
+            "release_url() = {url:?} does not end in tarball_filename() = {fname:?}"
+        );
+    }
+
     #[test]
     fn data_version_is_resolved_from_submodule() {
         assert_ne!(DATA_VERSION, "0.0.0-unknown",

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -229,6 +229,36 @@ pub fn ensure_data(library: String) -> Result<String, String> {
     Ok(cache.join("data").to_string_lossy().to_string())
 }
 
+/// SSoT accessors for the data-fetch path. Each command is a thin
+/// passthrough to `hyrr_core::data_fetch` — the frontend MUST consume
+/// these rather than hardcoding any of the constants below.
+///
+/// See `frontend/src/lib/compute/data-fetch-meta.ts` for the TS wrapper.
+#[tauri::command]
+pub fn data_release_url() -> String {
+    hyrr_core::data_fetch::release_url()
+}
+
+#[tauri::command]
+pub fn data_release_base_url() -> &'static str {
+    hyrr_core::data_fetch::release_base_url()
+}
+
+#[tauri::command]
+pub fn data_version() -> &'static str {
+    hyrr_core::data_fetch::data_version()
+}
+
+#[tauri::command]
+pub fn data_tarball_filename() -> String {
+    hyrr_core::data_fetch::tarball_filename()
+}
+
+#[tauri::command]
+pub fn data_cache_root_pattern() -> String {
+    hyrr_core::data_fetch::cache_root_pattern()
+}
+
 /// True when the auto-updater plugin is wired into this build of the app —
 /// i.e. when the frontend should attempt the post-startup version check.
 /// Mirrors the gating in `main.rs::updater_enabled`. The frontend uses this

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -54,6 +54,11 @@ fn main() {
             commands::compute_depth_preview,
             commands::ensure_data,
             commands::data_ready,
+            commands::data_release_url,
+            commands::data_release_base_url,
+            commands::data_version,
+            commands::data_tarball_filename,
+            commands::data_cache_root_pattern,
             commands::updater_enabled,
         ])
         .run(tauri::generate_context!())

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -73,12 +73,12 @@ For machines without internet (Faraday-cage labs, isolated networks):
    hyrr fetch-data --from hyrr-data.tar.zst
    ```
 
-Both machines must run matching `hyrr` versions for the bundle to apply cleanly — the cache is version-pinned, so a v0.9 bundle won't be picked up by a v0.10 install. Alternatively, drop the upstream GitHub Releases tarball directly:
+Both machines must run matching `hyrr` versions for the bundle to apply cleanly — the cache is version-pinned, so a v0.9 bundle won't be picked up by a v0.10 install. Alternatively, drop the upstream GitHub Releases tarball directly. The release URL pattern — host, path layout, tarball filename — is defined by `hyrr_core::data_fetch::release_url()` / `tarball_filename()`. Read your installed version from Python with `python -c "import hyrr._native as n; print(n.py_data_version())"` and substitute it for `<V>` below:
 
 ```bash
-# On a connected machine
-curl -LO https://github.com/exoma-ch/nucl-parquet/releases/download/v0.9.0/nucl-parquet-data-v0.9.0.tar.zst
+# On a connected machine — substitute <V> with the version printed above
+curl -LO "https://github.com/exoma-ch/nucl-parquet/releases/download/v<V>/nucl-parquet-data-v<V>.tar.zst"
 
 # On the air-gapped machine
-hyrr fetch-data --from nucl-parquet-data-v0.9.0.tar.zst
+hyrr fetch-data --from "nucl-parquet-data-v<V>.tar.zst"
 ```

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -9,6 +9,7 @@
  */
 
 import { isTauri } from "../utils/platform";
+import { DEFAULT_LIBRARY } from "./data-fetch-meta";
 import type { SimulationConfig, SimulationResult } from "@hyrr/compute";
 import type { DepthPreviewLayer } from "../stores/depth-preview.svelte";
 
@@ -47,7 +48,7 @@ export async function initBackend(
   if (isTauri()) {
     try {
       const { invoke } = await import("@tauri-apps/api/core");
-      const lib = library ?? "tendl-2025";
+      const lib = library ?? DEFAULT_LIBRARY;
 
       // #52: cache check before init. `data_ready` is cheap (file-existence
       // only), so we pay nothing on the returning-user path. When the cache
@@ -82,7 +83,7 @@ export async function initBackend(
     if (typeof wasm.default === "function") {
       await wasm.default();
     }
-    wasmStore = new wasm.WasmDataStore(library ?? "tendl-2025");
+    wasmStore = new wasm.WasmDataStore(library ?? DEFAULT_LIBRARY);
 
     // Feed data from existing TS DataStore (hyparquet)
     onProgress?.("Loading nuclear data for WASM...", 0.3);

--- a/frontend/src/lib/compute/data-fetch-meta.ts
+++ b/frontend/src/lib/compute/data-fetch-meta.ts
@@ -1,0 +1,83 @@
+/**
+ * Data-fetch metadata SSoT for the frontend.
+ *
+ * The Rust core (`core/src/data_fetch.rs`) is the single source of truth for
+ * the GitHub-Releases URL, DATA_VERSION, cache layout, and tarball filename
+ * pattern. The Tauri command surface re-exports each as a `data_*` command
+ * (see `desktop/src-tauri/src/commands.rs`); this module is the thin TS
+ * wrapper the rest of the frontend should import.
+ *
+ * Browser-mode fallback: the GH-Releases tarball is a desktop-only delivery
+ * mechanism — the deployed browser bundle ships its parquet files as static
+ * assets under `/data/parquet/`, so `getReleaseUrl()` etc. return `null`
+ * there. UI that surfaces these (e.g. the #118 recovery card) is desktop-
+ * only and should branch on `isTauri()` before calling.
+ *
+ * Values are cached in-memory after the first roundtrip; the Rust constants
+ * cannot change at runtime so this is safe.
+ */
+
+import { isTauri } from "../utils/platform";
+
+interface DataFetchMeta {
+  releaseUrl: string;
+  releaseBaseUrl: string;
+  dataVersion: string;
+  tarballFilename: string;
+  cacheRootPattern: string;
+}
+
+let cached: DataFetchMeta | null = null;
+let inflight: Promise<DataFetchMeta | null> | null = null;
+
+async function loadMeta(): Promise<DataFetchMeta | null> {
+  if (cached) return cached;
+  if (!isTauri()) return null;
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const [releaseUrl, releaseBaseUrl, dataVersion, tarballFilename, cacheRootPattern] =
+      await Promise.all([
+        invoke<string>("data_release_url"),
+        invoke<string>("data_release_base_url"),
+        invoke<string>("data_version"),
+        invoke<string>("data_tarball_filename"),
+        invoke<string>("data_cache_root_pattern"),
+      ]);
+    cached = { releaseUrl, releaseBaseUrl, dataVersion, tarballFilename, cacheRootPattern };
+    return cached;
+  })();
+
+  try {
+    return await inflight;
+  } finally {
+    inflight = null;
+  }
+}
+
+export async function getReleaseUrl(): Promise<string | null> {
+  return (await loadMeta())?.releaseUrl ?? null;
+}
+
+export async function getReleaseBaseUrl(): Promise<string | null> {
+  return (await loadMeta())?.releaseBaseUrl ?? null;
+}
+
+export async function getDataVersion(): Promise<string | null> {
+  return (await loadMeta())?.dataVersion ?? null;
+}
+
+export async function getTarballFilename(): Promise<string | null> {
+  return (await loadMeta())?.tarballFilename ?? null;
+}
+
+export async function getCacheRootPattern(): Promise<string | null> {
+  return (await loadMeta())?.cacheRootPattern ?? null;
+}
+
+/** Default nuclear-data library identifier. Mirrors
+ * `hyrr_core::mcp::transport::DEFAULT_LIBRARY`. Kept as a literal here so
+ * non-Tauri (browser, Node) callers get a synchronous answer; if it ever
+ * needs to vary, route through a `data_default_library` command. */
+export const DEFAULT_LIBRARY = "tendl-2025";

--- a/packages/compute/src/node-data-store.ts
+++ b/packages/compute/src/node-data-store.ts
@@ -65,6 +65,8 @@ async function readParquetFile(filePath: string): Promise<ParquetRow[]> {
  * Priority: explicit arg > HYRR_DATA env > ../nucl-parquet sibling > ~/.hyrr/nucl-parquet
  */
 export function resolveDataDir(dataDir?: string, library?: string): string {
+  // Mirrors `hyrr_core::mcp::transport::DEFAULT_LIBRARY`. Kept as a literal
+  // here because this package has no runtime path back to the Rust core.
   const lib = library ?? process.env.HYRR_LIBRARY ?? "tendl-2025";
 
   if (dataDir) {


### PR DESCRIPTION
## Summary

Closes the SSoT door before #118 (Tauri splash recovery card) lands, so the new code references canonical entry points instead of duplicating release URL / DATA_VERSION / cache-path / tarball-filename strings.

## Audit (Step 1)

| Concept | Canonical site | Drift fixed | Prose left as-is |
|---|---|---|---|
| Release-URL host | `core/src/data_fetch.rs:47` `RELEASE_BASE` (now `pub`) | docs example (was pinned to v0.9.0); CI assertion added | repo-URL prose in `transport.rs`, `installation.md` (link, not download) |
| `DATA_VERSION` | `core/src/data_fetch.rs:39` (build.rs from `nucl-parquet/pyproject.toml`) | `data_version()` accessor + Tauri command + `getDataVersion()` | — |
| Cache root layout | `core/src/data_fetch.rs::cache_dir` | `cache_root_pattern()` accessor + Tauri command | help-text prose in CLI / MCP error msgs |
| Tarball filename | `core/src/data_fetch.rs::tarball_filename` (new) | inline `format!` deduplicated; 4 sites → 1 helper | — |
| `MANDATORY_PREFIXES` | `core/src/data_fetch.rs:401-407` | already SSoT; not touched | — |
| Default library | `core/src/mcp/transport.rs:71` `DEFAULT_LIBRARY` | `frontend` `DEFAULT_LIBRARY` const + `backend.ts` import; CI workflows still pulling `tendl-2024/xs` aligned to `tendl-2025` | scripts/notebooks/docs |

## Canonical surface (Step 2)

```rust
// Rust
hyrr_core::data_fetch::RELEASE_BASE                      // pub const
hyrr_core::data_fetch::DATA_VERSION                      // pub const
hyrr_core::data_fetch::release_base_url() -> &'static str
hyrr_core::data_fetch::data_version()     -> &'static str
hyrr_core::data_fetch::release_url()      -> String
hyrr_core::data_fetch::release_url_for(version) -> String
hyrr_core::data_fetch::tarball_filename() -> String
hyrr_core::data_fetch::tarball_filename_for(version) -> String
hyrr_core::data_fetch::cache_root_pattern() -> String
hyrr_core::data_fetch::cache_dir() -> Result<PathBuf>    // already pub

// Tauri commands (desktop/src-tauri/src/commands.rs)
data_release_url       () -> String
data_release_base_url  () -> &'static str
data_version           () -> &'static str
data_tarball_filename  () -> String
data_cache_root_pattern() -> String

// Frontend (frontend/src/lib/compute/data-fetch-meta.ts)
import {
  getReleaseUrl, getReleaseBaseUrl,
  getDataVersion, getTarballFilename,
  getCacheRootPattern,
  DEFAULT_LIBRARY,
} from "$lib/compute/data-fetch-meta";
```

Browser-mode falls back to `null` for the URL/path getters — GH-Releases tarball delivery is desktop-only, the deployed bundle ships parquet as static assets.

## Before / after counts

- Concrete `releases/download/vN.N.N/...` URL spellings outside Rust SSoT: **1 → 0**
- `"tendl-2025"` literals in `frontend/src/lib/compute/backend.ts`: **2 → 0**
- Inline `format!("nucl-parquet-data-v{DATA_VERSION}.tar.zst")` sites in `data_fetch.rs`: **4 → 0** (all → `tarball_filename()`)
- CI workflow sparse-checkout sites still pulling `tendl-2024/xs`: **3 → 0**

## Drift guards

- `core/src/data_fetch.rs::tests::release_url_pattern_is_canonical` — pins host/path shape and the `release_url() ⇒ tarball_filename()` relationship.
- `.github/workflows/ci.yml::data-fetch-ssot` — fails CI if any concrete `vN.N.N.tar.zst` reappears under `docs/`, and verifies `RELEASE_BASE` literal still lives at its canonical site.

## Step 4 — #118 contract

Posted as a follow-up comment on #118 listing the exact Rust + Tauri + TS API surface the recovery-card implementer must use.

## Test plan

- [x] `cargo test --lib` — 41/41
- [x] `cargo test --lib data_fetch -- --test-threads=1` — 11/11 (incl. new `release_url_pattern_is_canonical`)
- [x] `cargo test --test projectile_matrix -- --include-ignored` — 3/3
- [x] `npm run check --workspace=hyrr-frontend` — 0 errors / 0 warnings
- [x] `npm test --workspace=hyrr-frontend` — 446/446
- [ ] CI: `data-fetch-ssot` job (added in this PR) — first run on this branch

## Constraints honoured

- Pure refactor — no runtime behaviour change, no new endpoints, no new validation paths, no new deps.
- Prose duplications (CLI help text, error messages, README runbooks) left in place per the brief.
- Docstring example in `installation.md` rewritten to a `<V>` placeholder pattern instead of being deleted, so the air-gap recipe still reads naturally.

Refs: #118, #127, #129