### PR TITLE
refactor(core+desktop+py/180): shared FetchProgressThrottle

### DIFF
--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -28,6 +28,7 @@ use std::io;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
 
 use fs2::FileExt;
 use serde::Serialize;
@@ -132,6 +133,156 @@ pub struct FetchProgress {
 /// using a `last_emit_at` field), and the `'_` lifetime lets the caller
 /// own the closure on the stack.
 pub type ProgressFn<'a> = &'a mut dyn FnMut(FetchProgress);
+
+/// Sink-agnostic rate-limiter for [`FetchProgress`] events.
+///
+/// Both the desktop Tauri command and the PyO3 CLI binding need to
+/// forward progress events to a slow sink (`AppHandle::emit` /
+/// `Python::attach` + GIL acquire). A 100 MB download fires the
+/// per-chunk progress callback ~thousands of times; without throttling
+/// every chunk would cross the IPC/GIL boundary and destroy both
+/// throughput and the UI render budget.
+///
+/// The throttle's policy (see [`FetchProgressThrottle::default_policy`]):
+///
+/// 1. **Stage change** — always emit. Lets the consumer relabel the
+///    progress bar instantly when transitioning Connecting →
+///    Downloading → Extracting → Verifying.
+/// 2. **Final-byte event** — always emit when `bytes_done >= bytes_total`
+///    (and `bytes_total > 0`). Guarantees the bar snaps to 100% before
+///    the stage flips, regardless of the byte-step gate.
+/// 3. **Downloading stage** — emit only if **both** ≥ 100 ms has elapsed
+///    since the last emit *and* ≥ 256 KiB of new bytes have been
+///    reported. Byte counts on this stage are real on-disk bytes and
+///    meaningfully tick by 256 KiB.
+/// 4. **Other stages** (Connecting, Extracting, Verifying) — emit only
+///    on the 100 ms interval. The bytes_done field on these stages is
+///    an entry count or sentinel state; 256-KiB gating would silence
+///    Extracting for the entire stage on small libraries.
+///
+/// The bytes counter resets on stage transitions because `bytes_done`
+/// means different things across stages (compressed bytes vs. entry
+/// count) — carrying the old value into the new stage's byte-step
+/// check would compare apples to oranges.
+///
+/// Construct via [`FetchProgressThrottle::default_policy`] or wrap a
+/// sink closure with [`throttle`] (the higher-order combinator form
+/// used by both the desktop and CLI call sites).
+#[derive(Debug)]
+pub struct FetchProgressThrottle {
+    last_emit_at: Option<Instant>,
+    last_bytes: u64,
+    last_stage: Option<FetchStage>,
+    min_interval: Duration,
+    min_bytes_step: u64,
+}
+
+impl FetchProgressThrottle {
+    /// Construct with the canonical policy: 100 ms minimum interval,
+    /// 256 KiB minimum byte-step (Downloading stage only). Inherited
+    /// verbatim from the original desktop `throttled_emit` (#160) and
+    /// the CLI `make_py_progress` (#179) — both implementations had the
+    /// same constants and gates by construction.
+    pub fn default_policy() -> Self {
+        Self {
+            last_emit_at: None,
+            last_bytes: 0,
+            last_stage: None,
+            min_interval: Duration::from_millis(100),
+            min_bytes_step: 256 * 1024,
+        }
+    }
+
+    /// Decide whether `p` should be forwarded to the sink. Mutates
+    /// internal state (`last_emit_at`, `last_bytes`, `last_stage`)
+    /// only when the answer is `true` — callers that don't pump the
+    /// event do not leak it into the throttle history.
+    pub fn should_emit(&mut self, p: &FetchProgress) -> bool {
+        let now = Instant::now();
+
+        let stage_changed = match self.last_stage {
+            None => true,
+            Some(prev) => !same_stage(prev, p.stage),
+        };
+
+        let final_byte = match p.bytes_total {
+            Some(total) => p.bytes_done >= total && total > 0,
+            None => false,
+        };
+
+        let interval_ok = self
+            .last_emit_at
+            .map(|t| now.saturating_duration_since(t) >= self.min_interval)
+            .unwrap_or(true);
+
+        // Reset the bytes counter on stage transition — bytes_done
+        // means different things across stages (compressed bytes vs.
+        // entry count) so the carry-over check is meaningless.
+        let bytes_step_ok = match (self.last_stage, p.stage) {
+            (Some(prev), curr) if !same_stage(prev, curr) => true,
+            _ => p
+                .bytes_done
+                .checked_sub(self.last_bytes)
+                .map(|d| d >= self.min_bytes_step)
+                .unwrap_or(true),
+        };
+
+        // Only the Downloading stage carries reliable byte counts in
+        // 256-KiB-meaningful units. Other stages emit on the 100 ms
+        // interval alone — prevents Extracting from going silent
+        // because entry counts never tick by 256 KiB.
+        let should_emit = stage_changed
+            || final_byte
+            || match p.stage {
+                FetchStage::Downloading => interval_ok && bytes_step_ok,
+                FetchStage::Connecting
+                | FetchStage::Extracting
+                | FetchStage::Verifying => interval_ok,
+            };
+
+        if !should_emit {
+            return false;
+        }
+
+        self.last_emit_at = Some(now);
+        self.last_bytes = p.bytes_done;
+        self.last_stage = Some(p.stage);
+        true
+    }
+}
+
+/// Wrap a [`FetchProgress`] sink closure with the default throttle
+/// policy. Returns a closure with the same signature that drops events
+/// failing the throttle gate; surviving events flow through to `sink`
+/// unchanged.
+///
+/// Both the desktop emit-to-AppHandle and the CLI emit-to-Python sinks
+/// are slow (cross IPC/GIL boundaries); use this to collapse the
+/// per-chunk progress firehose into a UI-friendly cadence without
+/// duplicating the throttle policy at every call site.
+pub fn throttle(mut sink: impl FnMut(FetchProgress)) -> impl FnMut(FetchProgress) {
+    let mut t = FetchProgressThrottle::default_policy();
+    move |p: FetchProgress| {
+        if t.should_emit(&p) {
+            sink(p);
+        }
+    }
+}
+
+/// Pattern-match helper: `true` iff `a` and `b` are the same
+/// [`FetchStage`] variant. Could be replaced by deriving
+/// `PartialEq`, but the explicit `matches!` keeps the discriminator
+/// surface obvious (every stage transition pair is named) and avoids
+/// committing to a derived trait on a wire type.
+fn same_stage(a: FetchStage, b: FetchStage) -> bool {
+    matches!(
+        (a, b),
+        (FetchStage::Connecting, FetchStage::Connecting)
+            | (FetchStage::Downloading, FetchStage::Downloading)
+            | (FetchStage::Extracting, FetchStage::Extracting)
+            | (FetchStage::Verifying, FetchStage::Verifying)
+    )
+}
 
 /// Convenience: a no-op progress callback for callers that don't need
 /// progress (CLI, MCP, tests). Spelled as a fresh closure rather than a
@@ -2100,5 +2251,133 @@ mod tests {
             err_string.contains("~/.hyrr/nucl-parquet"),
             "expected ~/.hyrr/... shape in error, got: {err_string}"
         );
+    }
+
+    // -----------------------------------------------------------------
+    // FetchProgressThrottle — sink-agnostic rate-limiter (issue #180)
+    // -----------------------------------------------------------------
+
+    fn dl(bytes_done: u64, bytes_total: Option<u64>) -> FetchProgress {
+        FetchProgress { stage: FetchStage::Downloading, bytes_done, bytes_total }
+    }
+
+    fn ev(stage: FetchStage, bytes_done: u64, bytes_total: Option<u64>) -> FetchProgress {
+        FetchProgress { stage, bytes_done, bytes_total }
+    }
+
+    /// First-ever event always emits (stage-changed bypass: last_stage
+    /// is `None`). Then a Downloading→Extracting transition immediately
+    /// emits, even though only nanoseconds have passed — the stage
+    /// change bypasses both the 100 ms interval and the 256 KiB
+    /// byte-step gate.
+    #[test]
+    fn throttle_emits_on_stage_change() {
+        let mut t = FetchProgressThrottle::default_policy();
+
+        // First event ever — stage_changed=true (None → Some).
+        assert!(t.should_emit(&dl(0, Some(1_000_000))));
+
+        // Second Downloading event arrives immediately and < 256 KiB
+        // later — should be dropped on the byte gate.
+        assert!(!t.should_emit(&dl(1_024, Some(1_000_000))));
+
+        // Stage flips to Extracting — should emit immediately,
+        // bypassing the 100 ms interval that hasn't elapsed.
+        assert!(t.should_emit(&ev(FetchStage::Extracting, 0, Some(10))));
+
+        // And Extracting → Verifying flips immediately too.
+        assert!(t.should_emit(&ev(FetchStage::Verifying, 0, None)));
+    }
+
+    /// On non-Downloading stages (where the byte-step gate is
+    /// dropped), events arriving inside the 100 ms window are
+    /// suppressed; events arriving after ≥100 ms pass through.
+    #[test]
+    fn throttle_respects_100ms_interval() {
+        let mut t = FetchProgressThrottle::default_policy();
+
+        // Seed: first Extracting event always emits.
+        assert!(t.should_emit(&ev(FetchStage::Extracting, 1, Some(100))));
+
+        // Immediate follow-up — within 100 ms, no stage change, so
+        // dropped on the interval gate (byte-step doesn't apply).
+        assert!(!t.should_emit(&ev(FetchStage::Extracting, 2, Some(100))));
+
+        // After ≥100 ms, the next event passes.
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(t.should_emit(&ev(FetchStage::Extracting, 3, Some(100))));
+    }
+
+    /// On the Downloading stage, the 256 KiB byte-step gate ANDs with
+    /// the 100 ms interval gate — a small byte delta is dropped even
+    /// after the interval elapses.
+    #[test]
+    fn throttle_respects_256kib_byte_step_on_downloading() {
+        let mut t = FetchProgressThrottle::default_policy();
+
+        // Seed at 0 bytes.
+        assert!(t.should_emit(&dl(0, Some(10_000_000))));
+
+        // Wait past the interval gate so only the byte gate can block.
+        std::thread::sleep(Duration::from_millis(120));
+
+        // Δ = 64 KiB < 256 KiB — dropped on the byte gate even
+        // though the 100 ms window has elapsed.
+        assert!(!t.should_emit(&dl(64 * 1024, Some(10_000_000))));
+
+        // Δ = 256 KiB exactly — meets the threshold, emits.
+        assert!(t.should_emit(&dl(256 * 1024, Some(10_000_000))));
+    }
+
+    /// The final-byte event (`bytes_done >= bytes_total`, with
+    /// `bytes_total > 0`) bypasses both gates so the progress bar
+    /// snaps cleanly to 100% before the stage flips.
+    #[test]
+    fn throttle_emits_final_byte_event_regardless_of_throttle() {
+        let mut t = FetchProgressThrottle::default_policy();
+        let total: u64 = 1_000_000;
+
+        // Seed with the first chunk; stage-changed bypass fires.
+        assert!(t.should_emit(&dl(0, Some(total))));
+
+        // Immediate follow-up at the final byte — would normally be
+        // suppressed (interval < 100 ms, byte gate could fail too),
+        // but the final_byte bypass forces an emit.
+        assert!(t.should_emit(&dl(total, Some(total))));
+
+        // bytes_total = None means we can't compute "final" — those
+        // events fall through the normal gates. With no time elapsed
+        // and a small byte delta, the second event drops.
+        let mut t2 = FetchProgressThrottle::default_policy();
+        assert!(t2.should_emit(&dl(0, None)));
+        assert!(!t2.should_emit(&dl(1, None)));
+    }
+
+    /// `bytes_done` carries different semantics across stages
+    /// (compressed download bytes vs. entry counts), so on a stage
+    /// transition the bytes counter resets — the next event in the
+    /// new stage must not be measured against the old stage's
+    /// `last_bytes`.
+    #[test]
+    fn throttle_resets_bytes_on_stage_transition() {
+        let mut t = FetchProgressThrottle::default_policy();
+
+        // Walk through a download up to 10 MiB.
+        assert!(t.should_emit(&dl(0, Some(10 * 1024 * 1024))));
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(t.should_emit(&dl(10 * 1024 * 1024, Some(10 * 1024 * 1024))));
+
+        // Now the stage flips to Extracting with bytes_done=1
+        // (entry index, not a 10 MiB regression). Stage-change
+        // bypass fires.
+        assert!(t.should_emit(&ev(FetchStage::Extracting, 1, Some(100))));
+
+        // Wait past the interval. The next Extracting event at
+        // bytes_done=2 must emit — last_bytes was reset to 1 on the
+        // transition, so the byte gate (which Extracting doesn't even
+        // apply, but the internal reset matters) doesn't compare 2
+        // against the old 10 MiB value.
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(t.should_emit(&ev(FetchStage::Extracting, 2, Some(100))));
     }
 }

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -14,7 +14,6 @@ use hyrr_core::types::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, State};
 
 // ---------------------------------------------------------------------------
