### PR TITLE
test(e2e/170): update material specs to match #92/#98/#132 UI rename

### DIFF
--- a/frontend/e2e/material-define-rows.spec.ts
+++ b/frontend/e2e/material-define-rows.spec.ts
@@ -25,32 +25,34 @@ test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
 
     // First "+ element" → PT modal.
     await page.getByRole("button", { name: "+ element" }).click();
-    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeVisible();
+    await expect(page.getByRole("dialog", { name: "Compose mixture" })).toBeVisible();
 
-    // Click Fe (Z=26).
+    // Click Fe (Z=26). Picker is stays-open (#92) — close it via Done.
     await page.locator('[data-z="26"]').click();
-    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeHidden();
+    await page.getByRole("button", { name: /^Done$/ }).click();
+    await expect(page.getByRole("dialog", { name: "Compose mixture" })).toBeHidden();
 
-    // §3.4 contract: focus lands on the new row's value input.
+    // Fill 50 in the Fe row's value input.
     const feValueInput = page
       .locator('[role="row"][data-row-id]')
       .filter({ hasText: "Fe" })
       .locator(".value-input");
-    await expect(feValueInput).toBeFocused();
-    await page.keyboard.type("50");
+    await feValueInput.fill("50");
 
-    // Second "+ element" → PT modal → pick Cu (Z=29).
+    // Second "+ element" → PT modal → pick Cu (Z=29) → Done.
     await page.getByRole("button", { name: "+ element" }).click();
     await page.locator('[data-z="29"]').click();
-    await expect(page.getByRole("dialog", { name: "Pick an element" })).toBeHidden();
+    await page.getByRole("button", { name: /^Done$/ }).click();
+    await expect(page.getByRole("dialog", { name: "Compose mixture" })).toBeHidden();
 
-    // Mark the Cu row as balance.
+    // Mark the Cu row as balance (checkbox per #92 redesign).
     const cuRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "Cu" });
-    await cuRow.getByRole("radio").check();
+    await cuRow.getByRole("checkbox").check();
 
-    // Density auto-fills from the mass-ratio computation; just verify the
-    // Save button is enabled and click it.
-    const saveBtn = page.getByRole("button", { name: /Save & Use/ });
+    // Density renders as a suggestion (#92) — accept it via "Use n.nn".
+    const saveBtn = page.getByRole("button", { name: /^Save & Use$/ });
+    await expect(saveBtn).toBeDisabled();
+    await page.getByRole("button", { name: /Use \d/ }).click();
     await expect(saveBtn).toBeEnabled();
     await saveBtn.click();
 
@@ -64,14 +66,14 @@ test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
     await page.getByRole("button", { name: /Define.*save material/ }).click();
 
-    const paste = page.getByPlaceholder(/Al2O3.*Al 80/);
+    const paste = page.getByPlaceholder(/Al2O3/);
     await paste.fill("Al 80%, Cu 5%, Zn %");
     await paste.blur();
 
     // Expect three rows.
     await expect(page.locator('[role="row"][data-row-id]')).toHaveCount(3);
-    // Zn row should be marked as balance (radio checked).
+    // Zn row should be marked as balance (checkbox checked per #92 redesign).
     const znRow = page.locator('[role="row"][data-row-id]').filter({ hasText: "Zn" });
-    await expect(znRow.getByRole("radio")).toBeChecked();
+    await expect(znRow.getByRole("checkbox")).toBeChecked();
   });
 });

--- a/frontend/e2e/material-form-redesign.spec.ts
+++ b/frontend/e2e/material-form-redesign.spec.ts
@@ -15,7 +15,7 @@ test.describe("Material-form redesign (#92)", () => {
     await waitReady(page);
   });
 
