### PR TITLE
ci: cargo check -p hyrr-py to catch PyO3 binding type drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,26 @@ jobs:
           HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
         run: cargo test --test projectile_matrix -- --include-ignored
 
+  hyrr-py-check:
+    # Catches PyO3 binding type drift against hyrr-core (Refs: #181).
+    # The py/ crate is excluded from the default workspace because the
+    # pyo3 extension-module feature gate breaks linking under `cargo test`,
+    # so signature changes in core (e.g. #150's Result-returning stopping
+    # functions) can break the wheel silently. `cargo check` doesn't link
+    # libpython, so it's safe to run here.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: py
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: cargo check py/ (PyO3 bindings)
+        run: cargo check --manifest-path py/Cargo.toml
+
   data-fetch-ssot:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Adds a dedicated `hyrr-py-check` job to `.github/workflows/ci.yml` that runs `cargo check --manifest-path py/Cargo.toml` on every PR. Catches PyO3 binding type drift against `hyrr-core` that today slips past CI.

The `py/` crate is excluded from the default workspace because the pyo3 `extension-module` feature gate breaks linking under `cargo test`. As a result, signature changes in core can break the wheel silently — this is exactly what happened with #150 (Result-returning stopping fns), which left `py/src/lib.rs` broken on main until PR #179 had to ship a prep fix as commit 1.

`cargo check` doesn't link libpython, so the extension-module gate is not a blocker here. New job is modeled on the existing `rust-projectile-matrix` style (separate job, Swatinem/rust-cache scoped to the `py` target).

## Test plan

Verified locally:

- [x] Clean `origin/main` HEAD: `cargo check --manifest-path py/Cargo.toml` succeeds (~5s warm cache, ~19s cold)
- [x] Intentional type-drift break in `py/src/lib.rs` (`py_saturation_yield` return type `f64` → `String`):
  ```
  error[E0308]: mismatched types
     --> src/lib.rs:153:5
      |
  152 | fn py_saturation_yield(rate: f64, half_life: Option<f64>, current_ma: f64) -> String {
      |                                                                               ------ expected `std::string::String` because of return type
  153 |     rust_sat_yield(rate, half_life, current_ma)
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `String`, found `f64`
  ```
- [x] YAML validates with `yaml.safe_load`
- [ ] CI job appears and passes on this PR

Refs: #181