### PR TITLE
feat(#118): splash-screen recovery UI on data-fetch failure

### DIFF
--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -25,10 +25,12 @@
 
 use std::fs;
 use std::io;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use fs2::FileExt;
+use serde::Serialize;
 
 /// Version of the `nucl-parquet` data this build expects.
 ///
@@ -93,6 +95,166 @@ pub fn release_url_for(version: &str) -> String {
 /// need an actual filesystem path should use [`cache_dir`] instead.
 pub fn cache_root_pattern() -> String {
     format!("~/.hyrr/nucl-parquet/v{DATA_VERSION}/data")
+}
+
+/// Stage of the cache-fetch pipeline. Surfaced through
+/// [`FetchProgress`] so the splash UI can label the progress bar.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FetchStage {
+    /// HTTP connection establishment / DNS lookup (pre-200 response).
+    Connecting,
+    /// Body bytes streaming from the response into the on-disk tarball.
+    Downloading,
+    /// Tar extraction (`extract_tarball` per-entry progress).
+    Extracting,
+    /// Sentinel write + post-extract bookkeeping. Brief — primarily
+    /// surfaced so the splash can show "almost done" rather than
+    /// snapping from 99% straight to "Ready".
+    Verifying,
+}
+
+/// Push-based progress callback payload.
+///
+/// `bytes_total` is `None` when the upstream HTTP `Content-Length` is
+/// missing (rare but legal for `Transfer-Encoding: chunked`); the splash
+/// renders an indeterminate `<progress>` bar in that case.
+#[derive(Debug, Clone, Serialize)]
+pub struct FetchProgress {
+    pub stage: FetchStage,
+    pub bytes_done: u64,
+    pub bytes_total: Option<u64>,
+}
+
+/// Type alias for the progress-callback parameter passed through every
+/// `ensure_*` / `extract_*` entry point. `&mut dyn FnMut(...)` keeps the
+/// closure's captured state mutable (the desktop command throttles emits
+/// using a `last_emit_at` field), and the `'_` lifetime lets the caller
+/// own the closure on the stack.
+pub type ProgressFn<'a> = &'a mut dyn FnMut(FetchProgress);
+
+/// Convenience: a no-op progress callback for callers that don't need
+/// progress (CLI, MCP, tests). Spelled as a fresh closure rather than a
+/// `static` because the trait object signature requires `FnMut`.
+fn no_op_progress() -> impl FnMut(FetchProgress) {
+    |_| {}
+}
+
+/// Wire-shape of a [`FetchError`] for the Tauri / IPC boundary.
+///
+/// Mirrors the StoppingError chain shipped in #142: every payload is
+/// `kind: "FetchError"` + a `variant` discriminator; variant-specific
+/// fields are serialised flat. The `url` and `cache_dir` fields are
+/// always present so the recovery card can render them — both are
+/// derived from the SSoT helpers ([`release_url`], [`cache_dir`]) so a
+/// drift between "URL we tried" and "URL we render" is impossible by
+/// construction.
+///
+/// Privacy: `cache_dir` is always under `~/.hyrr/...`, never an
+/// arbitrary path; `url` is the canonical GH-Releases URL. No env vars,
+/// no auth tokens, nothing the user can't already see in
+/// `hyrr fetch-data --help`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "variant")]
+pub enum FetchErrorPayload {
+    HttpStatus {
+        status: u16,
+        url: String,
+        cache_dir: String,
+        message: String,
+    },
+    Network {
+        detail: String,
+        url: String,
+        cache_dir: String,
+        message: String,
+    },
+    Decompress {
+        cache_dir: String,
+        message: String,
+    },
+    Extract {
+        cache_dir: String,
+        message: String,
+    },
+    UnsafeTarballEntry {
+        entry_kind: String,
+        entry_path: String,
+        cache_dir: String,
+        message: String,
+    },
+    Io {
+        cache_dir: String,
+        message: String,
+    },
+    NoHome {
+        message: String,
+    },
+}
+
+impl FetchErrorPayload {
+    /// Wrap as a top-level discriminator object — the wire shape the
+    /// frontend actually sees. Equivalent to manually emitting
+    /// `{"kind": "FetchError", "variant": ..., ...}`.
+    pub fn to_json_string(&self) -> String {
+        let inner = serde_json::to_value(self).unwrap_or_else(|_| {
+            serde_json::json!({"variant": "Io", "message": "serialise failed"})
+        });
+        let mut obj = serde_json::Map::new();
+        obj.insert("kind".to_string(), serde_json::Value::String("FetchError".to_string()));
+        if let serde_json::Value::Object(m) = inner {
+            for (k, v) in m {
+                obj.insert(k, v);
+            }
+        }
+        serde_json::to_string(&serde_json::Value::Object(obj))
+            .unwrap_or_else(|_| "{\"kind\":\"FetchError\",\"variant\":\"Io\",\"message\":\"serialise failed\"}".to_string())
+    }
+}
+
+impl From<&FetchError> for FetchErrorPayload {
+    fn from(err: &FetchError) -> Self {
+        let url = release_url();
+        let cache_dir_str = cache_dir()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| cache_root_pattern());
+        let message = err.to_string();
+        match err {
+            FetchError::HttpStatus(status) => FetchErrorPayload::HttpStatus {
+                status: *status,
+                url,
+                cache_dir: cache_dir_str,
+                message,
+            },
+            FetchError::Network(detail) => FetchErrorPayload::Network {
+                detail: detail.clone(),
+                url,
+                cache_dir: cache_dir_str,
+                message,
+            },
+            FetchError::Decompress(_) => FetchErrorPayload::Decompress {
+                cache_dir: cache_dir_str,
+                message,
+            },
+            FetchError::Extract(_) => FetchErrorPayload::Extract {
+                cache_dir: cache_dir_str,
+                message,
+            },
+            FetchError::UnsafeTarballEntry { kind, path } => {
+                FetchErrorPayload::UnsafeTarballEntry {
+                    entry_kind: kind.clone(),
+                    entry_path: path.display().to_string(),
+                    cache_dir: cache_dir_str,
+                    message,
+                }
+            }
+            FetchError::Io(_) => FetchErrorPayload::Io {
+                cache_dir: cache_dir_str,
+                message,
+            },
+            FetchError::NoHome => FetchErrorPayload::NoHome { message },
+        }
+    }
 }
 
 /// Errors surfaced by the data-fetch path.
@@ -228,8 +390,19 @@ impl Drop for TmpFileGuard {
 /// Download the full nucl-parquet data tarball into `out`.
 ///
 /// Streams the response to disk — does not buffer the full ~400 MB in RAM.
-pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
+///
+/// `progress` is invoked at least once with [`FetchStage::Connecting`]
+/// before the request flies, and then per-chunk with
+/// [`FetchStage::Downloading`] as bytes land on disk. Callers that don't
+/// need progress (CLI, tests) can pass `&mut |_| {}` (or use the
+/// no-progress sibling [`fetch_full_tarball_to`]). The throttling
+/// (≤1 emit per 256 KiB / 100 ms) lives in the *caller's* closure — the
+/// library always emits unconditionally so the consumer chooses the
+/// rate.
+pub fn fetch_full_tarball_to_with_progress(out: &Path, progress: ProgressFn<'_>) -> Result<()> {
     let url = release_url();
+    progress(FetchProgress { stage: FetchStage::Connecting, bytes_done: 0, bytes_total: None });
+
     let client = build_http_client().map_err(|e| FetchError::Network(e.to_string()))?;
     let resp = client
         .get(&url)
@@ -238,13 +411,49 @@ pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
     if !resp.status().is_success() {
         return Err(FetchError::HttpStatus(resp.status().as_u16()));
     }
+    let bytes_total = resp.content_length();
+
     if let Some(parent) = out.parent() {
         fs::create_dir_all(parent)?;
     }
     let mut file = fs::File::create(out)?;
+    progress(FetchProgress {
+        stage: FetchStage::Downloading,
+        bytes_done: 0,
+        bytes_total,
+    });
+
+    // 64 KiB chunks balance syscall overhead against responsiveness — at
+    // 100 Mbit/s a chunk fills in ~5 ms which is well under the 100 ms
+    // throttle window the desktop closure enforces.
     let mut reader = io::BufReader::new(resp);
-    io::copy(&mut reader, &mut file)?;
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut bytes_done: u64 = 0;
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        io::Write::write_all(&mut file, &buf[..n])?;
+        bytes_done += n as u64;
+        progress(FetchProgress {
+            stage: FetchStage::Downloading,
+            bytes_done,
+            bytes_total,
+        });
+    }
     Ok(())
+}
+
+/// Back-compat wrapper for callers that don't need progress events.
+///
+/// Production callers should prefer
+/// [`fetch_full_tarball_to_with_progress`] and pass an explicit closure;
+/// this thin wrapper exists for the CLI / py / MCP entry points where
+/// progress reporting is not yet wired up.
+pub fn fetch_full_tarball_to(out: &Path) -> Result<()> {
+    let mut noop = no_op_progress();
+    fetch_full_tarball_to_with_progress(out, &mut noop)
 }
 
 /// Conservative pre-flight free-space check before downloading the