-  test("paste 'SiO2 80%, H2O 20%' → mode flips to Mass mixture, rows materialize", async ({ page }) => {
+  test("paste 'SiO2 80%, H2O 20%' → mode flips to wt %, rows materialize", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
     await page.getByRole("button", { name: /Define.*save material/ }).click();
@@ -25,8 +25,8 @@ test.describe("Material-form redesign (#92)", () => {
     await paste.fill("SiO2 80%, H2O 20%");
     await paste.blur();
 
-    // Mode chip flips to Mass mixture.
-    await expect(page.getByRole("button", { name: /Mass mixture/i })).toBeVisible();
+    // Mode chip flips to wt % (mass mixture).
+    await expect(page.getByRole("button", { name: /^wt %/ })).toBeVisible();
 
     // Two rows: SiO2 + H2O.
     const rowItems = page.locator('[role="row"][data-row-id]');
@@ -51,9 +51,9 @@ test.describe("Material-form redesign (#92)", () => {
     // (Mass mode hides the bottom paste field, so the form switches back
     // to picker-as-text-path; for this fixture we exercise the contract
     // by re-opening single mode.)
-    // Switch back to single by clicking the chip → pick Single formula.
-    await page.getByRole("button", { name: /Mass mixture/ }).click();
-    await page.getByRole("menuitem", { name: /Single formula/ }).click();
+    // Switch back to single by clicking the chip → pick Formula.
+    await page.getByRole("button", { name: /^wt %/ }).click();
+    await page.getByRole("menuitem", { name: /^Formula$/ }).click();
 
     // Bottom paste field is now visible again. Clear it and blur.
     const paste2 = page.getByPlaceholder(/Al2O3/);
@@ -74,7 +74,7 @@ test.describe("Material-form redesign (#92)", () => {
     await paste.blur();
 
     // Chip text contains a "?" suffix when low-confidence.
-    const chip = page.getByRole("button", { name: /Mass mixture\?/ });
+    const chip = page.getByRole("button", { name: /^wt %\?/ });
     await expect(chip).toBeVisible();
     // Nudge mentions mol%.
     await expect(page.getByText(/mol%/i)).toBeVisible();

--- a/frontend/e2e/material-soda-lime.spec.ts
+++ b/frontend/e2e/material-soda-lime.spec.ts
@@ -38,7 +38,7 @@ test.describe("Soda-lime mass mixture walkthrough (#97)", () => {
     await paste.blur();
 
     // Mode chip flips amber with the mol% nudge.
-    await expect(page.getByRole("button", { name: /Mass mixture\?/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /^wt %\?/ })).toBeVisible();
     await expect(page.getByText(/mol%/i)).toBeVisible();
 
     // Three rows materialize.


### PR DESCRIPTION
## Summary

The 24-failure cluster surfaced by PR #136's cross-platform e2e workflow was four spec files lagging behind three deliberate UI changes that landed without test updates:

- **#132** renamed mode-chip labels: `Single formula` / `Mass mixture` / `Atom mixture` → `Formula` / `wt %` / `at %`
- **#98** renamed the picker dialog `Pick an element` → `Compose mixture` and made it stays-open (clicking a PT cell now appends a row but no longer auto-closes the picker — confirmed deliberate by the comment at `DefineForm.svelte:402-403`)
- **#92** redesign replaced the row balance radio with a checkbox and changed density auto-fill to a "Use n.nn" suggestion button

Pure test updates — no logic changes, no source-file edits.

## Local verification

\`\`\`
material-define-rows.spec.ts (2 tests × 4 viewports = 8)  ✓
material-form-redesign.spec.ts (5 tests × 4 viewports = 20) ✓
material-soda-lime.spec.ts (1 test × 4 viewports = 4)  ✓
\`\`\`

All 32 affected tests pass on desktop-1280 + iphone-se + iphone-14 + ipad locally. Confirmed via `npx playwright test`.

## Test plan

- [ ] PR #136 (cross-platform e2e workflow) goes green after this merges
- [ ] Existing 112 passing tests stay green

## Out of scope (follow-ups)

- The §3.4 focus contract from #64 ("focus lands on new row's value input after PT pick") was dropped — confirmed deliberate by the stays-open comment, but the spec doc (if any) may need an update.
- `material-soda-lime.spec.ts:48-51` comment claims the auto-fill suggestion doesn't fire for soda-lime; the gating in `DefineForm.svelte:131` is on `formulaPreview?.density` non-null, not coverage. Test is robust to either case via the `.or()` fallback, but the comment may be stale lore.

Closes #170
Refs: #136 #148