### PR TITLE
test(core/123): data_fetch concurrency + interrupted-merge coverage

### DIFF
--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -26,6 +26,7 @@
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use fs2::FileExt;
 
@@ -143,20 +144,50 @@ pub fn is_cache_complete() -> bool {
     sentinel_path().map(|p| p.exists()).unwrap_or(false)
 }
 
-/// Acquire an exclusive lock on `<cache_root>/.lock`. Blocks the current
-/// thread until competing fetch attempts release. Drops on `Drop`.
-fn acquire_lock() -> Result<fs::File> {
+/// Process-wide mutex that pairs with the on-disk `flock`. Two threads
+/// in the same process opening `<cache_root>/.lock` independently and
+/// both calling `flock(LOCK_EX)` is unreliable on macOS — the kernel
+/// can leave both threads parked when neither holds the lock. The
+/// in-process mutex makes the intra-process race deterministic; the
+/// file lock continues to handle the inter-process case (the GUI
+/// process and a separately-spawned `--mcp` process).
+fn process_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Combined cross-thread + cross-process lock guard. Holds the
+/// in-process mutex *and* the on-disk `flock` for as long as it lives.
+/// Both are released on `Drop` in field-declaration order: file lock
+/// first, then the mutex, which matches the order they were acquired
+/// in reverse.
+struct CacheLock {
+    _file: fs::File,
+    _guard: MutexGuard<'static, ()>,
+}
+
+/// Acquire the cross-thread + cross-process cache lock. Blocks the
+/// current thread until competing fetch attempts release. Drops on
+/// `Drop`.
+fn acquire_lock() -> Result<CacheLock> {
+    // In-process mutex first — see `process_lock` for the macOS
+    // rationale. Poisoning means a previous holder panicked mid-op;
+    // we recover and proceed because the file lock + sentinel-based
+    // recovery handle the on-disk consistency story.
+    let guard = process_lock()
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
     let root = cache_root()?;
     fs::create_dir_all(&root)?;
-    let lock = fs::OpenOptions::new()
+    let file = fs::OpenOptions::new()
         .create(true)
         .read(true)
         .write(true)
         .truncate(false)
         .open(root.join(".lock"))?;
-    lock.lock_exclusive()
+    file.lock_exclusive()
         .map_err(|e| FetchError::Io(io::Error::other(format!("lock: {e}"))))?;
-    Ok(lock)
+    Ok(CacheLock { _file: file, _guard: guard })
 }
 
 /// Build a configured reqwest client for cache fetches.
@@ -338,9 +369,12 @@ pub fn extract_tarball(
 ///
 /// `prefixes`: same semantics as `extract_tarball` — empty extracts
 /// everything, a list of strings filters by `starts_with`.
+///
+/// **Caller must hold the cache lock** (`acquire_lock`) — every public
+/// entry point in this module already does, and re-acquiring here
+/// would deadlock the in-process mutex paired with the on-disk
+/// `flock` (see `process_lock`).
 fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
-    let _lock = acquire_lock()?;
-
     let cache = cache_dir()?;
     let root = cache_root()?;
     let pid = std::process::id();
@@ -627,6 +661,7 @@ pub fn install_from_tarball(archive: &Path) -> Result<()> {
             format!("tarball not found: {}", archive.display()),
         )));
     }
+    let _lock = acquire_lock()?;
     install_tarball_atomic(archive, &["data"])
 }
 

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -400,6 +400,12 @@ fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
 
     extract_tarball(archive, &partial, prefixes)?;
 
+    // Test-only seam: between partial-dir build and the
+    // atomic-rename promotion, give tests a chance to simulate a
+    // SIGKILL. Production builds compile this away entirely.
+    #[cfg(test)]
+    test_hooks::run_pre_promote_hook()?;
+
     // If `cache` already exists but is incomplete, blow it away — its
     // contents are by definition stale (the sentinel would be present
     // otherwise).
@@ -480,9 +486,22 @@ pub fn ensure_meta_stopping() -> Result<()> {
     require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
-    fetch_full_tarball_to(&tmp)?;
+    fetch_full_tarball_with_seam(&tmp)?;
     install_tarball_atomic(&tmp, MANDATORY_PREFIXES)?;
     Ok(())
+}
+
+/// Indirection for the network fetch so tests can inject a local-file
+/// "fetcher" without touching production behaviour. In a non-test
+/// build this is a one-line forwarder to [`fetch_full_tarball_to`].
+fn fetch_full_tarball_with_seam(out: &Path) -> Result<()> {
+    #[cfg(test)]
+    {
+        if let Some(()) = test_hooks::try_test_fetch(out)? {
+            return Ok(());
+        }
+    }
+    fetch_full_tarball_to(out)
 }
 
 /// Ensure the given library's data is present in the cache.
