### PR TITLE
feat(frontend): clear-all-layers × button in layer stack toolbar

### DIFF
--- a/frontend/e2e/layer-clear.spec.ts
+++ b/frontend/e2e/layer-clear.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from "@playwright/test";
+
+/** Same TC-99m preset used by the other layer-stack specs. */
+const TC99M_URL =
+  "/hyrr/#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+
+async function waitReady(page: import("@playwright/test").Page) {
+  await page.waitForSelector(".status-bar", { state: "hidden", timeout: 30_000 }).catch(() => {});
+  await page.waitForSelector(".activity-table-enhanced", { timeout: 30_000 });
+}
+
+test.describe("Layer stack — clear-all button", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TC99M_URL);
+    await waitReady(page);
+  });
+
+  test("clear button removes all layers and then hides itself", async ({ page }) => {
+    // Preset starts with 3 layers (havar / Mo-100 / Cu).
+    await expect(page.locator(".layer-card")).toHaveCount(3);
+
+    const clearBtn = page.getByRole("button", { name: "Clear all layers" });
+    await expect(clearBtn).toBeVisible();
+    await clearBtn.click();
+
+    // All layer cards gone, and the clear button is gone too (gated on items.length > 0).
+    await expect(page.locator(".layer-card")).toHaveCount(0);
+    await expect(clearBtn).toBeHidden();
+  });
+});

--- a/frontend/src/lib/components/LayerStackHorizontal.svelte
+++ b/frontend/src/lib/components/LayerStackHorizontal.svelte
@@ -9,6 +9,7 @@
     removeGroup,
     updateGroup,
     moveGroup,
+    clearLayers,
     type InternalGroup,
   } from "../stores/config.svelte";
   import type { LayerConfig } from "../types";
@@ -192,6 +193,14 @@
   <div class="add-buttons">
     <button class="add-btn" onclick={handleAddLayer} title="Add layer">+</button>
     <button class="add-btn add-group" onclick={handleAddGroup} title="Add repeat group">⟳</button>
+    {#if items.length > 0}
+      <button
+        class="add-btn clear-btn"
+        onclick={clearLayers}
+        title="Clear all layers"
+        aria-label="Clear all layers"
+      >×</button>
+    {/if}
   </div>
 </div>
 
@@ -373,6 +382,11 @@
   .add-group:hover {
     border-color: var(--c-accent);
     color: var(--c-accent);
+  }
+
+  .clear-btn:hover {
+    border-color: var(--c-red);
+    color: var(--c-red);
   }
 
   .element-badges {


### PR DESCRIPTION
## Summary

Adds a destructive × button to the layer-stack toolbar — one click to wipe the entire stack instead of removing layers one by one.

- Button sits next to `+` (add layer) and `⟳` (add group); visible only when `items.length > 0` so it disappears on an empty stack
- Calls `clearLayers()` from `config.svelte.ts:446` which already records to the undo stack — Cmd-Z restores
- Red `:hover` border + text signal "destructive"
- `aria-label="Clear all layers"` for accessibility

## Test plan

- [x] `npm run check` — 0 errors, 0 warnings, 411 files
- [x] `npm test` (vitest) — 503/503 passing
- [x] New e2e spec `layer-clear.spec.ts` — passes on desktop-1280 + iphone-se + iphone-14 + ipad (4/4)
- [ ] Cross-platform e2e workflow (#136) goes green on this PR

## Out of scope

- Confirmation modal for the destructive action — undo handles it; an extra modal would just be friction.