@@ -267,91 +266,21 @@ pub fn install_from_local_tarball(app: AppHandle, path: String) -> Result<String
 }
 
 /// Build a closure that emits each [`FetchProgress`] event onto
-/// `hyrr://data-fetch-progress`, but rate-limits to ≤1 emit per
-/// 100 ms *and* a min-step of 256 KiB on byte-progress events (so a
-/// 64 KiB chunk loop emits roughly every 4th chunk during download).
-/// The download-stage gate is `bytes_step ≥ 256 KiB AND interval ≥
-/// 100 ms` — both must be satisfied to emit. The non-byte stages
-/// (extract entry counts, verifying) drop the bytes gate and use
-/// the 100 ms interval alone, otherwise the UI would freeze on
-/// "Extracting" with no updates between stage transitions. Stage
-/// changes and the final-byte event bypass the throttle so the
-/// progress bar snaps cleanly between phases.
+/// `hyrr://data-fetch-progress`, throttled by the canonical policy in
+/// [`hyrr_core::data_fetch::throttle`] (100 ms interval + 256 KiB
+/// byte-step on Downloading; stage transitions and final-byte events
+/// bypass the throttle). See the throttle's docs for the full gate
+/// matrix — this site is just the IPC sink.
 fn throttled_emit(app: &AppHandle) -> impl FnMut(FetchProgress) + '_ {
