### PR TITLE
test/docs(frontend/178): BugReportModal render test + CONTRIBUTING testing convention

### DIFF
--- a/frontend/CONTRIBUTING.md
+++ b/frontend/CONTRIBUTING.md
@@ -1,0 +1,229 @@
+# Contributing to the HYRR frontend
+
+This document covers the conventions a contributor needs to land a PR
+against `frontend/`. The repository-wide rules (commit format, issue
+linking, branch hygiene) live in the top-level `CLAUDE.md` and ADRs; the
+notes here are frontend-specific.
+
+## Quick reference
+
+| Task                  | Command                                  |
+| --------------------- | ---------------------------------------- |
+| Install               | `npm install --workspaces`               |
+| Type / template check | `npm run check --workspace=hyrr-frontend` |
+| Unit + render tests   | `npm test --workspace=hyrr-frontend`     |
+| Dev server            | `npm run dev --workspace=hyrr-frontend`  |
+| E2E (Playwright)      | See `frontend/e2e/README.md`             |
+
+`npm run check` must report `0 ERRORS 0 WARNINGS` before a PR is ready
+to merge. The full test suite runs in ~15 s and is expected to pass on
+every PR.
+
+## Testing Svelte components
+
+### The vitest split
+
+`vite.config.ts` configures vitest with **two projects**:
+
+- **`node`** — runs `src/**/*.test.ts`. Plain Node, no DOM. Fast.
+  - Use this for pure functions, helpers, store logic that doesn't
+    render anything.
+  - Files: `format.test.ts`, `bug-report-body.test.ts`,
+    `results.svelte.test.ts`, etc.
+- **`jsdom`** — runs `src/lib/components/**/*.svelte.test.ts`. jsdom +
+  `@testing-library/svelte`. Slower (svelte rune proxies + DOM globals).
+  - Use this for component render tests.
+  - Files: `FetchErrorCard.svelte.test.ts`,
+    `DataFetchSplash.svelte.test.ts`,
+    `BugReportModal.svelte.test.ts`.
+
+The split exists because Svelte 5 rune proxies behave differently under
+jsdom — `expect(x).toBe(x)` can fail because the rune wraps `$state` in
+a Proxy that's only identity-stable inside the same project. Keeping
+pure code on the node runner avoids that whole class of failure and
+keeps the fast path fast.
+
+### Naming convention
+
+| Goal                        | Filename                            | Location                       |
+| --------------------------- | ----------------------------------- | ------------------------------ |
+| Pure-function unit test     | `<thing>.test.ts`                   | next to the source             |
+| Svelte component render test | `<ComponentName>.svelte.test.ts`   | next to the `.svelte` file     |
+
+A pure helper extracted **from** a component (like
+`bug-report-body.ts`) stays in the node project — its test file is
+`bug-report-body.test.ts` (no `.svelte.` infix), not
+`BugReportBody.svelte.test.ts`. Reserve the `.svelte.test.ts` suffix
+for files that actually call `render()`.
+
+### A worked example: render the contract, not the implementation
+
+The minimal shape of a render test:
+
+```ts
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+
+// vi.mock is hoisted above imports — keep factories self-contained.
+vi.mock("../utils/platform", () => ({
+  isTauri: vi.fn(() => false),
+  detectOS: () => "macos",
+}));
+vi.mock("../utils/open-url", () => ({
+  openExternalUrl: vi.fn(async () => {}),
+}));
+
+import MyComponent from "./MyComponent.svelte";
+
+afterEach(() => cleanup());
+
+describe("MyComponent", () => {
+  it("calls onsubmit when the user clicks Submit", async () => {
+    const onsubmit = vi.fn();
+    const { getByRole } = render(MyComponent, { onsubmit });
+    await fireEvent.click(getByRole("button", { name: /submit/i }));
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+Three rules of thumb:
+
+1. **Couple to the rendered contract** — button text, accessible roles
+   (`getByRole`), `aria-label`, `data-testid` if you must. Do NOT
+   couple to CSS classes, internal `$state` variable names, or DOM
+   structure that's incidental.
+2. **One assertion per concept** — if you're checking "the button is
+   disabled AND the tooltip explains why", that's two `expect()`s in
+   one test, not two tests.
+3. **Reset mocks in `beforeEach`** — the jsdom project does not reset
+   between cases by default. Use `vi.fn().mockClear()` or
+   `vi.mocked(fn).mockReset()` to keep cases independent.
+
+### The `flush()` pattern for `onMount`-async components
+
+Several components in this codebase do async work inside `onMount`:
+
+- `DataFetchSplash` dynamically imports `@tauri-apps/api/event` and
+  awaits `listen()`.
+- `FetchErrorCard` awaits the data-fetch-meta SSoT getters.
+
+After `render()`, the rendered DOM reflects the **pre-onMount** state.
+You need to wait two microtask ticks for the async work to settle:
+
+```ts
+async function flush() {
+  // tick 1 — onMount async kicks the dynamic import
+  // tick 2 — listen()/getters resolve, $state assignment, $derived recompute
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+```
+
+Call `await flush()` after `render()` and after each event you fire
+that touches a `$derived` block. See
+`DataFetchSplash.svelte.test.ts` for the canonical example.
+
+### Mocking the surfaces a component reaches into
+
+The mock recipes below match the patterns the existing render tests
+already use — crib them rather than reinventing.
+
+**Platform / Tauri detection:**
+
+```ts
+vi.mock("../utils/platform", () => ({
+  isTauri: vi.fn(() => false), // flip per-test for desktop branches
+  detectOS: () => "macos",
+}));
+```
+
+**External URL open (Tauri opener):**
+
+```ts
+vi.mock("../utils/open-url", () => ({
+  openExternalUrl: vi.fn(async () => {}),
+}));
+```
+
+**`@tauri-apps/api/event` listener (capture-the-callback pattern):**
+
+```ts
+const listenCalls: Array<{ event: string; cb: (e: { payload: unknown }) => void }> = [];
+const unsubscribeMock = vi.fn(() => {});
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (event, cb) => {
+    listenCalls.push({ event, cb });
+    return unsubscribeMock;
+  }),
+}));
+// In the test: drive the component by calling listenCalls[0].cb({ payload }).
+```
+
+**SSoT getters from `data-fetch-meta`** (mock so jsdom doesn't try to
+talk to the Tauri invoke surface):
+
+```ts
+vi.mock("../compute/data-fetch-meta", () => ({
+  getReleaseUrl: vi.fn(async () => "https://example.test/data.tar.zst"),
+  getCacheRootPattern: vi.fn(async () => "~/.hyrr/nucl-parquet/<version>"),
+  getDataVersion: vi.fn(async () => "v0.10.0"),
+  DEFAULT_LIBRARY: "tendl-2025",
+}));
+```
+
+**Rune stores (e.g. `bugreport.svelte.ts`, `results.svelte.ts`):**
+mock the whole module so the test controls `getX()` return values
+directly. Rune state can't easily be reset between cases otherwise.
+
+```ts
+vi.mock("../stores/bugreport.svelte", () => ({
+  getBugReportOpen: vi.fn(() => true),
+  closeBugReport: vi.fn(),
+}));
+```
+
+### When NOT to write a component test
+
+If the behaviour you want to assert is pure (a string transform, a
+config validator, a body-builder), extract it to a helper module and
+test it on the node project. Component tests are 5-10× slower than
+node tests and exercise the rendered contract — they're the wrong
+tool for assertion on what a function returns.
+
+Concrete example: `bug-report-body.ts` was extracted from
+`BugReportModal.svelte` specifically so its branching logic could be
+covered without spinning up a render. The modal's test then asserts
+the wiring (does the click actually reach the helper?), not the
+helper's branches.
+
+### Worked examples
+
+Read these in order if you're writing your first render test:
+
+- `frontend/src/lib/components/FetchErrorCard.svelte.test.ts` —
+  render-matrix pattern (variant × platform × props), `getByRole`
+  for buttons, callback-fired-once assertions.
+- `frontend/src/lib/components/DataFetchSplash.svelte.test.ts` —
+  capture-the-callback for the `listen()` mock, two-tick `flush()`,
+  unmount-cleanup assertion.
+- `frontend/src/lib/components/BugReportModal.svelte.test.ts` —
+  mocking rune stores, end-to-end URL-construction assertion,
+  exercising the form-state contract without coupling to internal
+  `$state` names.
+
+## Commits
+
+Use the repo-wide format:
+
+```
+type(scope): short imperative description
+
+Optional longer body explaining why.
+
+Refs: #123
+```
+
+Every commit must have a `Refs:` line pointing at the GitHub issue.
+PRs that touch the frontend must keep `npm run check` and
+`npm test` green.

--- a/frontend/src/lib/components/BugReportModal.svelte.test.ts
+++ b/frontend/src/lib/components/BugReportModal.svelte.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Render-level coverage for `BugReportModal` (#178).
+ *
+ * The pure body-builder is covered by `bug-report-body.test.ts`; this suite
+ * asserts the form-state contract that wraps it:
+ *
+ *   - the modal is only visible when `getBugReportOpen() === true`
+ *   - "Open on GitHub" is gated on description / screenshot (disable-with-hover)
+ *   - typing a description enables the button
+ *   - clicking the button hands a well-formed GitHub `issues/new` URL to
+ *     `openExternalUrl()` with the title + body encoded via the shared
+ *     `bug-report-body` / `bug-report-title` helpers
+ *   - a non-null `computeError` from the results store flows into the body
+ *
+ * We exercise the rendered contract (button text, accessible roles, callback
+ * wiring) — NOT the component's internal `$state` names or CSS classes.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, cleanup } from "@testing-library/svelte";
+
+/** Grab a field by its DOM `id`. The modal's labels overlap textually
+ *  (the Title label mentions "description" in its hint), so by-label
+ *  matching is ambiguous — id is the stable handle. */
+function fieldById<T extends HTMLElement>(id: string): T {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`expected #${id} in the rendered modal`);
+  return el as T;
+}
+
+// ── Module mocks (hoisted by Vitest above all imports) ────────────────────
+
+// Platform: default to browser-mode so the non-desktop button matrix is shown
+// (an "Open on GitHub" button is present in both modes — they just sit in a
+// different action block).
+vi.mock("../utils/platform", () => ({
+  isTauri: vi.fn(() => false),
+  detectOS: () => "macos",
+}));
+
+// External-URL opener — the load-bearing observable for the openOnGitHub path.
+vi.mock("../utils/open-url", () => ({
+  openExternalUrl: vi.fn(async () => {}),
+}));
+
+// Bug-report open/close store — return open=true so the modal actually mounts.
+vi.mock("../stores/bugreport.svelte", () => ({
+  getBugReportOpen: vi.fn(() => true),
+  openBugReport: vi.fn(),
+  closeBugReport: vi.fn(),
+}));
+
+// Config store — supply a minimal valid SimulationConfig + SerializableConfig.
+vi.mock("../stores/config.svelte", () => ({
+  getConfig: vi.fn(() => ({
+    beam: { projectile: "p", energy_MeV: 16, current_mA: 0.15 },
+    layers: [{ material: "Cu", thickness_cm: 0.5 }],
+    irradiation_s: 86400,
+    cooling_s: 0,
+  })),
+  getSerializableConfig: vi.fn(() => ({
+    beam: { projectile: "p", energy_MeV: 16, current_mA: 0.15 },
+    items: [{ material: "Cu", thickness_cm: 0.5 }],
+    irradiation_s: 86400,
+    cooling_s: 0,
+  })),
+}));
+
+// Results store — getter trio used by the modal. `getResultError` is the
+// channel that feeds the "Compute error:" line of the body.
+const resultErrorMock = vi.fn(() => null as unknown);
+vi.mock("../stores/results.svelte", () => ({
+  getResult: vi.fn(() => null),
+  getResultError: () => resultErrorMock(),
+}));
+
+// Shareable-URL builder — return a stable fake. The body builder embeds this
+// verbatim, so we just need a known string to grep for if needed.
+vi.mock("../config-url", () => ({
+  getShareableUrl: vi.fn(() => "https://example.test/#config=stub"),
+}));
+
+// ── Imports (must come after vi.mock) ──────────────────────────────────────
+
+import BugReportModal from "./BugReportModal.svelte";
+import { openExternalUrl } from "../utils/open-url";
+import { closeBugReport } from "../stores/bugreport.svelte";
+
+const openExternalUrlMock = vi.mocked(openExternalUrl);
+const closeBugReportMock = vi.mocked(closeBugReport);
+
+/** Allow onMount + $derived to settle. Two ticks for parity with the
+ *  DataFetchSplash pattern (one for the rune proxy reaction, one for the
+ *  DOM commit). One is usually enough here, but two is harmless. */
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+beforeEach(() => {
+  openExternalUrlMock.mockClear();
+  closeBugReportMock.mockClear();
+  resultErrorMock.mockReturnValue(null);
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BugReportModal — initial render", () => {
+  it("renders the dialog when the bug-report store is open", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    expect(getByRole("dialog", { name: /report a bug/i })).toBeInTheDocument();
+  });
+
+  it("shows both report-type toggles (Bug / Feature)", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    expect(getByRole("button", { name: /^bug$/i })).toBeInTheDocument();
+    expect(getByRole("button", { name: /^feature$/i })).toBeInTheDocument();
+  });
+
+  it("renders an Open-on-GitHub button", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    expect(getByRole("button", { name: /open on github/i })).toBeInTheDocument();
+  });
+});
+
+describe("BugReportModal — Open-on-GitHub disable gate (description required)", () => {
+  it("is disabled when description is empty AND no screenshot is attached", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    const btn = getByRole("button", { name: /open on github/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("surfaces the disabledReason via the title attribute", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    const btn = getByRole("button", { name: /open on github/i });
+    // Hover-tooltip explains *why* the click is dead (see #160 / pre-PR-#160
+    // disable-with-hover behaviour). We only assert it mentions "description"
+    // — exact wording can drift.
+    expect(btn).toHaveAttribute("title", expect.stringMatching(/description/i));
+  });
+
+  it("becomes enabled once the description has content", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+
+    const desc = fieldById<HTMLTextAreaElement>("bug-desc");
+    await fireEvent.input(desc, { target: { value: "it broke when I clicked X" } });
+    await flush();
+
+    expect(getByRole("button", { name: /open on github/i })).not.toBeDisabled();
+  });
+});
+
+describe("BugReportModal — title field", () => {
+  it("has a static placeholder hinting at the format", async () => {
+    render(BugReportModal);
+    await flush();
+    const title = fieldById<HTMLInputElement>("bug-title");
+    // The placeholder is a static example; the actual auto-fill from
+    // description happens inside buildIssueTitle() at click time, which is
+    // covered separately in bug-report-title's own test.
+    expect(title).toHaveAttribute("placeholder", expect.stringMatching(/short summary/i));
+  });
+
+  it("accepts user input up to the maxlength cap", async () => {
+    render(BugReportModal);
+    await flush();
+    const title = fieldById<HTMLInputElement>("bug-title");
+    expect(title.maxLength).toBe(70);
+    await fireEvent.input(title, { target: { value: "Heavy ions crash compute" } });
+    expect(title.value).toBe("Heavy ions crash compute");
+  });
+});
+
+describe("BugReportModal — Open-on-GitHub click wiring", () => {
+  it("calls openExternalUrl with a GitHub issues/new URL containing the title + body", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+
+    await fireEvent.input(fieldById<HTMLInputElement>("bug-title"), {
+      target: { value: "Heavy ions crash compute" },
+    });
+    await fireEvent.input(fieldById<HTMLTextAreaElement>("bug-desc"), {
+      target: { value: "it broke when I clicked X" },
+    });
+    await flush();
+
+    await fireEvent.click(getByRole("button", { name: /open on github/i }));
+
+    expect(openExternalUrlMock).toHaveBeenCalledTimes(1);
+    const url = openExternalUrlMock.mock.calls[0][0] as string;
+
+    // Couple to the contract: it's a GitHub issues/new URL on the right repo.
+    expect(url).toMatch(/^https:\/\/github\.com\/exoma-ch\/hyrr\/issues\/new\?/);
+
+    // Title is encoded into the `title=` param via buildIssueTitle, which
+    // prefixes "[Bug] " for the default "bug" report type.
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("title")).toBe("[Bug] Heavy ions crash compute");
+
+    // Body carries the description plus the shared bug-report-body sections.
+    const body = params.get("body") ?? "";
+    expect(body).toContain("## Description");
+    expect(body).toContain("it broke when I clicked X");
+    // Beam line from buildBugReportBody — proves the config helper actually ran.
+    expect(body).toContain("**Beam:** p @ 16 MeV");
+
+    // Labels param follows the same rule (bug/enhancement).
+    expect(params.get("labels")).toBe("bug");
+  });
+
+  it("closes the modal after firing the open call", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    await fireEvent.input(fieldById<HTMLTextAreaElement>("bug-desc"), {
+      target: { value: "anything goes here" },
+    });
+    await flush();
+    await fireEvent.click(getByRole("button", { name: /open on github/i }));
+    expect(closeBugReportMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses [Feature] in the title when the Feature toggle is active", async () => {
+    const { getByRole } = render(BugReportModal);
+    await flush();
+
+    await fireEvent.click(getByRole("button", { name: /^feature$/i }));
+    await fireEvent.input(fieldById<HTMLInputElement>("bug-title"), {
+      target: { value: "Add streaming results" },
+    });
+    await fireEvent.input(fieldById<HTMLTextAreaElement>("bug-desc"), {
+      target: { value: "would be nice" },
+    });
+    await flush();
+
+    await fireEvent.click(getByRole("button", { name: /open on github/i }));
+    const url = openExternalUrlMock.mock.calls[0][0] as string;
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("title")).toBe("[Feature] Add streaming results");
+    expect(params.get("labels")).toBe("enhancement");
+  });
+});
+
+describe("BugReportModal — computeError flows into the body", () => {
+  it("includes the compute-error text in the URL body when getResultError() returns non-null", async () => {
+    resultErrorMock.mockReturnValue(new Error("StoppingError: O-16 unsupported"));
+
+    const { getByRole } = render(BugReportModal);
+    await flush();
+    await fireEvent.input(fieldById<HTMLTextAreaElement>("bug-desc"), {
+      target: { value: "compute died" },
+    });
+    await flush();
+    await fireEvent.click(getByRole("button", { name: /open on github/i }));
+
+    const url = openExternalUrlMock.mock.calls[0][0] as string;
+    const body = new URLSearchParams(url.split("?")[1]).get("body") ?? "";
+    expect(body).toContain("**Compute error:**");
+    expect(body).toContain("StoppingError: O-16 unsupported");
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two deferred items from #169 / PR #177:

- **BugReportModal render test** (`frontend/src/lib/components/BugReportModal.svelte.test.ts`, 12 cases) — covers the form-state contract that wraps the pure `bug-report-body` / `bug-report-title` helpers: the disable-with-hover gate on Open-on-GitHub, the title placeholder + maxlength cap, the Bug/Feature toggle, the end-to-end URL handed to `openExternalUrl()`, and the `getResultError()` → body wiring (the channel for #143).
- **`frontend/CONTRIBUTING.md`** — one-page guide so the next contributor adding a component knows the render-test convention without having to reverse-engineer it from the three existing examples. Covers the node-vs-jsdom split, the `flush()` pattern, mock recipes (platform / open-url / `@tauri-apps/api/event` listen / data-fetch-meta SSoT / rune stores), and when NOT to use a component test.

The tests couple to the rendered contract (button text, accessible roles, callback wiring), not to CSS classes or internal `\$state` names.

Refs: #178

## Test plan

- [x] `npm run check --workspace=hyrr-frontend` — 0 errors / 0 warnings (412 files)
- [x] `npm test --workspace=hyrr-frontend` — 515 tests pass (was 503; +12 from this PR)
- [x] BugReportModal test runs in isolation and inside the full suite with the same result
- [x] Read CONTRIBUTING.md cold — a contributor with no prior context can follow it to write a render test for the next component they ship