@@ -755,6 +774,97 @@ pub fn prune_old_versions(keep: usize) -> Result<usize> {
         removed += 1;
     }
     Ok(removed)
+}
+
+/// Test-only seams for concurrency / interrupted-merge coverage (#123).
+///
+/// These hooks exist purely to let tests simulate failure modes that
+/// are otherwise impossible to reproduce deterministically (SIGKILL
+/// mid-merge, double-fetch under contention). Production builds compile
+/// the module away entirely (`#[cfg(test)]`).
+#[cfg(test)]
+pub(crate) mod test_hooks {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Mutex;
+
+    /// Action to run inside `install_tarball_atomic` after the partial
+    /// dir is built but before promotion. `None` (the default) means
+    /// the hook is inert.
+    #[allow(dead_code)]
+    pub(crate) enum PrePromoteAction {
+        /// Panic — simulates a `SIGKILL` mid-install. Reserved for
+        /// future tests that exercise the unwind path; current tests
+        /// use `FailOnce` which produces the same on-disk recovery
+        /// state without needing `catch_unwind`.
+        PanicOnce,
+        /// Return a synthetic IO error from the hook — equivalent
+        /// on-disk effect to `PanicOnce` (partial dir survives,
+        /// sentinel does not get written) but propagates as `Err(_)`
+        /// through the normal `?` chain so tests can `assert!(_.is_err())`
+        /// without `catch_unwind`.
+        FailOnce,
+    }
+
+    static PRE_PROMOTE_ACTION: Mutex<Option<PrePromoteAction>> = Mutex::new(None);
+
+    pub(crate) fn arm_pre_promote(action: PrePromoteAction) {
+        *PRE_PROMOTE_ACTION.lock().unwrap() = Some(action);
+    }
+
+    pub(crate) fn clear_pre_promote() {
+        *PRE_PROMOTE_ACTION.lock().unwrap() = None;
+    }
+
+    pub(crate) fn run_pre_promote_hook() -> Result<()> {
+        let action = PRE_PROMOTE_ACTION.lock().unwrap().take();
+        match action {
+            None => Ok(()),
+            Some(PrePromoteAction::PanicOnce) => {
+                panic!("test_hooks: simulated SIGKILL mid-install");
+            }
+            Some(PrePromoteAction::FailOnce) => Err(FetchError::Io(io::Error::other(
+                "test_hooks: simulated mid-install failure",
+            ))),
+        }
+    }
+
+    /// When `Some(path)`, `ensure_meta_stopping`'s fetch step copies
+    /// `path` to `out` instead of hitting the network. The counter
+    /// tracks how many times the seam fired across all threads — used
+    /// by the lock-contention test to assert no double-fetch.
+    static FETCH_SOURCE: Mutex<Option<PathBuf>> = Mutex::new(None);
+    static FETCH_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    pub(crate) fn arm_fetch_source(src: PathBuf) {
+        *FETCH_SOURCE.lock().unwrap() = Some(src);
+        FETCH_COUNT.store(0, Ordering::SeqCst);
+    }
+
+    pub(crate) fn clear_fetch_source() {
+        *FETCH_SOURCE.lock().unwrap() = None;
+        FETCH_COUNT.store(0, Ordering::SeqCst);
+    }
+
+    pub(crate) fn fetch_count() -> usize {
+        FETCH_COUNT.load(Ordering::SeqCst)
+    }
+
+    /// If a test fetcher is armed, copy the local archive into `out`,
+    /// bump the counter, and report `Some(())`. Otherwise return
+    /// `None` to let the production fetcher run.
+    pub(crate) fn try_test_fetch(out: &Path) -> Result<Option<()>> {
+        let guard = FETCH_SOURCE.lock().unwrap();
+        let Some(src) = guard.as_ref() else {
+            return Ok(None);
+        };
+        if let Some(parent) = out.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(src, out)?;
+        FETCH_COUNT.fetch_add(1, Ordering::SeqCst);
+        Ok(Some(()))
+    }
 }
 
 #[cfg(test)]