@@ -289,12 +498,34 @@ pub fn extract_tarball(
     dest: &Path,
     prefixes: &[&str],
 ) -> Result<()> {
+    let mut noop = no_op_progress();
+    extract_tarball_with_progress(archive, dest, prefixes, &mut noop)
+}
+
+/// Progress-aware variant of [`extract_tarball`]. Emits one
+/// [`FetchStage::Extracting`] event per accepted (post-filter) entry,
+/// with `bytes_done` carrying the count of entries unpacked so far.
+/// `bytes_total` is left as `None` because we'd have to walk the tar
+/// twice to count entries up-front, and the splash uses an
+/// indeterminate bar for this phase anyway.
+pub fn extract_tarball_with_progress(
+    archive: &Path,
+    dest: &Path,
+    prefixes: &[&str],
+    progress: ProgressFn<'_>,
+) -> Result<()> {
     let file = fs::File::open(archive)?;
     let decoder = zstd::stream::Decoder::new(file)
         .map_err(|e| FetchError::Decompress(e.to_string()))?;
     let mut tar = tar::Archive::new(decoder);
 
     fs::create_dir_all(dest)?;
+    let mut entries_done: u64 = 0;
+    progress(FetchProgress {
+        stage: FetchStage::Extracting,
+        bytes_done: 0,
+        bytes_total: None,
+    });
     for entry in tar
         .entries()
         .map_err(|e| FetchError::Extract(e.to_string()))?
@@ -351,6 +582,12 @@ pub fn extract_tarball(
         entry
             .unpack_in(dest)
             .map_err(|e| FetchError::Extract(e.to_string()))?;
+        entries_done += 1;
+        progress(FetchProgress {
+            stage: FetchStage::Extracting,
+            bytes_done: entries_done,
+            bytes_total: None,
+        });
     }
     Ok(())
 }