-    use hyrr_core::data_fetch::FetchStage;
-
-    let mut last_emit_at: Option<Instant> = None;
-    let mut last_bytes: u64 = 0;
-    let mut last_stage: Option<FetchStage> = None;
-    let min_interval = Duration::from_millis(100);
-    let min_bytes_step: u64 = 256 * 1024;
-
-    move |p: FetchProgress| {
-        let now = Instant::now();
-
-        let stage_changed = match last_stage {
-            None => true,
-            Some(prev) => !same_stage(prev, p.stage),
-        };
-
-        let final_byte = match p.bytes_total {
-            Some(total) => p.bytes_done >= total && total > 0,
-            None => false,
-        };
-
-        let interval_ok = last_emit_at
-            .map(|t| now.saturating_duration_since(t) >= min_interval)
-            .unwrap_or(true);
-
-        // Reset the bytes counter on stage transition — bytes_done
-        // means different things across stages (compressed bytes vs.
-        // entry count) so the carry-over check is meaningless.
-        let bytes_step_ok = match (last_stage, p.stage) {
-            (Some(prev), curr) if !same_stage(prev, curr) => true,
-            _ => p
-                .bytes_done
-                .checked_sub(last_bytes)
-                .map(|d| d >= min_bytes_step)
-                .unwrap_or(true),
-        };
-
-        // Only the Downloading stage carries reliable byte counts in
-        // 256-KiB-meaningful units. Other stages emit on the 100 ms
-        // interval alone — prevents Extracting from going silent
-        // because entry counts never tick by 256 KiB.
-        let should_emit = stage_changed
-            || final_byte
-            || match p.stage {
-                FetchStage::Downloading => interval_ok && bytes_step_ok,
-                FetchStage::Connecting
-                | FetchStage::Extracting
-                | FetchStage::Verifying => interval_ok,
-            };
-        if !should_emit {
-            return;
-        }
-
-        last_emit_at = Some(now);
-        last_bytes = p.bytes_done;
-        last_stage = Some(p.stage);
+    let app = app.clone();
+    hyrr_core::data_fetch::throttle(move |p: FetchProgress| {
         // Failure to emit means the window has closed or no listener
         // is attached — both are recoverable from the user's
         // perspective, so log and proceed.
         if let Err(e) = app.emit("hyrr://data-fetch-progress", &p) {
             eprintln!("emit data-fetch-progress: {e}");
         }
-    }
-}
-
-fn same_stage(a: hyrr_core::data_fetch::FetchStage, b: hyrr_core::data_fetch::FetchStage) -> bool {
-    use hyrr_core::data_fetch::FetchStage::*;
-    matches!(
-        (a, b),
-        (Connecting, Connecting)
-            | (Downloading, Downloading)
-            | (Extracting, Extracting)
-            | (Verifying, Verifying)
-    )
+    })
 }
 
 /// SSoT accessors for the data-fetch path. Each command is a thin

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -6,7 +6,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Mutex;
-use std::time::{Duration, Instant};
 
 use hyrr_core::bateman::bateman_activity as rust_bateman;
 use hyrr_core::compute::compute_stack;
