### PR TITLE
chore: gitignore local scratch + track 3 regression probes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,3 +228,12 @@ data/*.sqlite
 # Tauri
 desktop/src-tauri/target/
 hyrr-*.png
+
+# Local dev screenshots/scratch (separate from hyrr-*.png export naming)
+rnp-*.png
+
+# Playwright MCP scratch — snapshot / page / screencap output (Apr 2026 onwards)
+.playwright-mcp/
+
+# Claude Code runtime locks
+.claude/scheduled_tasks.lock

--- a/core/examples/probe_chain_solver_58.rs
+++ b/core/examples/probe_chain_solver_58.rs
@@ -1,0 +1,220 @@
+//! Probe for hyrr issue #58: does `solve_chain` produce step-function activities
+//! for short-lived isotopes because `matrix_exp` on the augmented 2×2 matrix
+//! `[[-λ·dt, dt], [0, 0]]` returns garbage?
+//!
+//! Three experiments:
+//!   (1) For ¹⁵O at dt = 72 s, compare e_aug[1] (top-right entry) against the
+//!       closed-form φ₁(-λ·dt)·dt = (exp(-λ·dt) − 1) / (-λ).
+//!   (2) Sweep dt ∈ {0.5, 5, 50, 500, 5000} s — find at what scale (if any)
+//!       the augmented-matrix exponential breaks down.
+//!   (3) Drive a 1-isotope "chain" by stepping the ODE dN/dt = -λN + R via the
+//!       same `step_irradiation` path used in `chains.rs::solve_chain`, and
+//!       compare A(t) = λ·N(t) against the analytical Bateman curve at every
+//!       grid point. Report max relative error.
+
+use hyrr_core::bateman::bateman_activity;
+use hyrr_core::matrix_exp::{mat_vec_mul, matrix_exp};
+
+const LN2: f64 = std::f64::consts::LN_2;
+
+/// Re-implementation of `chains.rs::step_irradiation` (private there) so the
+/// probe exercises the exact same call sequence: scaled A, matrix_exp(A·dt),
+/// then matrix_exp on the 2n×2n augmented matrix to recover ∫exp(A·s)R ds.
+fn step_irradiation(a: &[f64], r: &[f64], n_state: &[f64], dt: f64, n: usize) -> Vec<f64> {
+    let a_dt: Vec<f64> = a.iter().map(|&x| x * dt).collect();
+    let ea = matrix_exp(&a_dt, n);
+    let mut result = mat_vec_mul(&ea, n_state, n);
+
+    let m = 2 * n;
+    let mut aug_m = vec![0.0; m * m];
+    for i in 0..n {
+        for j in 0..n {
+            aug_m[i * m + j] = a[i * n + j] * dt;
+        }
+    }
+    for i in 0..n {
+        aug_m[i * m + (n + i)] = dt;
+    }
+
+    let e_aug = matrix_exp(&aug_m, m);
+
+    for i in 0..n {
+        for j in 0..n {
+            result[i] += e_aug[i * m + (n + j)] * r[j];
+        }
+    }
+
+    result
+}
+
+/// Build the 2×2 augmented matrix [[-λ·dt, dt], [0, 0]] used inside
+/// step_irradiation for a 1-isotope chain.
+fn aug_2x2(lambda: f64, dt: f64) -> Vec<f64> {
+    vec![-lambda * dt, dt, 0.0, 0.0]
+}
+
+/// Closed form for φ₁(-λ·dt)·dt = (1 − exp(-λ·dt)) / λ.
+fn phi1_dt_closed(lambda: f64, dt: f64) -> f64 {
+    if lambda == 0.0 {
+        dt
+    } else {
+        (1.0 - (-lambda * dt).exp()) / lambda
+    }
+}
+
+fn norm1(m: &[f64], n: usize) -> f64 {
+    let mut max_col = 0.0_f64;
+    for j in 0..n {
+        let mut s = 0.0;
+        for i in 0..n {
+            s += m[i * n + j].abs();
+        }
+        if s > max_col {
+            max_col = s;
+        }
+    }
+    max_col
+}
+
+fn print_aug_result(label: &str, lambda: f64, dt: f64) {
+    let aug = aug_2x2(lambda, dt);
+    let n1 = norm1(&aug, 2);
+    let e = matrix_exp(&aug, 2);
+    let expected_top_right = phi1_dt_closed(lambda, dt);
+    let expected_top_left = (-lambda * dt).exp();
+
+    let rel_err_top_right = if expected_top_right.abs() > 0.0 {
+        (e[1] - expected_top_right).abs() / expected_top_right.abs()
+    } else {
+        e[1].abs()
+    };
+    let rel_err_top_left = if expected_top_left.abs() > 0.0 {
+        (e[0] - expected_top_left).abs() / expected_top_left.abs()
+    } else {
+        e[0].abs()
+    };
+
+    println!(
+        "{label}  λ·dt={:.4e}  ‖aug‖₁={:.3e}",
+        lambda * dt,
+        n1
+    );
+    println!(
+        "  e_aug = [[{:.6e}, {:.6e}], [{:.6e}, {:.6e}]]",
+        e[0], e[1], e[2], e[3]
+    );
+    println!(
+        "  expected top-left  exp(-λ·dt)        = {:.6e}   got {:.6e}   rel_err={:.2e}",
+        expected_top_left, e[0], rel_err_top_left
+    );
+    println!(
+        "  expected top-right (1-exp(-λ·dt))/λ = {:.6e}   got {:.6e}   rel_err={:.2e}",
+        expected_top_right, e[1], rel_err_top_right
+    );
+    println!(
+        "  expected bottom-row [0, 1]; got [{:.3e}, {:.6e}]",
+        e[2], e[3]
+    );
+}
+
+fn main() {
+    let half_life = 122.24_f64; // O-15
+    let lambda = LN2 / half_life;
+
+    println!("=== EXPERIMENT 1: augmented 2×2 at dt = 72 s (O-15) ===");
+    print_aug_result("[O-15, dt=72]", lambda, 72.0);
+
+    println!("\n=== EXPERIMENT 2: dt sweep on the augmented 2×2 (O-15) ===");
+    for &dt in &[0.5_f64, 5.0, 50.0, 500.0, 5000.0] {
+        print_aug_result(&format!("[dt={dt}]"), lambda, dt);
+    }
+
+    println!("\n=== EXPERIMENT 3: 1-isotope step-loop vs analytical Bateman ===");
+    let r = 1.294e11_f64;
+    let irr = 7200.0_f64; // 2 h
+    let cool = 3600.0_f64; // 1 h
+    let n_time_points = 200_usize;
+
+    // Replicate the linspace half-half grid used by solve_chain.
+    let n_irr = n_time_points / 2;
+    let n_cool = n_time_points - n_irr;
+    let t_irr: Vec<f64> = (0..n_irr)
+        .map(|i| i as f64 * irr / (n_irr - 1) as f64)
+        .collect();
+    let t_cool: Vec<f64> = (1..=n_cool)
+        .map(|i| irr + i as f64 * cool / n_cool as f64)
+        .collect();
+    let mut time_grid = Vec::with_capacity(n_irr + n_cool);
+    time_grid.extend_from_slice(&t_irr);
+    time_grid.extend_from_slice(&t_cool);
+
+    // 1-isotope decay matrix and production rate (units: atoms / s).
+    let a_mat = vec![-lambda];
+    let r_vec = vec![r];
+
+    let mut n_state = vec![0.0_f64];
+    let mut abundances = vec![0.0_f64; time_grid.len()];
+
+    // Irradiation phase
+    for ti in 1..n_irr {
+        let dt = t_irr[ti] - t_irr[ti - 1];
+        n_state = step_irradiation(&a_mat, &r_vec, &n_state, dt, 1);
+        if n_state[0] < 0.0 {
+            n_state[0] = 0.0;
+        }
+        abundances[ti] = n_state[0];
+    }
+    // Cooling phase: pure decay (matches solve_chain's cooling branch).
+    for ti in 0..n_cool {
+        let t_prev = if ti == 0 { irr } else { t_cool[ti - 1] };
+        let dt = t_cool[ti] - t_prev;
+        let a_dt = vec![-lambda * dt];
+        let ea = matrix_exp(&a_dt, 1);
+        n_state[0] = ea[0] * n_state[0];
+        if n_state[0] < 0.0 {
+            n_state[0] = 0.0;
+        }
+        abundances[n_irr + ti] = n_state[0];
+    }
+
+    // Compare to bateman_activity on the same grid.
+    let bat = bateman_activity(r, Some(half_life), irr, cool, n_time_points);
+
+    let mut max_abs_err = 0.0_f64;
+    let mut max_rel_err = 0.0_f64;
+    let mut max_rel_idx = 0usize;
+    println!(
+        "  {:>3}  {:>9}  {:>12}  {:>12}  {:>10}",
+        "i", "t (s)", "A_chain", "A_bateman", "rel_err"
+    );
+    for i in 0..time_grid.len() {
+        let a_chain = lambda * abundances[i];
+        let a_ref = bat.activity[i];
+        let abs_err = (a_chain - a_ref).abs();
+        let rel = if a_ref.abs() > 1e-30 {
+            abs_err / a_ref.abs()
+        } else {
+            0.0
+        };
+        if abs_err > max_abs_err {
+            max_abs_err = abs_err;
+        }
+        if rel > max_rel_err {
+            max_rel_err = rel;
+            max_rel_idx = i;
+        }
+        if [0_usize, 1, 2, 5, 10, 50, 98, 99, 100, 101, 150, 199]
+            .iter()
+            .any(|&j| j == i)
+        {
+            println!(
+                "  {:>3}  {:>9.2}  {:>12.4e}  {:>12.4e}  {:>10.2e}",
+                i, time_grid[i], a_chain, a_ref, rel
+            );
+        }
+    }
+    println!(
+        "  max_abs_err = {:.4e}   max_rel_err = {:.4e}  at i={} t={:.2}s",
+        max_abs_err, max_rel_err, max_rel_idx, time_grid[max_rel_idx]
+    );
+}

--- a/core/examples/probe_stopping.rs
+++ b/core/examples/probe_stopping.rs
@@ -1,0 +1,93 @@
+//! Probe proton stopping on Ti → Al → Al stack at 18 MeV.
+//! User report: 1 mm Al appears to stop the beam entirely — sanity check
+//! against NIST PSTAR, which gives CSDA range ≈ 2.4 mm Al @ 18 MeV.
+
+use hyrr_core::db::ParquetDataStore;
+use hyrr_core::materials::resolve_material;
+use hyrr_core::stopping::{compute_energy_out, dedx_mev_per_cm};
+use hyrr_core::types::*;
+
+fn main() {
+    let data_dir =
+        std::env::var("HYRR_DATA").unwrap_or_else(|_| "../nucl-parquet/data".to_string());
+    let db = ParquetDataStore::new(&data_dir, "tendl-2024").unwrap();
+
+    let al = resolve_material(&db, "Al", None);
+    let ti = resolve_material(&db, "Ti", None);
+
+    let al_comp: Vec<(u32, f64)> = {
+        let mut raw: Vec<(u32, f64)> = Vec::new();
+        for (elem, atom_frac) in &al.elements {
+            let mut avg_mass = 0.0_f64;
+            for (&a, &ab) in &elem.isotopes {
+                avg_mass += a as f64 * ab;
+            }
+            raw.push((elem.z, atom_frac * avg_mass));
+        }
+        let total: f64 = raw.iter().map(|(_, w)| w).sum();
+        raw.iter().map(|&(z, w)| (z, w / total)).collect()
+    };
+    let ti_comp: Vec<(u32, f64)> = {
+        let mut raw: Vec<(u32, f64)> = Vec::new();
+        for (elem, atom_frac) in &ti.elements {
+            let mut avg_mass = 0.0_f64;
+            for (&a, &ab) in &elem.isotopes {
+                avg_mass += a as f64 * ab;
+            }
+            raw.push((elem.z, atom_frac * avg_mass));
+        }
+        let total: f64 = raw.iter().map(|(_, w)| w).sum();
+        raw.iter().map(|&(z, w)| (z, w / total)).collect()
+    };
+
+    let he = resolve_material(&db, "He", None);
+    let he_comp: Vec<(u32, f64)> = {
+        let mut raw: Vec<(u32, f64)> = Vec::new();
+        for (elem, atom_frac) in &he.elements {
+            let mut avg_mass = 0.0_f64;
+            for (&a, &ab) in &elem.isotopes {
+                avg_mass += a as f64 * ab;
+            }
+            raw.push((elem.z, atom_frac * avg_mass));
+        }
+        let total: f64 = raw.iter().map(|(_, w)| w).sum();
+        raw.iter().map(|&(z, w)| (z, w / total)).collect()
+    };
+
+    // Point-wise dE/dx at a few energies for both materials
+    let proj = ProjectileType::Alpha;
+    let energies = vec![18.0_f64, 15.0, 10.0, 5.0, 2.0, 1.0];
+    println!("dE/dx [MeV/cm] for p+ at various E (density applied):");
+    for &e in &energies {
+        let al_v = dedx_mev_per_cm(&db, &proj, &al_comp, al.density, &[e]).unwrap()[0];
+        let ti_v = dedx_mev_per_cm(&db, &proj, &ti_comp, ti.density, &[e]).unwrap()[0];
+        // NIST PSTAR reference (no density factor):
+        // Al @ 18 MeV: 24.5 MeV cm²/g × 2.70 g/cm³ = 66 MeV/cm expected
+        println!("  E={:>5.2} MeV   Al={:>8.3}   Ti={:>8.3}", e, al_v, ti_v);
+    }
+
+    // Full stack: pass E_in through each layer in turn (matches user URL)
+    println!();
+    println!("Passing 18 MeV α through user's stack:");
+    let mut e = 18.0_f64;
+    let steps: Vec<(&str, f64, f64, &Vec<(u32, f64)>)> = vec![
+        ("Ti window (0.025 mm)", 0.0025, ti.density, &ti_comp),
+        ("He gas (30 mm @ STP)", 3.0, he.density, &he_comp),
+        ("Al (1 mm)", 0.1, al.density, &al_comp),
+    ];
+    for (label, thick_cm, dens, comp) in steps {
+        let e_out = compute_energy_out(&db, &proj, comp, dens, e, thick_cm, 1000).unwrap();
+        let dedx_avg = (e - e_out) / thick_cm;
+        println!(
+            "  {:>24}   E {:>6.2} → {:>6.2} MeV   ⟨dE/dx⟩={:.2} MeV/cm",
+            label, e, e_out, dedx_avg
+        );
+        e = e_out;
+    }
+
+    println!();
+    println!("Expected (NIST ASTAR for α):");
+    println!("  18 MeV α in Al: dE/dx ≈ 540 MeV/cm (~200 MeV·cm²/g × 2.70 g/cm³)");
+    println!("  CSDA range at 18 MeV α ≈ 0.26 mm Al — 1 mm Al stops the beam.");
+    println!("  Bragg peak at ~E<1 MeV gives dE/dx ~ 5000 MeV/cm near end of range.");
+}

--- a/core/examples/scan_sc44.rs
+++ b/core/examples/scan_sc44.rs
@@ -1,0 +1,96 @@
+//! Scan: Sc-44g / Sc-44m production from ⁴⁴Ca-enriched target (99 %) via p,X
+//! over 5 → 15 MeV.
+//!
+//! Emits TSV on stdout:
+//!     E_MeV   E_out   rate_Sc44g   rate_Sc44m   A_Sc44g_Bq   A_Sc44m_Bq   ratio
+//! with one row per scan step. Feed into a plotter.
+
+use std::collections::HashMap;
+
+use hyrr_core::compute::compute_stack;
+use hyrr_core::db::ParquetDataStore;
+use hyrr_core::materials::resolve_material;
+use hyrr_core::types::*;
+
+fn main() {
+    let data_dir =
+        std::env::var("HYRR_DATA").unwrap_or_else(|_| "../nucl-parquet/data".to_string());
+    let mut db = ParquetDataStore::new(&data_dir, "tendl-2024").unwrap();
+    db.load_xs("p", 20).expect("load p+Ca");
+
+    // 99% Ca-44, remainder Ca-40 (most abundant stable alternative).
+    let mut enrichment: HashMap<String, HashMap<u32, f64>> = HashMap::new();
+    let mut ca_map = HashMap::new();
+    ca_map.insert(44, 0.99);
+    ca_map.insert(40, 0.01);
+    enrichment.insert("Ca".to_string(), ca_map);
+    let ca = resolve_material(&db, "Ca", Some(&enrichment));
+
+    // Thick-target: 2 mm Ca (range of 15 MeV p in Ca ≈ 1.6 mm so it stops the
+    // 5-15 MeV scan range). 1 µA beam, 1 h irradiation — activity at EOB in
+    // Bq is then the GBq/µA·h figure (divided by 1e9).
+    eprintln!("Ca composition used: density={} g/cm³", ca.density);
+    for (el, f) in &ca.elements {
+        eprintln!(
+            "  {} Z={}  atom_frac={}  isotopes={:?}",
+            el.symbol, el.z, f, el.isotopes
+        );
+    }
+    eprintln!();
+
+    let make_layer = || Layer {
+        density_g_cm3: ca.density,
+        elements: ca.elements.clone(),
+        thickness_cm: Some(0.2), // 2 mm
+        areal_density_g_cm2: None,
+        energy_out_mev: None,
+        is_monitor: false,
+        computed_energy_in: 0.0,
+        computed_energy_out: 0.0,
+        computed_thickness: 0.0,
+    };
+
+    let current_ma = 1e-3_f64; // 1 µA
+    let irr_s = 3600.0_f64; // 1 h
+    let cool_s = 0.0_f64;
+
+    println!(
+        "{}",
+        "E_MeV\tE_out_MeV\trate_Sc44g\trate_Sc44m\tA_Sc44g_Bq\tA_Sc44m_Bq\tratio_g_over_m\tGBq_per_uAh_total"
+    );
+
+    let steps: Vec<f64> = (0..=40).map(|i| 5.0 + i as f64 * 0.25).collect(); // 40 steps 5→15 MeV
+    for &e_in in &steps {
+        let mut stack = TargetStack {
+            beam: Beam::new(ProjectileType::Proton, e_in, current_ma),
+            layers: vec![make_layer()],
+            irradiation_time_s: irr_s,
+            cooling_time_s: cool_s,
+            area_cm2: 1.0,
+            current_profile: None,
+        };
+        let res = compute_stack(&db, &mut stack, true).unwrap();
+        let lr = &res.layer_results[0];
+        let sc44g = lr
+            .isotope_results
+            .get("Sc-44")
+            .map(|i| (i.production_rate, i.activity_bq))
+            .unwrap_or((0.0, 0.0));
+        let sc44m = lr
+            .isotope_results
+            .get("Sc-44m")
+            .map(|i| (i.production_rate, i.activity_bq))
+            .unwrap_or((0.0, 0.0));
+        let ratio = if sc44m.0 > 0.0 {
+            sc44g.0 / sc44m.0
+        } else {
+            f64::INFINITY
+        };
+        let total_gbq = (sc44g.1 + sc44m.1) / 1.0e9;
+
+        println!(
+            "{:.3}\t{:.3}\t{:.6e}\t{:.6e}\t{:.6e}\t{:.6e}\t{:.6e}\t{:.6e}",
+            e_in, lr.energy_out, sc44g.0, sc44m.0, sc44g.1, sc44m.1, ratio, total_gbq
+        );
+    }
+}


### PR DESCRIPTION
Pre-release housekeeping (CalVer data + SemVer code).

## What

- Adds three `core/examples/probe_*.rs` files that have been sitting untracked alongside the existing tracked ones. They're regression harnesses with explicit issue references — same style as `probe_table.rs` / `probe_bateman.rs` / `probe_cooltime.rs` which are already on main.
- Adds four `.gitignore` entries covering local scratch: `rnp-*.png` (screenshot dump), `.playwright-mcp/` (158+ MCP debug snapshots from Apr 2026 onwards), and `.claude/scheduled_tasks.lock` (Claude Code runtime lock).

## Test plan

- [x] `cargo check --examples` clean — the probes compile against current main APIs
- [ ] After merge, primary working tree shows zero untracked files