### PR TITLE
test(frontend/169): @testing-library/svelte component-render coverage

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,9 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@sveltejs/vite-plugin-svelte": "^7.1.0",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
+    "jsdom": "^29.1.1",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "^6.0.3",

--- a/frontend/src/lib/components/DataFetchSplash.svelte.test.ts
+++ b/frontend/src/lib/components/DataFetchSplash.svelte.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Render coverage for `DataFetchSplash` (#169).
+ *
+ * The component subscribes to `hyrr://data-fetch-progress` over Tauri
+ * IPC and translates each `RustProgress` payload into a stage label +
+ * progress-bar state. This test mocks `@tauri-apps/api/event::listen`
+ * so we can grab the registered callback, fire fake progress events,
+ * and assert the rendered transitions.
+ *
+ * Why this test exists separate from `parse-fetch-error.test.ts`:
+ * the splash's "Connecting → Downloading → Extracting" wire-up
+ * lives in the Svelte `$derived` block, not in any pure helper —
+ * the only way to assert it is via render.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+
+// Force desktop mode so the component subscribes (browser mode no-ops).
+vi.mock("../utils/platform", () => ({
+  isTauri: vi.fn(() => true),
+  detectOS: () => "macos",
+}));
+
+// SSoT mocks for the FetchErrorCard subtree — DataFetchSplash mounts it
+// when `loadingError` is non-null. We never set that in these tests, so
+// the mocks act as safety net rather than load-bearing.
+vi.mock("../compute/data-fetch-meta", () => ({
+  getReleaseUrl: vi.fn(async () => null),
+  getCacheRootPattern: vi.fn(async () => null),
+  getTarballFilename: vi.fn(async () => null),
+  getReleaseBaseUrl: vi.fn(async () => null),
+  getDataVersion: vi.fn(async () => null),
+  DEFAULT_LIBRARY: "tendl-2025",
+}));
+
+// Capture every `listen()` call so each test can grab the latest handler.
+type EventCallback = (event: { payload: unknown }) => void;
+const listenCalls: Array<{ event: string; cb: EventCallback }> = [];
+const unsubscribeMock = vi.fn(() => {});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (event: string, cb: EventCallback) => {
+    listenCalls.push({ event, cb });
+    return unsubscribeMock;
+  }),
+}));
+
+import DataFetchSplash from "./DataFetchSplash.svelte";
+
+/** Wait one microtask for onMount + dynamic import + $derived to settle. */
+async function flush() {
+  // The component awaits a dynamic import of @tauri-apps/api/event inside
+  // onMount, so we need a few ticks. Two `setTimeout` settles handle:
+  //   tick 1 — onMount async kicks the dynamic import
+  //   tick 2 — listen resolves, $state assignment, $derived recompute
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+beforeEach(() => {
+  listenCalls.length = 0;
+  unsubscribeMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DataFetchSplash — initial render falls back to loadingState", () => {
+  it("shows the parent's loading text when no rust event has arrived", async () => {
+    const { getByTestId } = render(DataFetchSplash, {
+      loadingState: "Loading nuclear data…",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(getByTestId("splash-stage")).toHaveTextContent("Loading nuclear data…");
+  });
+
+  it("subscribes to the hyrr://data-fetch-progress event on mount", async () => {
+    render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(listenCalls.length).toBe(1);
+    expect(listenCalls[0].event).toBe("hyrr://data-fetch-progress");
+  });
+});
+
+describe("DataFetchSplash — progress events update stage label", () => {
+  it("Connecting event → 'Connecting…'", async () => {
+    const { getByTestId } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+
+    listenCalls[0].cb({
+      payload: { stage: "connecting", bytes_done: 0, bytes_total: null },
+    });
+    await flush();
+
+    expect(getByTestId("splash-stage")).toHaveTextContent("Connecting…");
+  });
+
+  it("Downloading event with bytes → 'Downloading nuclear data…' + size hint", async () => {
+    const { getByTestId } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+
+    listenCalls[0].cb({
+      payload: {
+        stage: "downloading",
+        bytes_done: 10 * 1024 * 1024,
+        bytes_total: 100 * 1024 * 1024,
+      },
+    });
+    await flush();
+
+    expect(getByTestId("splash-stage")).toHaveTextContent(
+      "Downloading nuclear data…",
+    );
+    // Size hint surfaces MiB-formatted progress when total is known.
+    expect(getByTestId("splash-size")).toHaveTextContent("10.0 / 100.0 MiB");
+  });
+
+  it("Extracting event → 'Extracting…'", async () => {
+    const { getByTestId } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+
+    listenCalls[0].cb({
+      payload: { stage: "extracting", bytes_done: 0, bytes_total: null },
+    });
+    await flush();
+
+    expect(getByTestId("splash-stage")).toHaveTextContent("Extracting…");
+  });
+
+  it("Verifying event → 'Finalising…' (no size hint without total)", async () => {
+    const { getByTestId, queryByTestId } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+
+    listenCalls[0].cb({
+      payload: { stage: "verifying", bytes_done: 0, bytes_total: null },
+    });
+    await flush();
+
+    expect(getByTestId("splash-stage")).toHaveTextContent("Finalising…");
+    expect(queryByTestId("splash-size")).toBeNull();
+  });
+
+  it("transitions Connecting → Downloading → Extracting as events fire", async () => {
+    const { getByTestId } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+
+    const { cb } = listenCalls[0];
+
+    cb({ payload: { stage: "connecting", bytes_done: 0, bytes_total: null } });
+    await flush();
+    expect(getByTestId("splash-stage")).toHaveTextContent("Connecting…");
+
+    cb({
+      payload: {
+        stage: "downloading",
+        bytes_done: 1024,
+        bytes_total: 2048,
+      },
+    });
+    await flush();
+    expect(getByTestId("splash-stage")).toHaveTextContent(
+      "Downloading nuclear data…",
+    );
+
+    cb({ payload: { stage: "extracting", bytes_done: 0, bytes_total: null } });
+    await flush();
+    expect(getByTestId("splash-stage")).toHaveTextContent("Extracting…");
+  });
+});
+
+describe("DataFetchSplash — unsubscribes the listener on unmount", () => {
+  it("invokes the listen() return value when destroyed", async () => {
+    const { unmount } = render(DataFetchSplash, {
+      loadingState: "init",
+      fallbackFraction: 0,
+      loadingError: null,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(unsubscribeMock).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/components/FetchErrorCard.svelte.test.ts
+++ b/frontend/src/lib/components/FetchErrorCard.svelte.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Render-matrix coverage for `FetchErrorCard` (#169).
+ *
+ * The pure-function path is covered by `parse-fetch-error.test.ts`; this
+ * suite asserts the rendered contract — title text, the four-button
+ * visibility matrix (varies by variant × `isTauri()` × `onuselimited`
+ * presence), and the callback wiring.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+
+// Mock the platform helper. The mock factory must be self-contained because
+// vi.mock is hoisted above imports.
+vi.mock("../utils/platform", () => ({
+  isTauri: vi.fn(() => false),
+  detectOS: () => "macos",
+}));
+
+// Mock the data-fetch-meta SSoT — we don't want the test to hit the
+// (non-existent in jsdom) Tauri invoke surface.
+vi.mock("../compute/data-fetch-meta", () => ({
+  getReleaseUrl: vi.fn(async () =>
+    "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst",
+  ),
+  getCacheRootPattern: vi.fn(async () => "~/.hyrr/nucl-parquet/<version>"),
+  getTarballFilename: vi.fn(async () => "nucl-parquet-data-v0.10.0.tar.zst"),
+  getReleaseBaseUrl: vi.fn(async () => "https://github.com/exoma-ch/nucl-parquet"),
+  getDataVersion: vi.fn(async () => "v0.10.0"),
+  DEFAULT_LIBRARY: "tendl-2025",
+}));
+
+// Mock open-url so we don't try to escape jsdom.
+vi.mock("../utils/open-url", () => ({
+  openExternalUrl: vi.fn(async () => {}),
+}));
+
+import FetchErrorCard from "./FetchErrorCard.svelte";
+import {
+  fetchErrorTitle,
+  type ParsedFetchError,
+} from "../utils/parse-fetch-error";
+import { isTauri } from "../utils/platform";
+
+const mockedIsTauri = vi.mocked(isTauri);
+
+const CACHE = "/Users/x/.hyrr/nucl-parquet/v0.10.0";
+const URL_ = "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst";
+
+/** One representative payload per parsed-error variant. Seven entries. */
+const variants: Array<{ name: string; payload: ParsedFetchError; carriesUrl: boolean }> = [
+  {
+    name: "HttpStatus",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "HttpStatus",
+      status: 404,
+      url: URL_,
+      cache_dir: CACHE,
+      message: "HTTP 404",
+    },
+  },
+  {
+    name: "Network",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "Network",
+      detail: "dns lookup failed",
+      url: URL_,
+      cache_dir: CACHE,
+      message: "network error: dns lookup failed",
+    },
+  },
+  {
+    name: "Decompress",
+    // Variants without a `url` field fall back to the SSoT `releaseUrl`
+    // mock above, so the "Open URL" button still renders after onMount.
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "Decompress",
+      cache_dir: CACHE,
+      message: "zstd: bad magic",
+    },
+  },
+  {
+    name: "Extract",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "Extract",
+      cache_dir: CACHE,
+      message: "unexpected eof",
+    },
+  },
+  {
+    name: "UnsafeTarballEntry",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "UnsafeTarballEntry",
+      entry_kind: "Symlink",
+      entry_path: "data/meta/evil",
+      cache_dir: CACHE,
+      message: "unsafe tarball entry Symlink at data/meta/evil",
+    },
+  },
+  {
+    name: "Io",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "Io",
+      cache_dir: CACHE,
+      message: "insufficient disk space",
+    },
+  },
+  {
+    name: "NoHome",
+    carriesUrl: true,
+    payload: {
+      kind: "FetchError",
+      variant: "NoHome",
+      message: "HOME environment variable not set",
+    },
+  },
+];
+
+/** Wait one microtask + a tick for onMount + $derived to settle. */
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+afterEach(() => {
+  cleanup();
+  mockedIsTauri.mockReset();
+  mockedIsTauri.mockImplementation(() => false);
+});
+
+describe("FetchErrorCard — title text matches fetchErrorTitle()", () => {
+  for (const { name, payload } of variants) {
+    it(`renders the ${name} title`, async () => {
+      mockedIsTauri.mockReturnValue(false);
+      const { getByText } = render(FetchErrorCard, {
+        error: payload,
+        onretry: vi.fn(),
+      });
+      await flush();
+      // Title text is the SSoT — couples the rendered header to the same
+      // string the support triage uses.
+      expect(getByText(fetchErrorTitle(payload))).toBeInTheDocument();
+    });
+  }
+});
+
+describe("FetchErrorCard — Retry button is always rendered", () => {
+  for (const { name, payload } of variants) {
+    for (const desktop of [false, true]) {
+      it(`shows Retry for ${name} (isTauri=${desktop})`, async () => {
+        mockedIsTauri.mockReturnValue(desktop);
+        const { getByRole } = render(FetchErrorCard, {
+          error: payload,
+          onretry: vi.fn(),
+        });
+        await flush();
+        const retry = getByRole("button", { name: /retry/i });
+        expect(retry).toBeInTheDocument();
+        expect(retry).not.toBeDisabled();
+      });
+    }
+  }
+});
+
+describe("FetchErrorCard — Open URL button visibility tracks triedUrl", () => {
+  it("renders Open URL when the variant carries a URL (HttpStatus)", async () => {
+    mockedIsTauri.mockReturnValue(false);
+    const { queryByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(queryByRole("button", { name: /open url/i })).toBeInTheDocument();
+  });
+
+  it("renders Open URL for variants without a URL via the SSoT fallback", async () => {
+    // Decompress carries no url field; the component falls back to
+    // `getReleaseUrl()` (mocked above to return a non-empty string).
+    mockedIsTauri.mockReturnValue(false);
+    const { queryByRole } = render(FetchErrorCard, {
+      error: variants[2].payload,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(queryByRole("button", { name: /open url/i })).toBeInTheDocument();
+  });
+});
+
+describe("FetchErrorCard — desktop-only buttons gated by isTauri()", () => {
+  it("hides Install/Use-bundled in browser mode (isTauri=false)", async () => {
+    mockedIsTauri.mockReturnValue(false);
+    const { queryByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry: vi.fn(),
+      onuselimited: vi.fn(),
+    });
+    await flush();
+    expect(
+      queryByRole("button", { name: /install from local tarball/i }),
+    ).toBeNull();
+    expect(queryByRole("button", { name: /use bundled data only/i })).toBeNull();
+  });
+
+  it("shows Install in desktop mode (isTauri=true)", async () => {
+    mockedIsTauri.mockReturnValue(true);
+    const { queryByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry: vi.fn(),
+    });
+    await flush();
+    expect(
+      queryByRole("button", { name: /install from local tarball/i }),
+    ).toBeInTheDocument();
+    // Without onuselimited, the bundled button stays hidden even on desktop.
+    expect(queryByRole("button", { name: /use bundled data only/i })).toBeNull();
+  });
+
+  it("shows Use-bundled only when isTauri=true AND onuselimited provided", async () => {
+    mockedIsTauri.mockReturnValue(true);
+    const { queryByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry: vi.fn(),
+      onuselimited: vi.fn(),
+    });
+    await flush();
+    expect(
+      queryByRole("button", { name: /use bundled data only/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("FetchErrorCard — callbacks fire on button click", () => {
+  it("Retry → onretry()", async () => {
+    mockedIsTauri.mockReturnValue(false);
+    const onretry = vi.fn();
+    const { getByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry,
+    });
+    await flush();
+    await fireEvent.click(getByRole("button", { name: /retry/i }));
+    expect(onretry).toHaveBeenCalledTimes(1);
+  });
+
+  it("Use bundled data only → onuselimited()", async () => {
+    mockedIsTauri.mockReturnValue(true);
+    const onretry = vi.fn();
+    const onuselimited = vi.fn();
+    const { getByRole } = render(FetchErrorCard, {
+      error: variants[0].payload,
+      onretry,
+      onuselimited,
+    });
+    await flush();
+    await fireEvent.click(
+      getByRole("button", { name: /use bundled data only/i }),
+    );
+    expect(onuselimited).toHaveBeenCalledTimes(1);
+    // The use-bundled handler must not also kick a retry.
+    expect(onretry).not.toHaveBeenCalled();
+  });
+
+  it("Open URL → openExternalUrl(triedUrl)", async () => {
+    mockedIsTauri.mockReturnValue(false);
+    const { openExternalUrl } = await import("../utils/open-url");
+    const mocked = vi.mocked(openExternalUrl);
+    mocked.mockClear();
+    const { getByRole } = render(FetchErrorCard, {
+      error: variants[0].payload, // HttpStatus carries url=URL_
+      onretry: vi.fn(),
+    });
+    await flush();
+    await fireEvent.click(getByRole("button", { name: /open url/i }));
+    expect(mocked).toHaveBeenCalledTimes(1);
+    expect(mocked).toHaveBeenCalledWith(URL_);
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": false,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "types": ["@testing-library/jest-dom"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,16 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { svelteTesting } from "@testing-library/svelte/vite";
 import pkg from "./package.json" with { type: "json" };
 
 export default defineConfig({
-  plugins: [svelte()],
+  // `svelteTesting()` is a no-op outside `VITEST` — it flips the
+  // `resolve.conditions` order (browser ahead of node) so svelte's
+  // browser entry is loaded under jsdom and adds an auto-cleanup
+  // afterEach hook. Without it, `render()` blows up with
+  // `mount(...) is not available on the server` because Vite would
+  // serve svelte's SSR build to tests.
+  plugins: [svelte(), svelteTesting()],
   base: process.env.TAURI_ENV_PLATFORM ? "./" : "/hyrr/",
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -27,6 +27,46 @@ export default defineConfig({
     rollupOptions: {},
   },
   test: {
+    // Split into two projects (#169):
+    //   - `node`  — fast path for non-render tests. Keeps the existing
+    //               466-test suite on a no-DOM runner. This covers
+    //               pure-function tests (`*.test.ts`) **and** the existing
+    //               rune-store test (`src/lib/stores/*.svelte.test.ts`),
+    //               which doesn't render any Svelte component.
+    //   - `jsdom` — component-render tests under `src/lib/components/`
+    //               named `*.svelte.test.ts` via @testing-library/svelte.
+    //               jsdom over happy-dom because @tauri-apps/api's
+    //               event-listen mocks are more compatible.
+    //
+    // The directory-based split keeps the existing fast path intact —
+    // running `.svelte.test.ts` in jsdom breaks Svelte rune proxy
+    // identity (`expect(x).toBe(x)` fails because runes wrap state in a
+    // Proxy under DOM globals).
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "node",
+          environment: "node",
+          include: ["src/**/*.test.ts"],
+          exclude: [
+            "src/lib/components/**/*.svelte.test.ts",
+            "e2e/**",
+            "**/node_modules/**",
+          ],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "jsdom",
+          environment: "jsdom",
+          include: ["src/lib/components/**/*.svelte.test.ts"],
+          exclude: ["e2e/**", "**/node_modules/**"],
+          setupFiles: ["./vitest.setup.ts"],
+        },
+      },
+    ],
     exclude: ["e2e/**", "**/node_modules/**"],
   },
 });

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,8 @@
+/**
+ * vitest setup for the jsdom (component-render) project (#169).
+ *
+ * Wires `@testing-library/jest-dom`'s custom matchers (`toBeInTheDocument`,
+ * `toBeDisabled`, `toHaveAttribute`, …) into vitest's `expect`. Only loaded
+ * for `*.svelte.test.ts` files — the fast `node` project skips this.
+ */
+import "@testing-library/jest-dom/vitest";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-aadd92b3c110fc886",
+  "name": "agent-a17d1df96a6384b45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -35,6 +35,9 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@sveltejs/vite-plugin-svelte": "^7.1.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/svelte": "^5.3.1",
+        "jsdom": "^29.1.1",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "typescript": "^6.0.3",
@@ -46,6 +49,272 @@
       "name": "hyrr-wasm",
       "version": "0.1.0",
       "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@hyrr/compute": {
       "resolved": "packages/compute",
@@ -502,6 +771,103 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -512,6 +878,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -672,6 +1045,29 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -709,6 +1105,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/chai": {
@@ -763,6 +1169,48 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -771,6 +1219,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -789,6 +1247,26 @@
       "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
@@ -887,6 +1365,19 @@
       "integrity": "sha512-dkuVSOKKwh3eas5VkJy1AW1vFpet8TA/fGmVA5krThl8YcOVE/8ZIoEA1+U1vEn5ckxxhLirSdY837azmbaNHA==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -939,6 +1430,23 @@
       "integrity": "sha512-MNrC4NfwDGPb889O6gIfEtbvEZCSWUsSEhsz4Oq2FRcpGtXHfeVz3KciSPp5Pnnz1NjFMgDQNfxdJozymJEDDA==",
       "license": "MIT"
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -947,6 +1455,55 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -1217,6 +1774,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.6.tgz",
+      "integrity": "sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1225,6 +1802,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mri": {
@@ -1266,6 +1860,19 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1362,6 +1969,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1374,6 +2013,30 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -1423,6 +2086,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1453,6 +2129,19 @@
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/svelte": {
       "version": "5.55.5",
@@ -1507,6 +2196,13 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/text-segmentation": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
@@ -1560,6 +2256,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -1581,6 +2323,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/utrie": {
@@ -1712,6 +2464,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -1796,6 +2549,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1812,6 +2613,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",


### PR DESCRIPTION
## Summary

Adopts `@testing-library/svelte` + jsdom for component-render coverage of the two new components from #160 (`FetchErrorCard`, `DataFetchSplash`). The pure-function path (`parse-fetch-error.test.ts`) stays in place; this PR layers the render-level contract checks on top.

- **Vitest project split** — `node` for `*.test.ts` (the existing 466-test fast path, no DOM), `jsdom` for `src/lib/components/**/*.svelte.test.ts`. Directory-based glob preserves the existing rune-store test (`results.svelte.test.ts` lives under `src/lib/stores/` and breaks under jsdom because `\$state` proxies break `expect(x).toBe(x)` identity).
- **FetchErrorCard render matrix** (29 tests) — title text per variant, four-button visibility (Retry × Open URL × Install × Use-bundled) across the 7 ParsedFetchError variants × `isTauri()` true/false × `onuselimited` presence, plus callback wiring (Retry → onretry, Use-bundled → onuselimited only, Open URL → openExternalUrl(triedUrl)).
- **DataFetchSplash event handling** (8 tests) — `\@tauri-apps/api/event::listen` mock captures the registered handler so we can fire fake `RustProgress` events and assert stage transitions (`Connecting…` → `Downloading nuclear data…` → `Extracting…` → `Finalising…`), the MiB-formatted size hint, and that the unsubscribe callback fires on unmount.

Test counts: **466 → 503** (+37). Node-mode environment overhead unchanged at ~8ms.

Refs: #169, #118, #160

## Test plan

- [x] `npm test --workspace=hyrr-frontend` — 503/503 passing (was 466 before #169).
- [x] `npm run check --workspace=hyrr-frontend` — 0 errors, 0 warnings.
- [x] Verified the existing `src/lib/stores/results.svelte.test.ts` rune-store test stays on node and keeps passing — directory-based glob split intentionally excludes it from jsdom.
- [x] Verified node-mode runtime (env setup) is not regressed by the project split.

## Out of scope

- BugReportModal render test (#169 acceptance item 3). Bundling it into this PR would extend it past the "infrastructure + the two #160 components" scope; happy to file as a fast-follow once this lands.
- `frontend/CONTRIBUTING.md` documentation pass (#169 acceptance item 5) — same fast-follow.