@@ -242,67 +241,20 @@ fn stage_str(stage: FetchStage) -> &'static str {
     }
 }
 
-/// Build a closure that throttles `FetchProgress` events and forwards them
-/// to a Python callable. The throttle matches the desktop's
-/// `throttled_emit` (≤1 emit per 100 ms *and* ≥256 KiB byte-step on the
-/// Downloading stage; stage transitions and the final-byte event always
-/// pass through). Without it a 100 MB download crosses the GIL ~thousands
-/// of times during the chunk loop, which destroys both throughput and the
-/// CLI's render budget.
+/// Build a closure that forwards `FetchProgress` events to a Python
+/// callable, throttled by the canonical policy in
+/// [`hyrr_core::data_fetch::throttle`] (≤1 emit per 100 ms + 256 KiB
+/// byte-step on Downloading; stage transitions and final-byte events
+/// bypass the throttle). Without throttling a 100 MB download crosses
+/// the GIL ~thousands of times during the chunk loop, which destroys
+/// both throughput and the CLI's render budget.
 ///
 /// Exception safety: if the Python callable raises, we **swallow** the
 /// exception (logging it via `PyErr::print`) and return — propagating it
 /// would unwind through the Rust fetch state machine and abort the
 /// download. The progress bar is cosmetic; never let it crash the install.
 fn make_py_progress(progress_obj: Py<PyAny>) -> impl FnMut(FetchProgress) {
-    let mut last_emit_at: Option<Instant> = None;
-    let mut last_bytes: u64 = 0;
-    let mut last_stage: Option<FetchStage> = None;
-    let min_interval = Duration::from_millis(100);
-    let min_bytes_step: u64 = 256 * 1024;
-
-    move |p: FetchProgress| {
-        let now = Instant::now();
-
-        let stage_changed = match last_stage {
-            None => true,
-            Some(prev) => !same_stage(prev, p.stage),
-        };
-
-        let final_byte = match p.bytes_total {
-            Some(total) => p.bytes_done >= total && total > 0,
-            None => false,
-        };
-
-        let interval_ok = last_emit_at
-            .map(|t| now.saturating_duration_since(t) >= min_interval)
-            .unwrap_or(true);
-
-        let bytes_step_ok = match (last_stage, p.stage) {
-            (Some(prev), curr) if !same_stage(prev, curr) => true,
-            _ => p
-                .bytes_done
-                .checked_sub(last_bytes)
-                .map(|d| d >= min_bytes_step)
-                .unwrap_or(true),
-        };
-
-        let should_emit = stage_changed
-            || final_byte
-            || match p.stage {
-                FetchStage::Downloading => interval_ok && bytes_step_ok,
-                FetchStage::Connecting
-                | FetchStage::Extracting
-                | FetchStage::Verifying => interval_ok,
-            };
-        if !should_emit {
-            return;
-        }
-
-        last_emit_at = Some(now);
-        last_bytes = p.bytes_done;
-        last_stage = Some(p.stage);
-
+    data_fetch::throttle(move |p: FetchProgress| {
         Python::attach(|py| {
             let dict = PyDict::new(py);
             // Best-effort population — set_item only fails on OOM, which
@@ -316,17 +268,7 @@ fn make_py_progress(progress_obj: Py<PyAny>) -> impl FnMut(FetchProgress) {
                 err.print(py);
             }
         });
-    }
-}
-
-fn same_stage(a: FetchStage, b: FetchStage) -> bool {
-    matches!(
-        (a, b),
-        (FetchStage::Connecting, FetchStage::Connecting)
-            | (FetchStage::Downloading, FetchStage::Downloading)
-            | (FetchStage::Extracting, FetchStage::Extracting)
-            | (FetchStage::Verifying, FetchStage::Verifying)
-    )
+    })
 }
 
 /// Implements `hyrr fetch-data`. Exactly one of the four mutually-exclusive