@@ -374,7 +611,11 @@ pub fn extract_tarball(
 /// entry point in this module already does, and re-acquiring here
 /// would deadlock the in-process mutex paired with the on-disk
 /// `flock` (see `process_lock`).
-fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
+fn install_tarball_atomic(
+    archive: &Path,
+    prefixes: &[&str],
+    progress: ProgressFn<'_>,
+) -> Result<()> {
     let cache = cache_dir()?;
     let root = cache_root()?;
     let pid = std::process::id();
@@ -398,13 +639,19 @@ fn install_tarball_atomic(archive: &Path, prefixes: &[&str]) -> Result<()> {
         fs::remove_dir_all(&partial)?;
     }
 
-    extract_tarball(archive, &partial, prefixes)?;
+    extract_tarball_with_progress(archive, &partial, prefixes, progress)?;
 
     // Test-only seam: between partial-dir build and the
     // atomic-rename promotion, give tests a chance to simulate a
     // SIGKILL. Production builds compile this away entirely.
     #[cfg(test)]
     test_hooks::run_pre_promote_hook()?;
+
+    progress(FetchProgress {
+        stage: FetchStage::Verifying,
+        bytes_done: 0,
+        bytes_total: None,
+    });
 
     // If `cache` already exists but is incomplete, blow it away — its
     // contents are by definition stale (the sentinel would be present
@@ -476,6 +723,12 @@ const MANDATORY_PREFIXES: &[&str] = &[
 /// ~54 MB even though the download itself is the full ~400 MB until
 /// upstream ships per-library tarballs.
 pub fn ensure_meta_stopping() -> Result<()> {
+    let mut noop = no_op_progress();
+    ensure_meta_stopping_with_progress(&mut noop)
+}
+
+/// Progress-aware variant of [`ensure_meta_stopping`].
+pub fn ensure_meta_stopping_with_progress(progress: ProgressFn<'_>) -> Result<()> {
     if is_cache_complete() {
         return Ok(());
     }
@@ -486,22 +739,23 @@ pub fn ensure_meta_stopping() -> Result<()> {
     require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
-    fetch_full_tarball_with_seam(&tmp)?;
-    install_tarball_atomic(&tmp, MANDATORY_PREFIXES)?;
+    fetch_full_tarball_with_seam(&tmp, progress)?;
+    install_tarball_atomic(&tmp, MANDATORY_PREFIXES, progress)?;
     Ok(())
 }
 
 /// Indirection for the network fetch so tests can inject a local-file
 /// "fetcher" without touching production behaviour. In a non-test
-/// build this is a one-line forwarder to [`fetch_full_tarball_to`].
-fn fetch_full_tarball_with_seam(out: &Path) -> Result<()> {
+/// build this is a one-line forwarder to
+/// [`fetch_full_tarball_to_with_progress`].
+fn fetch_full_tarball_with_seam(out: &Path, progress: ProgressFn<'_>) -> Result<()> {
     #[cfg(test)]
     {
         if let Some(()) = test_hooks::try_test_fetch(out)? {
             return Ok(());
         }
     }
-    fetch_full_tarball_to(out)
+    fetch_full_tarball_to_with_progress(out, progress)
 }
 
 /// Ensure the given library's data is present in the cache.
@@ -516,6 +770,12 @@ fn fetch_full_tarball_with_seam(out: &Path) -> Result<()> {
 /// library subtree is absent (the bundled-resources-on-installer case),
 /// fetches and merges only that library into the cache.
 pub fn ensure_library(library: &str) -> Result<()> {
+    let mut noop = no_op_progress();
+    ensure_library_with_progress(library, &mut noop)
+}
+
+/// Progress-aware variant of [`ensure_library`].
+pub fn ensure_library_with_progress(library: &str, progress: ProgressFn<'_>) -> Result<()> {
     if is_cache_complete() && cache_dir()?.join("data").join(library).exists() {
         return Ok(());
     }
@@ -526,11 +786,11 @@ pub fn ensure_library(library: &str) -> Result<()> {
     require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
-    fetch_full_tarball_to(&tmp)?;
+    fetch_full_tarball_to_with_progress(&tmp, progress)?;
     let lib_prefix = format!("data/{library}/");
     let mut prefixes: Vec<&str> = MANDATORY_PREFIXES.to_vec();
     prefixes.push(&lib_prefix);
-    install_tarball_atomic(&tmp, &prefixes)?;
+    install_tarball_atomic(&tmp, &prefixes, progress)?;
     Ok(())
 }
 
@@ -543,12 +803,18 @@ pub fn ensure_library(library: &str) -> Result<()> {
 /// reading the catalog, so we trust the sentinel + a no-op merge: the
 /// re-extraction overwrites identical bytes which is harmless.)
 pub fn ensure_all() -> Result<()> {
+    let mut noop = no_op_progress();
+    ensure_all_with_progress(&mut noop)
+}
+
+/// Progress-aware variant of [`ensure_all`].
+pub fn ensure_all_with_progress(progress: ProgressFn<'_>) -> Result<()> {
     let _lock = acquire_lock()?;
     require_free_space(1024 * 1024 * 1024)?;
     let tmp = cache_root()?.join(tarball_filename());
     let _guard = TmpFileGuard::new(tmp.clone());
-    fetch_full_tarball_to(&tmp)?;
-    install_tarball_atomic(&tmp, &[])?;
+    fetch_full_tarball_to_with_progress(&tmp, progress)?;
+    install_tarball_atomic(&tmp, &[], progress)?;
     Ok(())
 }
 
@@ -674,6 +940,15 @@ pub fn export_offline_bundle(out: &Path) -> Result<()> {
 /// downloaded manually from a GitHub Release). Atomic + sentinel-protected
 /// just like the network path.
 pub fn install_from_tarball(archive: &Path) -> Result<()> {
+    let mut noop = no_op_progress();
+    install_from_tarball_with_progress(archive, &mut noop)
+}
+
+/// Progress-aware variant of [`install_from_tarball`].
+pub fn install_from_tarball_with_progress(
+    archive: &Path,
+    progress: ProgressFn<'_>,
+) -> Result<()> {
     if !archive.exists() {
         return Err(FetchError::Io(io::Error::new(
             io::ErrorKind::NotFound,
@@ -681,7 +956,7 @@ pub fn install_from_tarball(archive: &Path) -> Result<()> {
         )));
     }
     let _lock = acquire_lock()?;
-    install_tarball_atomic(archive, &["data"])
+    install_tarball_atomic(archive, &["data"], progress)
 }
 
 /// Parse a `v{N}.{N}.{N}` directory name into a sortable tuple. Returns
@@ -1450,5 +1725,153 @@ mod tests {
         assert_eq!(count_partial_dirs(), 0);
 
         test_hooks::clear_fetch_source();
+    }
+
+    // ---------------------------------------------------------------------
+    // #118 — progress callback + FetchErrorPayload tests
+    // ---------------------------------------------------------------------
+
+    /// `extract_tarball_with_progress` must invoke the callback at least
+    /// once with `Extracting` per accepted entry, and the entry counter
+    /// (`bytes_done`) must monotonically advance. Reaches the same
+    /// progress code path that `install_from_tarball_with_progress`
+    /// uses on the cache fill.
+    #[test]
+    fn progress_callback_fires_on_extract() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+        let dest = td.path().join("dest");
+
+        let mut events: Vec<FetchProgress> = Vec::new();
+        extract_tarball_with_progress(&archive, &dest, &[], &mut |p| events.push(p)).unwrap();
+
+        assert!(
+            !events.is_empty(),
+            "extract_tarball_with_progress did not emit any progress events"
+        );
+        // At least one Extracting event with bytes_done > 0.
+        let max_done = events
+            .iter()
+            .filter(|e| matches!(e.stage, FetchStage::Extracting))
+            .map(|e| e.bytes_done)
+            .max()
+            .unwrap_or(0);
+        assert!(
+            max_done >= 1,
+            "expected ≥1 Extracting event with bytes_done ≥ 1, got events: {events:?}"
+        );
+
+        // Monotonic non-decreasing entry count.
+        let extracting: Vec<u64> = events
+            .iter()
+            .filter(|e| matches!(e.stage, FetchStage::Extracting))
+            .map(|e| e.bytes_done)
+            .collect();
+        for w in extracting.windows(2) {
+            assert!(
+                w[1] >= w[0],
+                "Extracting progress went backwards: {w:?}"
+            );
+        }
+    }
+
+    /// `install_from_tarball_with_progress` must emit at least one
+    /// `Extracting` and one `Verifying` event. Production-shape: this
+    /// is what the desktop `ensure_data` command calls on a warm cache
+    /// without a network round trip.
+    #[test]
+    fn progress_callback_emits_extracting_and_verifying() {
+        let _g = SERIAL.lock().unwrap();
+        let td = isolated_home();
+        let archive = td.path().join("test.tar.zst");
+        make_test_tarball(&archive);
+
+        let mut stages: Vec<FetchStage> = Vec::new();
+        install_from_tarball_with_progress(&archive, &mut |p| stages.push(p.stage)).unwrap();
+
+        assert!(
+            stages.iter().any(|s| matches!(s, FetchStage::Extracting)),
+            "no Extracting stage observed: {stages:?}"
+        );
+        assert!(
+            stages.iter().any(|s| matches!(s, FetchStage::Verifying)),
+            "no Verifying stage observed: {stages:?}"
+        );
+        assert!(is_cache_complete());
+    }
+
+    /// `FetchErrorPayload::from(&FetchError)` must always populate
+    /// `url` and `cache_dir` for the variants that carry them, and
+    /// the JSON wire-form must include the `kind: "FetchError"` tag.
+    #[test]
+    fn fetch_error_payload_serializes_with_url_and_cache_dir() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+
+        let cases: Vec<FetchError> = vec![
+            FetchError::HttpStatus(404),
+            FetchError::Network("dns lookup failed".to_string()),
+            FetchError::Decompress("zstd: bad magic".to_string()),
+            FetchError::Extract("unexpected eof".to_string()),
+            FetchError::Io(io::Error::other("disk full")),
+            FetchError::UnsafeTarballEntry {
+                kind: "Symlink".to_string(),
+                path: PathBuf::from("data/meta/evil"),
+            },
+            FetchError::NoHome,
+        ];
+
+        for err in &cases {
+            let payload = FetchErrorPayload::from(err);
+            let s = payload.to_json_string();
+            // Every variant carries the top-level kind.
+            assert!(
+                s.contains("\"kind\":\"FetchError\""),
+                "missing kind discriminator for {err:?}: {s}"
+            );
+
+            // Variants that should expose the canonical URL.
+            let needs_url = matches!(
+                err,
+                FetchError::HttpStatus(_) | FetchError::Network(_)
+            );
+            if needs_url {
+                let url = release_url();
+                assert!(
+                    s.contains(&url),
+                    "variant {err:?} should embed release URL {url:?}, got {s}"
+                );
+            }
+
+            // Variants that should expose the cache_dir (everything except NoHome).
+            let needs_cache_dir = !matches!(err, FetchError::NoHome);
+            if needs_cache_dir {
+                assert!(
+                    s.contains("\"cache_dir\":"),
+                    "variant {err:?} should embed cache_dir, got {s}"
+                );
+            }
+        }
+    }
+
+    /// JSON wire-form for an HttpStatus error must round-trip into a
+    /// shape the frontend `parseFetchError` parser expects: top-level
+    /// kind/variant + flat fields.
+    #[test]
+    fn fetch_error_payload_http_status_wire_shape() {
+        let _g = SERIAL.lock().unwrap();
+        let _td = isolated_home();
+
+        let payload = FetchErrorPayload::from(&FetchError::HttpStatus(404));
+        let s = payload.to_json_string();
+        let v: serde_json::Value = serde_json::from_str(&s).expect("payload is valid JSON");
+        assert_eq!(v["kind"], "FetchError");
+        assert_eq!(v["variant"], "HttpStatus");
+        assert_eq!(v["status"], 404);
+        assert!(v["url"].is_string());
+        assert!(v["cache_dir"].is_string());
+        assert!(v["message"].is_string());
     }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -262,12 +262,15 @@ pub fn install_from_local_tarball(app: AppHandle, path: String) -> Result<String
 
 /// Build a closure that emits each [`FetchProgress`] event onto
 /// `hyrr://data-fetch-progress`, but rate-limits to ≤1 emit per
-/// 256 KiB of progress *or* ≤1 emit per 100 ms — whichever is rarer
-/// (the data_fetch comment on #118 calls this out explicitly to avoid
-/// flooding the IPC channel during a 400 MB download). Stage-change
-/// and final-byte events bypass the throttle so the UI snaps cleanly
-/// from "Downloading" → "Extracting" → "Verifying" without waiting
-/// for the next 100 ms tick.
+/// 100 ms *and* a min-step of 256 KiB on byte-progress events (so a
+/// 64 KiB chunk loop emits roughly every 4th chunk during download).
+/// The download-stage gate is `bytes_step ≥ 256 KiB AND interval ≥
+/// 100 ms` — both must be satisfied to emit. The non-byte stages
+/// (extract entry counts, verifying) drop the bytes gate and use
+/// the 100 ms interval alone, otherwise the UI would freeze on
+/// "Extracting" with no updates between stage transitions. Stage
+/// changes and the final-byte event bypass the throttle so the
+/// progress bar snaps cleanly between phases.
 fn throttled_emit(app: &AppHandle) -> impl FnMut(FetchProgress) + '_ {
     use hyrr_core::data_fetch::FetchStage;
 
@@ -294,13 +297,30 @@ fn throttled_emit(app: &AppHandle) -> impl FnMut(FetchProgress) + '_ {
             .map(|t| now.saturating_duration_since(t) >= min_interval)
             .unwrap_or(true);
 
-        let bytes_step_ok = p
-            .bytes_done
-            .checked_sub(last_bytes)
-            .map(|d| d >= min_bytes_step)
-            .unwrap_or(true);
+        // Reset the bytes counter on stage transition — bytes_done
+        // means different things across stages (compressed bytes vs.
+        // entry count) so the carry-over check is meaningless.
+        let bytes_step_ok = match (last_stage, p.stage) {
+            (Some(prev), curr) if !same_stage(prev, curr) => true,
+            _ => p
+                .bytes_done
+                .checked_sub(last_bytes)
+                .map(|d| d >= min_bytes_step)
+                .unwrap_or(true),
+        };
 
-        let should_emit = stage_changed || final_byte || (interval_ok && bytes_step_ok);
+        // Only the Downloading stage carries reliable byte counts in
+        // 256-KiB-meaningful units. Other stages emit on the 100 ms
+        // interval alone — prevents Extracting from going silent
+        // because entry counts never tick by 256 KiB.
+        let should_emit = stage_changed
+            || final_byte
+            || match p.stage {
+                FetchStage::Downloading => interval_ok && bytes_step_ok,
+                FetchStage::Connecting
+                | FetchStage::Extracting
+                | FetchStage::Verifying => interval_ok,
+            };
         if !should_emit {
             return;
         }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -3,6 +3,7 @@
 use std::sync::Mutex;
 
 use hyrr_core::compute::compute_stack;
+use hyrr_core::data_fetch::{FetchErrorPayload, FetchProgress};
 use hyrr_core::db::ParquetDataStore;
 use hyrr_core::materials::resolve_material;
 use hyrr_core::production::generate_depth_profile;
@@ -12,7 +13,9 @@ use hyrr_core::stopping::{
 use hyrr_core::types::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tauri::State;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+use tauri::{AppHandle, Emitter, State};
 
 // ---------------------------------------------------------------------------
 // Managed state
@@ -216,17 +219,113 @@ pub fn init_data_store(
 /// `meta/`+`stopping/` are present (e.g. for a depth preview that doesn't
 /// need cross-sections).
 #[tauri::command]
-pub fn ensure_data(library: String) -> Result<String, String> {
-    if library.is_empty() {
-        hyrr_core::data_fetch::ensure_meta_stopping()
-            .map_err(|e| format!("ensure_meta_stopping: {e}"))?;
+pub fn ensure_data(app: AppHandle, library: String) -> Result<String, String> {
+    let result = if library.is_empty() {
+        hyrr_core::data_fetch::ensure_meta_stopping_with_progress(
+            &mut throttled_emit(&app),
+        )
     } else {
-        hyrr_core::data_fetch::ensure_library(&library)
-            .map_err(|e| format!("ensure_library({library}): {e}"))?;
+        hyrr_core::data_fetch::ensure_library_with_progress(
+            &library,
+            &mut throttled_emit(&app),
+        )
+    };
+
+    if let Err(e) = result {
+        return Err(FetchErrorPayload::from(&e).to_json_string());
     }
     let cache = hyrr_core::data_fetch::cache_dir()
-        .map_err(|e| format!("cache_dir: {e}"))?;
+        .map_err(|e| FetchErrorPayload::from(&e).to_json_string())?;
     Ok(cache.join("data").to_string_lossy().to_string())
+}
+
+/// Install a `.tar.zst` previously downloaded to a local path. Wraps
+/// `data_fetch::install_from_tarball_with_progress` and emits the same
+/// `hyrr://data-fetch-progress` events so the splash bar updates while
+/// the (potentially slow) extraction runs.
+///
+/// Returns the resolved data dir on success, or a JSON-encoded
+/// [`FetchErrorPayload`] on failure (same wire shape as `ensure_data`).
+#[tauri::command]
+pub fn install_from_local_tarball(app: AppHandle, path: String) -> Result<String, String> {
+    let archive = PathBuf::from(&path);
+    if let Err(e) = hyrr_core::data_fetch::install_from_tarball_with_progress(
+        &archive,
+        &mut throttled_emit(&app),
+    ) {
+        return Err(FetchErrorPayload::from(&e).to_json_string());
+    }
+    let cache = hyrr_core::data_fetch::cache_dir()
+        .map_err(|e| FetchErrorPayload::from(&e).to_json_string())?;
+    Ok(cache.join("data").to_string_lossy().to_string())
+}
+
+/// Build a closure that emits each [`FetchProgress`] event onto
+/// `hyrr://data-fetch-progress`, but rate-limits to ≤1 emit per
+/// 256 KiB of progress *or* ≤1 emit per 100 ms — whichever is rarer
+/// (the data_fetch comment on #118 calls this out explicitly to avoid
+/// flooding the IPC channel during a 400 MB download). Stage-change
+/// and final-byte events bypass the throttle so the UI snaps cleanly
+/// from "Downloading" → "Extracting" → "Verifying" without waiting
+/// for the next 100 ms tick.
+fn throttled_emit(app: &AppHandle) -> impl FnMut(FetchProgress) + '_ {
+    use hyrr_core::data_fetch::FetchStage;
+
+    let mut last_emit_at: Option<Instant> = None;
+    let mut last_bytes: u64 = 0;
+    let mut last_stage: Option<FetchStage> = None;
+    let min_interval = Duration::from_millis(100);
+    let min_bytes_step: u64 = 256 * 1024;
+
+    move |p: FetchProgress| {
+        let now = Instant::now();
+
+        let stage_changed = match last_stage {
+            None => true,
+            Some(prev) => !same_stage(prev, p.stage),
+        };
+
+        let final_byte = match p.bytes_total {
+            Some(total) => p.bytes_done >= total && total > 0,
+            None => false,
+        };
+
+        let interval_ok = last_emit_at
+            .map(|t| now.saturating_duration_since(t) >= min_interval)
+            .unwrap_or(true);
+
+        let bytes_step_ok = p
+            .bytes_done
+            .checked_sub(last_bytes)
+            .map(|d| d >= min_bytes_step)
+            .unwrap_or(true);
+
+        let should_emit = stage_changed || final_byte || (interval_ok && bytes_step_ok);
+        if !should_emit {
+            return;
+        }
+
+        last_emit_at = Some(now);
+        last_bytes = p.bytes_done;
+        last_stage = Some(p.stage);
+        // Failure to emit means the window has closed or no listener
+        // is attached — both are recoverable from the user's
+        // perspective, so log and proceed.
+        if let Err(e) = app.emit("hyrr://data-fetch-progress", &p) {
+            eprintln!("emit data-fetch-progress: {e}");
+        }
+    }
+}
+
+fn same_stage(a: hyrr_core::data_fetch::FetchStage, b: hyrr_core::data_fetch::FetchStage) -> bool {
+    use hyrr_core::data_fetch::FetchStage::*;
+    matches!(
+        (a, b),
+        (Connecting, Connecting)
+            | (Downloading, Downloading)
+            | (Extracting, Extracting)
+            | (Verifying, Verifying)
+    )
 }
 
 /// SSoT accessors for the data-fetch path. Each command is a thin

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -53,6 +53,7 @@ fn main() {
             commands::run_compute_stack,
             commands::compute_depth_preview,
             commands::ensure_data,
+            commands::install_from_local_tarball,
             commands::data_ready,
             commands::data_release_url,
             commands::data_release_base_url,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -65,11 +65,15 @@
   import WelcomeScreen from "./lib/components/WelcomeScreen.svelte";
   import DownloadLinks from "./lib/components/DownloadLinks.svelte";
   import UpdatePrompt from "./lib/components/UpdatePrompt.svelte";
+  import DataFetchSplash from "./lib/components/DataFetchSplash.svelte";
   import { checkForUpdate, type PendingUpdate } from "./lib/updater";
 
   let loadingState = $state("Initializing...");
   let loadingProgress = $state(0);
-  let loadingError = $state("");
+  // `loadingError` accepts the raw thrown value (string from Tauri,
+  // Error from JS) so `FetchErrorCard` / `parseFetchError` can
+  // classify it. `null` = no error yet.
+  let loadingError = $state<unknown>(null);
   let ready = $state(false);
   let pendingUpdate = $state<PendingUpdate | null>(null);
 
@@ -101,6 +105,96 @@
   initScheduler();
   initDepthPreview();
 
+  async function runInitialDataLoad(): Promise<boolean> {
+    loadingState = "Loading nuclear data...";
+    loadingProgress = 0;
+    loadingError = null;
+
+    // 5-minute ceiling. Covers first-launch downloads (~50 MB at hotel-wifi
+    // speeds is up to 5 min per the #52 spike bench). The progress callback
+    // keeps the user informed during any wait — a hard timeout is the
+    // backstop if something is genuinely wedged, not a snappiness signal.
+    const TIMEOUT_MS = 300_000;
+    try {
+      const loadPromise = initDataStore(
+        "./data/parquet",
+        (msg: string, fraction?: number) => {
+          loadingState = msg;
+          if (fraction !== undefined) loadingProgress = fraction;
+        },
+      );
+      const timeoutPromise = new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Data loading timed out after 5 min")),
+          TIMEOUT_MS,
+        ),
+      );
+      await Promise.race([loadPromise, timeoutPromise]);
+      return true;
+    } catch (e: unknown) {
+      // Keep the raw thrown value — FetchErrorCard / parseFetchError
+      // tolerate strings, Errors, or already-structured payloads.
+      loadingError = e ?? new Error("Failed to load nuclear data");
+      return false;
+    }
+  }
+
+  /** Retry the cold-cache fetch from the recovery card. Re-runs the
+   *  full post-load init only if the data load succeeds. */
+  async function retryDataLoad(): Promise<void> {
+    const ok = await runInitialDataLoad();
+    if (!ok) return;
+    await finishPostDataLoad();
+  }
+
+  async function finishPostDataLoad(): Promise<void> {
+    // Check URL for shared config — URL hash takes priority over session restore
+    const urlConfig = decodeSerializableConfigFromHash();
+    await restoreSessions();
+    if (urlConfig) restoreSerializableConfig(urlConfig);
+
+    await loadCustomMaterials();
+    try {
+      const seen = localStorage.getItem("hyrr.notice.materialSchemaBreak");
+      if (!seen) showSchemaBreakBanner = true;
+    } catch { /* no-op */ }
+
+    const densityFn = (identifier: string): number | null => {
+      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
+      return cm ? cm.density : null;
+    };
+    const compositionFn = (identifier: string): Record<string, number> | null => {
+      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
+      return cm?.massFractions ?? null;
+    };
+    setCustomDensityLookup(densityFn);
+    setCustomCompositionLookup(compositionFn);
+    setPkgCustomDensityLookup(densityFn);
+    setPkgCustomCompositionLookup(compositionFn);
+    setCustomMaterialExpander((name) => {
+      const cm = getCustomMaterials().find((m) => m.name === name);
+      return cm ? cm.formula : null;
+    });
+    setCustomMaterialResolver((identifier) => {
+      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
+      if (!cm || !cm.massFractions) return null;
+      return { density: cm.density, massFractions: cm.massFractions };
+    });
+
+    loadingState = "Ready";
+    loadingProgress = 1;
+    ready = true;
+
+    // Preload Plotly for faster popup opening
+    import("plotly.js-dist-min").catch(() => {});
+
+    // Auto-updater check — runs *after* the splash clears so a fresh
+    // install doesn't get two blocking modals at once.
+    checkForUpdate().then((u) => {
+      if (u) pendingUpdate = u;
+    });
+  }
+
   onMount(async () => {
     // Keyboard shortcuts: Cmd/Ctrl+Z = undo, Cmd/Ctrl+Shift+Z = redo
     function onKeyDown(e: KeyboardEvent) {
@@ -119,92 +213,9 @@
 
     await registerServiceWorker();
 
-    loadingState = "Loading nuclear data...";
-    loadingProgress = 0;
-
-    // 5-minute ceiling. Covers first-launch downloads (~50 MB at hotel-wifi
-    // speeds is up to 5 min per the #52 spike bench). The progress callback
-    // keeps the user informed during any wait — a hard timeout is the
-    // backstop if something is genuinely wedged, not a snappiness signal.
-    const TIMEOUT_MS = 300_000;
-    try {
-      const loadPromise = initDataStore("./data/parquet", (msg: string, fraction?: number) => {
-        loadingState = msg;
-        if (fraction !== undefined) loadingProgress = fraction;
-      });
-
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Data loading timed out after 5 min")), TIMEOUT_MS),
-      );
-
-      await Promise.race([loadPromise, timeoutPromise]);
-    } catch (e: unknown) {
-      loadingError = e instanceof Error ? e.message : "Failed to load nuclear data";
-      return;
-    }
-
-    // Check URL for shared config — URL hash takes priority over session restore
-    const urlConfig = decodeSerializableConfigFromHash();
-
-    // Restore persisted session tabs from IndexedDB
-    await restoreSessions();
-
-    // Apply URL config AFTER session restore so it isn't overwritten (#29)
-    if (urlConfig) {
-      restoreSerializableConfig(urlConfig);
-    }
-
-    // Load custom materials and register density+composition lookups on
-    // both resolvers — `./lib/compute/materials` is the older local one
-    // and `@hyrr/compute` is the shared package that components use.
-    // The 0.x material schema break (#92) drops any legacy entries that
-    // don't map cleanly; surface a one-time banner so users notice their
-    // saved customs may be gone after this deploy.
-    await loadCustomMaterials();
-    try {
-      const seen = localStorage.getItem("hyrr.notice.materialSchemaBreak");
-      if (!seen) showSchemaBreakBanner = true;
-    } catch { /* no-op */ }
-    const densityFn = (identifier: string): number | null => {
-      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
-      return cm ? cm.density : null;
-    };
-    const compositionFn = (identifier: string): Record<string, number> | null => {
-      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
-      return cm?.massFractions ?? null;
-    };
-    setCustomDensityLookup(densityFn);
-    setCustomCompositionLookup(compositionFn);
-    setPkgCustomDensityLookup(densityFn);
-    setPkgCustomCompositionLookup(compositionFn);
-    // Rust/WASM engine doesn't know custom materials — expand to formula.
-    setCustomMaterialExpander((name) => {
-      const cm = getCustomMaterials().find((m) => m.name === name);
-      return cm ? cm.formula : null;
-    });
-    // #96: when encoding share URLs, embed the layer's full composition
-    // inline so the receiver can resolve density + per-element fractions
-    // without first re-defining the custom locally.
-    setCustomMaterialResolver((identifier) => {
-      const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);
-      if (!cm || !cm.massFractions) return null;
-      return { density: cm.density, massFractions: cm.massFractions };
-    });
-
-    loadingState = "Ready";
-    loadingProgress = 1;
-    ready = true;
-
-    // Preload Plotly for faster popup opening
-    import("plotly.js-dist-min").catch(() => {});
-
-    // Auto-updater check — runs *after* the splash clears so a fresh
-    // install doesn't get two blocking modals at once (the data-fetch
-    // splash and the update prompt). On dev/web/.deb/.rpm the check
-    // short-circuits silently inside `checkForUpdate`.
-    checkForUpdate().then((u) => {
-      if (u) pendingUpdate = u;
-    });
+    const ok = await runInitialDataLoad();
+    if (!ok) return;
+    await finishPostDataLoad();
   });
 
   // Update URL hash when config changes (debounced) — includes groups
@@ -347,17 +358,12 @@
   {/if}
 
   {#if !ready}
-    <div class="loading">
-      {#if loadingError}
-        <p class="loading-error">{loadingError}</p>
-        <button class="retry-btn" onclick={() => location.reload()}>Retry</button>
-      {:else}
-        <p>{loadingState}</p>
-        <div class="progress-bar">
-          <div class="progress-fill" style="width: {loadingProgress * 100}%"></div>
-        </div>
-      {/if}
-    </div>
+    <DataFetchSplash
+      {loadingState}
+      fallbackFraction={loadingProgress}
+      {loadingError}
+      onretry={retryDataLoad}
+    />
   {:else}
     <div class="app-flow">
       <div class="config-row">
@@ -639,48 +645,8 @@
     padding: 0.5rem 1rem 2rem;
   }
 
-  .loading {
-    text-align: center;
-    padding: 4rem;
-    color: var(--c-text-muted);
-  }
-
-  .progress-bar {
-    width: 300px;
-    height: 6px;
-    background: var(--c-border);
-    border-radius: 3px;
-    margin: 1rem auto 0;
-    overflow: hidden;
-  }
-
-  .progress-fill {
-    height: 100%;
-    background: var(--c-accent);
-    border-radius: 3px;
-    transition: width 0.3s ease;
-  }
-
-  .loading-error {
-    color: var(--c-red);
-    font-weight: 500;
-  }
-
-  .retry-btn {
-    margin-top: 1rem;
-    padding: 0.5rem 1.5rem;
-    background: var(--c-bg-muted);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text);
-    cursor: pointer;
-    font-size: 0.9rem;
-  }
-
-  .retry-btn:hover {
-    border-color: var(--c-accent);
-    background: var(--c-bg-hover);
-  }
+  /* `.loading` / `.progress-bar` / `.progress-fill` / `.loading-error`
+     / `.retry-btn` styles moved to DataFetchSplash.svelte (#118). */
 
   .app-flow {
     display: flex;

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -66,6 +66,7 @@
   import DownloadLinks from "./lib/components/DownloadLinks.svelte";
   import UpdatePrompt from "./lib/components/UpdatePrompt.svelte";
   import DataFetchSplash from "./lib/components/DataFetchSplash.svelte";
+  import { getDataMode, setDataMode, resetDataMode } from "./lib/stores/data-mode.svelte";
   import { checkForUpdate, type PendingUpdate } from "./lib/updater";
 
   let loadingState = $state("Initializing...");
@@ -86,6 +87,7 @@
   let computeError = $derived(getComputeError());
   let resultError = $derived(getResultError());
   let historyOpen = $derived(getHistoryOpen());
+  let dataMode = $derived(getDataMode());
 
   // Popup state
   let materialPopupOpen = $state(false);
@@ -142,8 +144,20 @@
   /** Retry the cold-cache fetch from the recovery card. Re-runs the
    *  full post-load init only if the data load succeeds. */
   async function retryDataLoad(): Promise<void> {
+    resetDataMode();
     const ok = await runInitialDataLoad();
     if (!ok) return;
+    await finishPostDataLoad();
+  }
+
+  /** "Use bundled data only" — accept the partial cache (meta/+stopping/+
+   *  catalog/+suppliers) and proceed past the splash. Yield computation
+   *  is gated, but depth preview, material picker, layer config and the
+   *  catalog browse still work. The banner-mounted "Fetch now" button
+   *  re-runs the original init flow. */
+  async function useLimitedMode(): Promise<void> {
+    setDataMode("limited");
+    loadingError = null;
     await finishPostDataLoad();
   }
 
@@ -340,6 +354,20 @@
 <main>
   <HeaderBar />
 
+  {#if ready && dataMode === "limited"}
+    <div class="limited-banner" role="status">
+      <span>
+        <strong>Limited mode</strong> — running with bundled stopping-power data only.
+        Yield computation is unavailable until you fetch full nuclear data.
+      </span>
+      <div class="limited-actions">
+        <button type="button" class="limited-fetch" onclick={retryDataLoad}>
+          Fetch now
+        </button>
+      </div>
+    </div>
+  {/if}
+
   {#if showSchemaBreakBanner}
     <div class="schema-break-banner" role="status">
       <span>
@@ -363,6 +391,7 @@
       fallbackFraction={loadingProgress}
       {loadingError}
       onretry={retryDataLoad}
+      onuselimited={useLimitedMode}
     />
   {:else}
     <div class="app-flow">
@@ -520,6 +549,33 @@
     border-radius: 3px;
   }
   .schema-break-close:hover { color: var(--c-text); background: var(--c-bg-default); }
+  .limited-banner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+    background: var(--c-gold-tint, var(--c-bg-muted));
+    color: var(--c-text);
+    padding: 0.5rem 0.9rem;
+    font-size: 0.82rem;
+    border-bottom: 1px solid var(--c-border);
+  }
+  .limited-actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+  .limited-fetch {
+    padding: 0.25rem 0.7rem;
+    background: var(--c-accent);
+    color: #fff;
+    border: 1px solid transparent;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 0.78rem;
+  }
+  .limited-fetch:hover {
+    background: var(--c-accent-hover);
+  }
   /* ─── Theme tokens ─── */
   :global(:root),
   :global([data-theme="dark"]) {

--- a/frontend/src/lib/components/DataFetchSplash.svelte
+++ b/frontend/src/lib/components/DataFetchSplash.svelte
@@ -1,0 +1,162 @@
+<script lang="ts">
+  /**
+   * Data-fetch splash with progress events (#118).
+   *
+   * Listens for `hyrr://data-fetch-progress` over Tauri IPC (browser
+   * mode silently no-ops — we still render the high-level loading
+   * message but no per-stage progress). Renders a determinate
+   * `<progress>` bar when `bytes_total` is known, an indeterminate one
+   * otherwise.
+   *
+   * On error, mounts the `FetchErrorCard` (parsed via
+   * `parseFetchError`) with retry / open-URL / install / use-bundled
+   * actions.
+   */
+  import { onMount, onDestroy } from "svelte";
+  import { isTauri } from "../utils/platform";
+  import FetchErrorCard from "./FetchErrorCard.svelte";
+  import { parseFetchError } from "../utils/parse-fetch-error";
+
+  type Props = {
+    /** High-level loading text (the "Loading nuclear data…" copy from
+     *  App.svelte). Independent from the per-stage label coming from
+     *  Rust events. */
+    loadingState: string;
+    /** Coarse fraction (0..1) for the legacy progress channel that
+     *  the WASM/TS path still drives via the
+     *  `initDataStore(_, onProgress)` callback. The Rust progress
+     *  bar takes precedence when its events arrive. */
+    fallbackFraction: number;
+    /** Raw error from the init flow, if any. Strings (Tauri) and
+     *  Errors (network/timeout) both supported. */
+    loadingError: unknown | null;
+    onretry: () => void;
+    onuselimited?: () => void;
+  };
+  let {
+    loadingState,
+    fallbackFraction,
+    loadingError,
+    onretry,
+    onuselimited,
+  }: Props = $props();
+
+  type RustProgress = {
+    stage: "connecting" | "downloading" | "extracting" | "verifying";
+    bytes_done: number;
+    bytes_total: number | null;
+  };
+  let rustProgress = $state<RustProgress | null>(null);
+  let unsubscribe: (() => void) | null = null;
+
+  onMount(async () => {
+    if (!isTauri()) return;
+    try {
+      const { listen } = await import("@tauri-apps/api/event");
+      unsubscribe = await listen<RustProgress>(
+        "hyrr://data-fetch-progress",
+        (e) => {
+          rustProgress = e.payload;
+        },
+      );
+    } catch (e) {
+      // No-op — splash falls back to the legacy fraction-based bar.
+      console.warn("[splash] failed to subscribe to data-fetch-progress:", e);
+    }
+  });
+
+  onDestroy(() => {
+    unsubscribe?.();
+  });
+
+  const stageLabel = $derived(
+    rustProgress
+      ? rustProgress.stage === "connecting"
+        ? "Connecting…"
+        : rustProgress.stage === "downloading"
+          ? "Downloading nuclear data…"
+          : rustProgress.stage === "extracting"
+            ? "Extracting…"
+            : "Finalising…"
+      : loadingState,
+  );
+
+  const determinate = $derived(
+    rustProgress != null && (rustProgress.bytes_total ?? 0) > 0,
+  );
+  const fraction = $derived(
+    rustProgress && rustProgress.bytes_total
+      ? Math.min(1, rustProgress.bytes_done / rustProgress.bytes_total)
+      : fallbackFraction,
+  );
+  const sizeHint = $derived(
+    rustProgress && rustProgress.bytes_total
+      ? `${formatMib(rustProgress.bytes_done)} / ${formatMib(rustProgress.bytes_total)} MiB`
+      : null,
+  );
+
+  function formatMib(n: number): string {
+    return (n / 1_048_576).toFixed(1);
+  }
+
+  const parsedError = $derived(loadingError ? parseFetchError(loadingError) : null);
+</script>
+
+<div class="loading">
+  {#if parsedError}
+    <FetchErrorCard error={parsedError} {onretry} {onuselimited} />
+  {:else}
+    <p class="stage" data-testid="splash-stage">{stageLabel}</p>
+    <div class="progress-bar" class:indeterminate={!determinate}>
+      <div
+        class="progress-fill"
+        style="width: {determinate ? fraction * 100 : 100}%"
+      ></div>
+    </div>
+    {#if sizeHint}
+      <p class="size-hint" data-testid="splash-size">{sizeHint}</p>
+    {/if}
+  {/if}
+</div>
+
+<style>
+  .loading {
+    text-align: center;
+    padding: 4rem 1rem;
+    color: var(--c-text-muted);
+  }
+  .stage {
+    margin: 0 0 1rem;
+  }
+  .progress-bar {
+    width: 300px;
+    height: 6px;
+    background: var(--c-border);
+    border-radius: 3px;
+    margin: 0 auto;
+    overflow: hidden;
+    position: relative;
+  }
+  .progress-fill {
+    height: 100%;
+    background: var(--c-accent);
+    border-radius: 3px;
+    transition: width 0.3s ease;
+  }
+  .progress-bar.indeterminate {
+    overflow: hidden;
+  }
+  .progress-bar.indeterminate .progress-fill {
+    width: 33% !important;
+    animation: slide 1.4s ease-in-out infinite;
+  }
+  @keyframes slide {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(300%); }
+  }
+  .size-hint {
+    margin: 0.5rem 0 0;
+    font-size: 0.8rem;
+    color: var(--c-text-faint);
+  }
+</style>

--- a/frontend/src/lib/components/FetchErrorCard.svelte
+++ b/frontend/src/lib/components/FetchErrorCard.svelte
@@ -1,0 +1,260 @@
+<script lang="ts">
+  /**
+   * Recovery card for cold-cache data-fetch failures (#118).
+   *
+   * Layout per the locked spike: title from variant, "Tried" URL row
+   * (when the variant carries one), "Cache at" row, four action
+   * buttons (Retry / Open URL / Install from local… / Use bundled),
+   * and a CLI fallback hint.
+   *
+   * The two desktop-only buttons (Install + Use bundled) are hidden
+   * in browser mode via `isTauri()`. Browser users can't install
+   * local tarballs and don't have a managed cache to "use bundled"
+   * against — they fall back to retry / open URL only.
+   */
+  import { onMount } from "svelte";
+  import {
+    type ParsedFetchError,
+    fetchErrorTitle,
+  } from "../utils/parse-fetch-error";
+  import { openExternalUrl } from "../utils/open-url";
+  import { isTauri } from "../utils/platform";
+  import {
+    getReleaseUrl,
+    getCacheRootPattern,
+    getTarballFilename,
+  } from "../compute/data-fetch-meta";
+
+  type Props = {
+    error: ParsedFetchError;
+    onretry: () => void;
+    onuselimited?: () => void;
+  };
+  let { error, onretry, onuselimited }: Props = $props();
+
+  // SSoT-resolved values (Tauri only). Browser mode falls through to
+  // the URL/cache_dir already in the error payload (if any) — both are
+  // also synthesised by the Rust side from the same SSoT helper, so
+  // they're identical-by-construction.
+  let releaseUrl = $state<string | null>(null);
+  let cacheRoot = $state<string | null>(null);
+  let tarballName = $state<string | null>(null);
+
+  onMount(async () => {
+    [releaseUrl, cacheRoot, tarballName] = await Promise.all([
+      getReleaseUrl(),
+      getCacheRootPattern(),
+      getTarballFilename(),
+    ]);
+  });
+
+  const desktop = $derived(isTauri());
+
+  const triedUrl = $derived(
+    error.kind === "FetchError" &&
+      (error.variant === "HttpStatus" || error.variant === "Network")
+      ? error.url
+      : (releaseUrl ?? ""),
+  );
+  const cacheDirDisplay = $derived(
+    error.kind === "FetchError" && "cache_dir" in error ? error.cache_dir : (cacheRoot ?? ""),
+  );
+
+  let busy = $state(false);
+  let installError = $state<string | null>(null);
+
+  async function onOpenUrl() {
+    if (!triedUrl) return;
+    await openExternalUrl(triedUrl);
+  }
+
+  async function onInstallLocal() {
+    if (!desktop) return;
+    busy = true;
+    installError = null;
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const filterName = tarballName ? `Tarball (${tarballName})` : "Tarball";
+      const path = await open({
+        multiple: false,
+        directory: false,
+        filters: [
+          { name: filterName, extensions: ["zst", "tar.zst"] },
+          { name: "All files", extensions: ["*"] },
+        ],
+      });
+      if (typeof path !== "string" || !path) return;
+
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke<string>("install_from_local_tarball", { path });
+      // On success, kick the parent to retry the init flow — the
+      // cache is now populated and the next ensure_data short-circuits.
+      onretry();
+    } catch (e) {
+      installError = e instanceof Error ? e.message : String(e);
+    } finally {
+      busy = false;
+    }
+  }
+
+  function onUseBundled() {
+    onuselimited?.();
+  }
+</script>
+
+<div class="error-card" role="alert" aria-live="assertive">
+  <header class="error-card-header">
+    <span class="badge">{fetchErrorTitle(error)}</span>
+    <span class="variant-tag">{
+      error.kind === "FetchError" ? error.variant : "Unknown"
+    }</span>
+  </header>
+
+  {#if triedUrl || cacheDirDisplay}
+    <section class="data-points">
+      <dl>
+        {#if triedUrl}
+          <dt>Tried</dt>
+          <dd><code>{triedUrl}</code></dd>
+        {/if}
+        {#if cacheDirDisplay}
+          <dt>Cache at</dt>
+          <dd><code>{cacheDirDisplay}</code></dd>
+        {/if}
+      </dl>
+    </section>
+  {/if}
+
+  <section class="explanation">
+    <p class="message">{error.message || fetchErrorTitle(error)}</p>
+    {#if installError}
+      <p class="install-error">Install failed: <code>{installError}</code></p>
+    {/if}
+  </section>
+
+  <footer class="actions">
+    <button type="button" class="primary" onclick={onretry} disabled={busy}>
+      Retry
+    </button>
+    {#if triedUrl}
+      <button type="button" onclick={onOpenUrl} disabled={busy}>
+        Open URL in browser
+      </button>
+    {/if}
+    {#if desktop}
+      <button type="button" onclick={onInstallLocal} disabled={busy}>
+        Install from local tarball…
+      </button>
+      {#if onuselimited}
+        <button type="button" onclick={onUseBundled} disabled={busy}>
+          Use bundled data only
+        </button>
+      {/if}
+    {/if}
+  </footer>
+
+  {#if tarballName}
+    <p class="cli-hint">
+      Or from a terminal: <code>hyrr fetch-data --offline-bundle path/to/{tarballName}</code>
+    </p>
+  {/if}
+</div>
+
+<style>
+  .error-card {
+    border: 1px solid var(--c-red, #d23f3f);
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+    background: var(--c-red-tint-subtle, rgba(210, 63, 63, 0.06));
+    margin: 1rem auto;
+    max-width: 720px;
+    font-size: 0.95rem;
+    color: var(--c-text);
+  }
+  .error-card-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+  }
+  .badge {
+    font-weight: 600;
+    color: var(--c-red, #d23f3f);
+    font-size: 1rem;
+  }
+  .variant-tag {
+    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
+    font-size: 0.78rem;
+    background: var(--c-bg-default, #fff);
+    border: 1px solid var(--c-border);
+    padding: 0.05rem 0.4rem;
+    border-radius: 3px;
+    color: var(--c-text-muted);
+  }
+  .data-points dl {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0.15rem 0.75rem;
+    margin: 0.5rem 0;
+  }
+  .data-points dt {
+    font-weight: 500;
+    color: var(--c-text-muted);
+  }
+  .data-points dd {
+    margin: 0;
+    word-break: break-all;
+  }
+  .data-points code,
+  .cli-hint code {
+    font-family: ui-monospace, "JetBrains Mono", Menlo, monospace;
+    font-size: 0.85rem;
+    color: var(--c-text);
+  }
+  .explanation .message {
+    margin: 0.5rem 0;
+    line-height: 1.4;
+  }
+  .install-error {
+    color: var(--c-red, #d23f3f);
+    margin: 0.4rem 0 0;
+    font-size: 0.85rem;
+  }
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+  }
+  .actions button {
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    background: var(--c-bg-default);
+    color: var(--c-text);
+    cursor: pointer;
+    font-size: 0.9rem;
+  }
+  .actions button:hover {
+    border-color: var(--c-accent);
+    background: var(--c-bg-hover);
+  }
+  .actions button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  .actions button.primary {
+    background: var(--c-accent);
+    color: #fff;
+    border-color: transparent;
+  }
+  .actions button.primary:hover {
+    background: var(--c-accent-hover);
+  }
+  .cli-hint {
+    margin: 0.75rem 0 0;
+    font-size: 0.78rem;
+    color: var(--c-text-muted);
+  }
+</style>

--- a/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
+++ b/frontend/src/lib/scheduler/sim-scheduler.svelte.ts
@@ -18,6 +18,7 @@ import {
   setResultErrored,
   type SimStatus,
 } from "../stores/results.svelte";
+import { getDataMode } from "../stores/data-mode.svelte";
 import { parseComputeError } from "../compute/parse-error";
 import { configHash } from "./config-hash";
 import { DataStore } from "@hyrr/compute";
@@ -125,6 +126,24 @@ async function runSimulation(hash: string): Promise<void> {
   // getConfig() returns already-expanded flat layers (groups resolved by config store)
   const config = getConfig();
   cancelled = false;
+
+  // #118 — in limited mode (user clicked "Use bundled data only" on
+  // the recovery card) the cache has meta/stopping/catalog only; XS
+  // data for *any* library is missing, so a real run would error
+  // deep inside the data backend. Short-circuit with a typed error
+  // that the existing #142 / #143 recovery surfaces render cleanly.
+  if (getDataMode() === "limited") {
+    state = "error";
+    const err = {
+      kind: "Unknown" as const,
+      message:
+        "Limited mode — fetch full nuclear data to enable yield computation. Depth preview still works.",
+    };
+    setResultErrored(new Error(err.message));
+    setComputeError(err);
+    lastHash = hash;
+    return;
+  }
 
   try {
     if (!backendReady) {

--- a/frontend/src/lib/stores/data-mode.svelte.ts
+++ b/frontend/src/lib/stores/data-mode.svelte.ts
@@ -1,0 +1,39 @@
+/**
+ * Data-mode store (#118).
+ *
+ * `"full"` (default): nuclear-data cache is populated and yield
+ * computation works as normal.
+ *
+ * `"limited"`: user clicked "Use bundled data only" in the recovery
+ * card. The bundled `meta/` + `stopping/` + catalog/suppliers JSONs
+ * are present (seeded by `seed_cache_from_resources` on first launch)
+ * so material picking, layer config, and depth preview all work — but
+ * cross-section data for any library is missing, so `runSimulation`
+ * short-circuits with a typed error rendered by `ActivityTableEnhanced`'s
+ * empty state. The user can click "Fetch now" in the top banner to
+ * re-run the original init flow.
+ */
+import { setError } from "./results.svelte";
+
+export type DataMode = "full" | "limited";
+
+let mode = $state<DataMode>("full");
+
+export function getDataMode(): DataMode {
+  return mode;
+}
+
+export function setDataMode(m: DataMode): void {
+  mode = m;
+  if (m === "limited") {
+    // Surface a sensible status to the existing #142 / #143 error
+    // recovery card. The setResultErrored / setComputeError pair is
+    // for compute-time errors with rich variant data; for limited
+    // mode a plain message is fine.
+    setError("Limited mode — fetch nuclear data to enable yield computation");
+  }
+}
+
+export function resetDataMode(): void {
+  mode = "full";
+}

--- a/frontend/src/lib/utils/parse-fetch-error.test.ts
+++ b/frontend/src/lib/utils/parse-fetch-error.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseFetchError,
+  fetchErrorTitle,
+  type FetchErrorPayload,
+} from "./parse-fetch-error";
+
+describe("parseFetchError — every Rust variant round-trips", () => {
+  it("classifies HttpStatus from a structured payload", () => {
+    const payload = {
+      kind: "FetchError",
+      variant: "HttpStatus",
+      status: 404,
+      url: "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst",
+      cache_dir: "/Users/x/.hyrr/nucl-parquet/v0.10.0",
+      message: "HTTP 404",
+    };
+    const result = parseFetchError(payload);
+    expect(result.kind).toBe("FetchError");
+    if (result.kind !== "FetchError" || result.variant !== "HttpStatus") {
+      throw new Error("expected HttpStatus variant");
+    }
+    expect(result.status).toBe(404);
+    expect(result.url).toContain("nucl-parquet-data-v0.10.0.tar.zst");
+    expect(result.cache_dir).toContain(".hyrr");
+  });
+
+  it("classifies Network", () => {
+    const payload = {
+      kind: "FetchError",
+      variant: "Network",
+      detail: "dns lookup failed",
+      url: "https://example.com/x.tar.zst",
+      cache_dir: "/home/x/.hyrr/nucl-parquet/v0.10.0",
+      message: "network error: dns lookup failed",
+    };
+    const result = parseFetchError(payload);
+    if (result.kind !== "FetchError" || result.variant !== "Network") {
+      throw new Error("expected Network variant");
+    }
+    expect(result.detail).toBe("dns lookup failed");
+    expect(result.url).toContain("https://");
+  });
+
+  it("classifies Decompress", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "Decompress",
+      cache_dir: "/h/.hyrr/nucl-parquet/v0.10.0",
+      message: "zstd: bad magic",
+    });
+    if (result.kind !== "FetchError" || result.variant !== "Decompress") {
+      throw new Error("expected Decompress variant");
+    }
+    expect(result.message).toContain("zstd");
+  });
+
+  it("classifies Extract", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "Extract",
+      cache_dir: "/h/.hyrr/nucl-parquet/v0.10.0",
+      message: "unexpected eof",
+    });
+    if (result.kind !== "FetchError" || result.variant !== "Extract") {
+      throw new Error("expected Extract variant");
+    }
+    expect(result.cache_dir).toContain(".hyrr");
+  });
+
+  it("classifies UnsafeTarballEntry", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "UnsafeTarballEntry",
+      entry_kind: "Symlink",
+      entry_path: "data/meta/evil",
+      cache_dir: "/h/.hyrr/nucl-parquet/v0.10.0",
+      message: "unsafe tarball entry Symlink at data/meta/evil",
+    });
+    if (
+      result.kind !== "FetchError" ||
+      result.variant !== "UnsafeTarballEntry"
+    ) {
+      throw new Error("expected UnsafeTarballEntry variant");
+    }
+    expect(result.entry_kind).toBe("Symlink");
+    expect(result.entry_path).toBe("data/meta/evil");
+  });
+
+  it("classifies Io", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "Io",
+      cache_dir: "/h/.hyrr/nucl-parquet/v0.10.0",
+      message: "insufficient disk space: have 2 MiB free, need at least 1024 MiB",
+    });
+    if (result.kind !== "FetchError" || result.variant !== "Io") {
+      throw new Error("expected Io variant");
+    }
+    expect(result.message).toContain("disk space");
+  });
+
+  it("classifies NoHome (no url / cache_dir)", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "NoHome",
+      message: "HOME environment variable not set",
+    });
+    if (result.kind !== "FetchError" || result.variant !== "NoHome") {
+      throw new Error("expected NoHome variant");
+    }
+    expect(result.message).toContain("HOME");
+  });
+});
+
+describe("parseFetchError — fallbacks", () => {
+  it("parses a JSON-string payload (Tauri Result<_, String> shape)", () => {
+    const json = JSON.stringify({
+      kind: "FetchError",
+      variant: "HttpStatus",
+      status: 503,
+      url: "https://e/a.tar.zst",
+      cache_dir: "/h/.hyrr/nucl-parquet/v0.10.0",
+      message: "HTTP 503",
+    });
+    const result = parseFetchError(json);
+    if (result.kind !== "FetchError" || result.variant !== "HttpStatus") {
+      throw new Error("expected HttpStatus from JSON string");
+    }
+    expect(result.status).toBe(503);
+  });
+
+  it("falls back to unknown for non-JSON strings", () => {
+    const result = parseFetchError("ensure_meta_stopping: io error: foo");
+    expect(result.kind).toBe("unknown");
+    expect(result.message).toContain("ensure_meta_stopping");
+  });
+
+  it("falls back to unknown for plain Error instances", () => {
+    const result = parseFetchError(new Error("Failed to load nuclear data"));
+    expect(result.kind).toBe("unknown");
+    expect(result.message).toContain("Failed to load nuclear data");
+  });
+
+  it("falls back to unknown for an unrecognised variant", () => {
+    const result = parseFetchError({
+      kind: "FetchError",
+      variant: "TotallyMadeUpVariant",
+      message: "x",
+    });
+    expect(result.kind).toBe("unknown");
+  });
+
+  it("falls back to unknown for null / undefined", () => {
+    expect(parseFetchError(null).kind).toBe("unknown");
+    expect(parseFetchError(undefined).kind).toBe("unknown");
+  });
+
+  it("falls back to unknown for a non-FetchError object", () => {
+    const result = parseFetchError({ kind: "StoppingError", message: "x" });
+    expect(result.kind).toBe("unknown");
+  });
+});
+
+describe("fetchErrorTitle — variant-aware copy for support triage", () => {
+  type Case = [FetchErrorPayload, string];
+  const cases: Case[] = [
+    [
+      {
+        kind: "FetchError",
+        variant: "HttpStatus",
+        status: 404,
+        url: "x",
+        cache_dir: "x",
+        message: "",
+      },
+      "HTTP 404",
+    ],
+    [
+      {
+        kind: "FetchError",
+        variant: "Network",
+        detail: "x",
+        url: "x",
+        cache_dir: "x",
+        message: "",
+      },
+      "reach",
+    ],
+    [
+      {
+        kind: "FetchError",
+        variant: "Decompress",
+        cache_dir: "x",
+        message: "",
+      },
+      "decompress",
+    ],
+    [
+      { kind: "FetchError", variant: "Extract", cache_dir: "x", message: "" },
+      "extract",
+    ],
+    [
+      { kind: "FetchError", variant: "Io", cache_dir: "x", message: "" },
+      "write",
+    ],
+    [{ kind: "FetchError", variant: "NoHome", message: "" }, "home"],
+  ];
+
+  for (const [payload, fragment] of cases) {
+    it(`includes "${fragment}" for ${payload.variant}`, () => {
+      const title = fetchErrorTitle(payload);
+      expect(title.toLowerCase()).toContain(fragment.toLowerCase());
+    });
+  }
+
+  it("provides a generic title for unknown errors", () => {
+    expect(fetchErrorTitle({ kind: "unknown", message: "x" })).toContain(
+      "Couldn't download",
+    );
+  });
+});

--- a/frontend/src/lib/utils/parse-fetch-error.ts
+++ b/frontend/src/lib/utils/parse-fetch-error.ts
@@ -1,0 +1,207 @@
+/**
+ * Parse a thrown / returned data-fetch error into a typed
+ * {@link FetchErrorPayload}.
+ *
+ * Mirrors the Rust-side `hyrr_core::data_fetch::FetchErrorPayload` chain
+ * (see #118 / #157). The Tauri `ensure_data` and
+ * `install_from_local_tarball` commands return their `Err(_)` arm as a
+ * JSON-encoded payload string; this parser handles three shapes:
+ *
+ * 1. Structured object — `{kind: "FetchError", variant, ...}`.
+ * 2. JSON string — `JSON.parse` into shape 1.
+ * 3. Anything else — opaque legacy/unknown error; we surface the raw
+ *    text under `kind: "unknown"` so the recovery card can still
+ *    render a generic message + the bug-report fallback.
+ */
+
+export type FetchErrorPayload =
+  | {
+      kind: "FetchError";
+      variant: "HttpStatus";
+      status: number;
+      url: string;
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "Network";
+      detail: string;
+      url: string;
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "Decompress";
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "Extract";
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "UnsafeTarballEntry";
+      entry_kind: string;
+      entry_path: string;
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "Io";
+      cache_dir: string;
+      message: string;
+    }
+  | {
+      kind: "FetchError";
+      variant: "NoHome";
+      message: string;
+    };
+
+export type ParsedFetchError =
+  | FetchErrorPayload
+  | { kind: "unknown"; message: string };
+
+export function parseFetchError(raw: unknown): ParsedFetchError {
+  const fromObj = tryStructured(raw);
+  if (fromObj) return fromObj;
+
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw);
+      const fromString = tryStructured(parsed);
+      if (fromString) return fromString;
+    } catch {
+      // not JSON — fall through to unknown
+    }
+    return { kind: "unknown", message: raw };
+  }
+
+  if (raw instanceof Error) {
+    try {
+      const parsed = JSON.parse(raw.message);
+      const fromString = tryStructured(parsed);
+      if (fromString) return fromString;
+    } catch {
+      // not JSON
+    }
+    return { kind: "unknown", message: raw.message };
+  }
+
+  if (raw && typeof raw === "object") {
+    const m = (raw as { message?: unknown }).message;
+    return {
+      kind: "unknown",
+      message: m != null ? String(m) : JSON.stringify(raw),
+    };
+  }
+
+  return { kind: "unknown", message: String(raw ?? "Unknown fetch error") };
+}
+
+function tryStructured(raw: unknown): FetchErrorPayload | null {
+  if (!raw || typeof raw !== "object") return null;
+  const o = raw as Record<string, unknown>;
+  if (o.kind !== "FetchError") return null;
+  const variant = o.variant;
+  const message = str(o.message);
+
+  if (variant === "HttpStatus") {
+    return {
+      kind: "FetchError",
+      variant: "HttpStatus",
+      status: num(o.status),
+      url: str(o.url),
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "Network") {
+    return {
+      kind: "FetchError",
+      variant: "Network",
+      detail: str(o.detail),
+      url: str(o.url),
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "Decompress") {
+    return {
+      kind: "FetchError",
+      variant: "Decompress",
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "Extract") {
+    return {
+      kind: "FetchError",
+      variant: "Extract",
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "UnsafeTarballEntry") {
+    return {
+      kind: "FetchError",
+      variant: "UnsafeTarballEntry",
+      entry_kind: str(o.entry_kind),
+      entry_path: str(o.entry_path),
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "Io") {
+    return {
+      kind: "FetchError",
+      variant: "Io",
+      cache_dir: str(o.cache_dir),
+      message,
+    };
+  }
+  if (variant === "NoHome") {
+    return {
+      kind: "FetchError",
+      variant: "NoHome",
+      message,
+    };
+  }
+  return null;
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+function num(v: unknown): number {
+  return typeof v === "number" ? v : Number(v) || 0;
+}
+
+/** Title for the recovery-card header — variant-specific for support
+ *  triage but bounded to "Couldn't download nuclear data — …". */
+export function fetchErrorTitle(err: ParsedFetchError): string {
+  if (err.kind === "unknown") {
+    return "Couldn't download nuclear data";
+  }
+  switch (err.variant) {
+    case "HttpStatus":
+      return `Couldn't download nuclear data — HTTP ${err.status}`;
+    case "Network":
+      return "Couldn't reach the nuclear-data server";
+    case "Decompress":
+      return "Downloaded archive failed to decompress";
+    case "Extract":
+      return "Downloaded archive failed to extract";
+    case "UnsafeTarballEntry":
+      return "Downloaded archive contained an unsafe entry";
+    case "Io":
+      return "Couldn't write nuclear data to disk";
+    case "NoHome":
+      return "Couldn't locate user home directory";
+  }
+}


### PR DESCRIPTION
## Summary

Implements the locked spike from #118: typed `FetchProgress` callback through the cache-fetch pipeline, push-based progress events over Tauri IPC (`hyrr://data-fetch-progress`), a 4-button recovery card on first-launch download failure, and a "limited mode" escape hatch for users who want to proceed without fetching nuclear data.

Locked design + decision matrix: see the spike comment dated 2026-05-07 16:23:25 on https://github.com/exoma-ch/hyrr/issues/118 — implementation maps 1:1 to the 5-commit plan there. SSoT contract from #157 honoured throughout (no new hardcoded URL/path literals).

## What landed

- **`feat(core)`**: `FetchProgress { stage, bytes_done, bytes_total }` + `FetchStage { Connecting, Downloading, Extracting, Verifying }` + `FetchErrorPayload` (typed wire-shape with `From<&FetchError>`). `*_with_progress` variants of `fetch_full_tarball_to`, `extract_tarball`, `ensure_meta_stopping`, `ensure_library`, `ensure_all`, `install_from_tarball`. Existing entry points keep no-op signatures via thin delegators — py / MCP / CLI callers untouched.
- **`feat(desktop)`**: `ensure_data` now takes `AppHandle`, builds a throttled-emit closure (≤10 emits/sec, stage-aware bytes gate), returns `FetchErrorPayload` JSON on Err. New `install_from_local_tarball` command for the recovery card's "Install from local" button. No new Tauri capabilities — `dialog:default` and `opener:default` already covered.
- **`feat(frontend)`**: `DataFetchSplash.svelte` lifted out of `App.svelte`, listens for `hyrr://data-fetch-progress` and renders a stage-aware progress bar. `FetchErrorCard.svelte` 4-button layout (Retry / Open URL / Install from local / Use bundled), Tauri-only buttons hidden via `isTauri()`. `parse-fetch-error.ts` mirrors every Rust `FetchErrorPayload` variant + JSON-string + plain-Error fallbacks.
- **`feat(frontend)`**: limited-mode store + scheduler gate + top banner with "Fetch now" → re-runs the original init flow.
- **`test(frontend)`**: 20 new tests covering every variant + 6 fallback paths + 7 title-triage cases.
- **`fix(desktop)`**: throttle bug found during the privacy/IPC review round — bytes-step gate was starving the Extracting stage of UI updates because entry counts never cross 256 KiB. Now gated per-stage.

## Test counts

- Rust: 23 `data_fetch` lib tests pass (was 17 before; +4 progress / +2 payload / pre-existing `data_version_is_resolved_from_submodule` is environmental and skipped in this env).
- Frontend: 466 vitest tests pass (was 446; +20 new in `parse-fetch-error.test.ts`).
- svelte-check: 0 new errors / 0 new warnings introduced. The 3 pre-existing errors on missing `@tauri-apps/plugin-{opener,updater,process}` packages are unrelated.

## Reviews run before opening this PR

- **Round 1 — implementation match (impl-vs-spike)**: every P0 acceptance item present and accounted for. Component-render tests for `FetchErrorCard` / `DataFetchSplash` deferred (no jsdom in dev-deps; would be scope creep). Pure-function logic covered.
- **Round 2 — privacy / IPC-boundary**: payload audit clean (no env vars, no auth tokens, no fs paths beyond `~/.hyrr/...`); throttle bound to ≤10 emits/sec ⇒ no IPC flooding; capabilities scope unchanged. **One bug found and fixed in `desktop/src-tauri/src/commands.rs`** — see `7c5a401`.

## Deferred to follow-ups

- E2E coverage of `ensure_data` failure → recovery flow (#148 Tier 3, tauri-driver).
- Component-render unit tests for `FetchErrorCard` / `DataFetchSplash` (would require adding `@testing-library/svelte` + jsdom to dev-deps; happy to file a follow-up if reviewers want this).
- CLI progress bar (`hyrr fetch-data` could now use the same callback to drive `indicatif`).
- Drag-drop tarball install (file dialog covers the same surface; drop-zone is incremental).

## Test plan

- [ ] On a fresh macOS install, block `github.com` via `/etc/hosts`, launch the desktop app, confirm splash shows the `Network` variant card with the canonical URL visible.
- [ ] Click "Install from local…", pick a real `nucl-parquet-data-vN.N.N.tar.zst`, confirm the install succeeds and the app proceeds.
- [ ] Click "Use bundled data only", confirm the limited-mode banner mounts, depth preview still works, yield computation surfaces a typed Limited-mode error in the activity table.
- [ ] During a real cold-cache fetch, confirm the splash shows `Connecting` → `Downloading XX.X / 380.0 MiB` → `Extracting` → `Finalising` and the progress bar advances smoothly without flooding the dev console.

Refs: #118