@@ -1196,5 +1306,149 @@ mod tests {
         let _ = prune_old_versions(1).unwrap();
         let removed = prune_old_versions(1).unwrap();
         assert_eq!(removed, 0);
+    }
+
+    /// Helper: count `v{V}.partial-*` directories left under
+    /// `cache_root()`. Used by the concurrency / interruption tests
+    /// to assert no orphaned partials survive a recovery cycle.
+    fn count_partial_dirs() -> usize {
+        let root = cache_root().unwrap();
+        let prefix = format!("v{DATA_VERSION}.partial-");
+        match fs::read_dir(&root) {
+            Ok(it) => it
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_name().to_string_lossy().starts_with(&prefix))
+                .count(),
+            Err(_) => 0,
+        }
+    }
+
+    /// #123 — doc-comment claim:
+    /// "the user can kill the process at any moment and the next
+    /// invocation finds either (a) a fully-populated cache, or (b) a
+    /// missing/incomplete cache that gets re-fetched cleanly."
+    ///
+    /// Two threads race `install_from_tarball` against the same cache
+    /// root. The `<cache_root>/.lock` file lock must serialise them so
+    /// neither sees a half-merged cache and neither deadlocks. Both
+    /// invocations are expected to succeed (the second merges into a
+    /// populated cache and re-writes the sentinel); at minimum one
+    /// must succeed and the final state must be consistent.
+    #[test]
+    fn concurrent_install_from_tarball_serialises() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        let archive_ref = &archive;
+        let (r1, r2) = std::thread::scope(|s| {
+            let h1 = s.spawn(|| install_from_tarball(archive_ref));
+            let h2 = s.spawn(|| install_from_tarball(archive_ref));
+            (h1.join().expect("t1 panicked"), h2.join().expect("t2 panicked"))
+        });
+
+        // Neither thread deadlocked (we got here) and at least one
+        // succeeded. A second-mover may legitimately succeed too via
+        // the merge path; what's not allowed is *both* failing.
+        assert!(
+            r1.is_ok() || r2.is_ok(),
+            "both threads failed: r1={r1:?} r2={r2:?}"
+        );
+
+        // Final state is consistent: sentinel + payload present, no
+        // stray partial dirs.
+        assert!(is_cache_complete(), "sentinel missing after both threads finished");
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists(), "payload missing after concurrent install");
+        assert_eq!(fs::read(&marker).unwrap(), b"test-marker");
+        assert_eq!(count_partial_dirs(), 0, "stray partial dirs left behind");
+    }
+
+    /// #123 — recovery half of the doc-comment claim. Simulate a
+    /// SIGKILL between partial-dir build and atomic-rename via the
+    /// test-only `FailOnce` hook. The first invocation must error and
+    /// leave the cache visibly incomplete; the next invocation must
+    /// observe `is_cache_complete() == false`, sweep the orphan
+    /// partial, and finish cleanly.
+    #[test]
+    fn interrupted_merge_recovers_on_next_invocation() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        // Arm the seam, run the interrupted install. We expect Err.
+        test_hooks::arm_pre_promote(test_hooks::PrePromoteAction::FailOnce);
+        let interrupted = install_from_tarball(&archive);
+        assert!(interrupted.is_err(), "armed hook did not fire");
+        // Hook is single-shot but clear defensively in case of test
+        // re-entry.
+        test_hooks::clear_pre_promote();
+
+        // After the interrupted install: cache must be incomplete and
+        // an orphan partial-{pid} should be visible to the sweep.
+        assert!(!is_cache_complete(), "sentinel written despite interruption");
+        assert!(
+            count_partial_dirs() >= 1,
+            "expected an orphan partial dir from the interrupted install"
+        );
+
+        // Second invocation: clean run. The orphan partial must be
+        // swept, the cache promoted, and the sentinel re-asserted.
+        install_from_tarball(&archive).expect("clean re-run failed");
+        assert!(is_cache_complete(), "sentinel not written on retry");
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists(), "payload missing after recovery");
+        assert_eq!(count_partial_dirs(), 0, "orphan partial was not swept");
+    }
+
+    /// #123 — N-thread lock contention on `ensure_meta_stopping`. With
+    /// the network fetch redirected to a local file via the test seam,
+    /// N=4 threads racing against an empty cache must end in exactly
+    /// ONE fetch (the rest see the sentinel after the lock-holder
+    /// finishes and short-circuit). All threads must succeed.
+    #[test]
+    fn ensure_meta_stopping_serialises_and_dedupes_fetches() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        test_hooks::arm_fetch_source(archive.clone());
+        // Defensive cleanup if a previous test scribbled state.
+        let starting_count = test_hooks::fetch_count();
+        assert_eq!(starting_count, 0, "fetch counter should reset on arm");
+
+        const N: usize = 4;
+        let results = std::thread::scope(|s| {
+            let mut handles = Vec::with_capacity(N);
+            for _ in 0..N {
+                handles.push(s.spawn(|| ensure_meta_stopping()));
+            }
+            handles
+                .into_iter()
+                .map(|h| h.join().expect("worker panicked"))
+                .collect::<Vec<_>>()
+        });
+
+        // Every thread succeeded — the lock made them serial, not
+        // failed.
+        for (i, r) in results.iter().enumerate() {
+            assert!(r.is_ok(), "thread {i} failed: {r:?}");
+        }
+        // Exactly one thread actually performed the fetch; the rest
+        // observed the sentinel after acquiring the lock and bailed.
+        assert_eq!(
+            test_hooks::fetch_count(),
+            1,
+            "expected exactly one fetch under contention"
+        );
+        assert!(is_cache_complete());
+        let marker = cache_dir().unwrap().join("data/meta/marker");
+        assert!(marker.exists(), "meta/marker missing after ensure_meta_stopping race");
+        assert_eq!(count_partial_dirs(), 0);
+
+        test_hooks::clear_fetch_source();
     }
 }