### PR DESCRIPTION
Closes #180.

## What changed

Extracts the throttled-emit policy from `desktop/src-tauri/src/commands.rs::throttled_emit` (landed via #160) and `py/src/lib.rs::make_py_progress` (landed via #179) into a single `hyrr_core::data_fetch::throttle()` combinator. Same throttle policy (100 ms interval + 256 KiB byte-step on Downloading; stage transitions and final-byte events bypass), just lives in one place now.

Three commits:

1. **`refactor(core)`** — adds `FetchProgressThrottle` + `throttle()` combinator + 5 unit tests covering the gate matrix (stage-change bypass, 100 ms interval, 256 KiB byte-step on Downloading only, final-byte bypass, bytes-reset on stage transition).
2. **`refactor(desktop)`** — reduces `throttled_emit` from ~85 LOC to ~10. Sink is the existing `app.emit(\"hyrr://data-fetch-progress\")` + Err-logging closure.
3. **`refactor(py)`** — reduces `make_py_progress` similarly. Sink is the `Python::attach` block that builds a dict and calls the Python callable.

## No behavioural change

The throttle constants and gate logic are bit-identical to what shipped via #160 / #179. The unit tests in commit 1 codify the cadence so a future tweak gets caught.

## Net diff

- Core: +~220 LOC (the throttle + 5 tests).
- Desktop: -79 / +18 LOC.
- Py: -67 / +9 LOC.

Net: roughly break-even on LOC, but call sites are now a 1-liner around the sink closure, and any future throttle tweak (e.g. when #159 tracing wires in) only changes one place.

## Provenance note

Original /land agent hit Anthropic API rate limit ~80% through, after committing commit 1 and finishing the diff for commit 2 (uncommitted). I finished commits 2 + 3 directly — pure pattern-match against commit 1's design, no judgement calls beyond what the agent had already prototyped. All three commits structurally identical at the API level.

## Verification

- `cargo test --lib data_fetch -- --skip data_version_is_resolved_from_submodule` — 33 pass (was 28 + 5 new throttle tests; the skipped one is env-dependent on submodule init, same as #160's PR notes).
- `cargo check` clean on `core/`, `desktop/src-tauri/` (in a worktree with submodule symlink), and `py/`.
- Manual line-by-line walkthrough: the deleted code in both desktop and py is 1:1 replaced by `data_fetch::throttle(sink)` with no policy delta.

## Out of scope

- Throttle constants (100 ms / 256 KiB) are inherited — separate PR if we ever tune them.
- Back-pressure signal from sink to throttle — neither call site needs it today.

Refs: #160, #172, #179, #180