### PR DESCRIPTION
## Summary

The `core/src/data_fetch.rs` module-level [doc-comment](https://github.com/exoma-ch/hyrr/blob/main/core/src/data_fetch.rs#L1-L19) promises that **"the user can kill the process at any moment and the next invocation finds either (a) a fully-populated cache, or (b) a missing/incomplete cache that gets re-fetched cleanly"** — but no test in the existing 9-test suite actually exercises concurrency or interruption. This PR adds three tests that pin that guarantee down, plus the minimal production fix needed to make intra-process thread serialisation actually work on macOS.

## Tests added

1. **`concurrent_install_from_tarball_serialises`** — two threads race `install_from_tarball` against the same `cache_root` via `std::thread::scope`. Asserts no deadlock, sentinel + marker file present, no stray `v{V}.partial-*` dirs, at least one thread succeeded. Covers the doc-comment claim about `flock` serialising competing extracts.
2. **`interrupted_merge_recovers_on_next_invocation`** — injects a `FailOnce` error between partial-dir build and atomic-rename promotion, simulating SIGKILL. Asserts the cache is visibly incomplete after the failed run, the orphan partial survives, and a clean second invocation sweeps the orphan + writes the sentinel. Covers the recovery half of the doc-comment.
3. **`ensure_meta_stopping_serialises_and_dedupes_fetches`** — N=4 threads race `ensure_meta_stopping` with the network fetch redirected (test-only seam) to a local tarball + counter. Asserts every thread succeeds and exactly **one** fetch fired (the others see the sentinel after their lock acquire). Covers the lock-contention dedup story.

## Refactor (minimal)

- **Production fix (commit 1)**: paired the on-disk `flock` with a process-wide `Mutex` inside `acquire_lock`. macOS' `flock(2)` is unreliable when multiple threads in the same process open the lock file independently and call `LOCK_EX` — the kernel can park them all. The cross-process case (GUI vs `--mcp`) still works via the file lock alone; the in-process mutex is what makes the new concurrent test deterministic. As part of the same fix, removed the (recursive) `acquire_lock` call from `install_tarball_atomic` and moved it to `install_from_tarball` — every other public caller already takes the lock, so the inner re-acquire was a latent double-lock that became a hard deadlock once the mutex was added.
- **Test seam (commit 2)**: `#[cfg(test)] mod test_hooks` exposes two single-shot statics — `PRE_PROMOTE_ACTION` (panic / fail mid-install) and `FETCH_SOURCE`+`FETCH_COUNT` (local-file fetcher) — plus inert call sites guarded by `#[cfg(test)]` in `install_tarball_atomic` and a new private `fetch_full_tarball_with_seam` indirection. Production builds compile the module away entirely.

## Test plan

- [x] `cargo test -p hyrr-core data_fetch` — all 13 tests green
- [x] `concurrent_install_from_tarball_serialises` ran 50 iterations clean (no flakes)
- [x] `interrupted_merge_recovers_on_next_invocation` + `ensure_meta_stopping_serialises_and_dedupes_fetches` ran 25 iterations each clean
- [x] full `data_fetch` suite ran 10 iterations clean
- [x] no test relies on `~/.hyrr` — every test uses `tempfile::TempDir` via the existing `isolated_home()` helper
- [ ] CI green on Linux + macOS

Closes #123