### PR TITLE
docs(ci): fix stale comment in docs.yml — docs deploy is in promote-to-prod

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,11 @@
-# Docs are now built as part of deploy-frontend.yml and served at /docs/
-# This workflow only validates the docs build (no deploy).
+# Docs deploy lives in `promote-to-prod.yml` (manual workflow_dispatch):
+# mkdocs builds into `frontend/dist/docs/` and the whole tree ships to the
+# gh-pages branch root, served at https://exoma-ch.github.io/hyrr/docs/.
+# `deploy-frontend.yml` (auto on push to main) only deploys the frontend to
+# /hyrr/tst/ — docs are NOT in the staging slot.
+#
+# This workflow is PR-time validation only: catches docs breakage before
+# merge so a future promote-to-prod doesn't fail half-way through.
 name: Validate docs
 
 on:


### PR DESCRIPTION
The header comment in `.github/workflows/docs.yml` claimed docs were built as part of `deploy-frontend.yml`, but that workflow has never run \`mkdocs build\`. The actual deploy is in \`promote-to-prod.yml\` (manual \`workflow_dispatch\`).

## Pipeline reality

\`\`\`
push to main  → deploy-frontend.yml  → gh-pages /tst/  (frontend ONLY)
                       ↓
              deploy-staging-smoke.yml (post-deploy gate)
                       ↓
        manual: promote-to-prod.yml  → gh-pages /      (frontend + mkdocs → /docs/)
\`\`\`

Found while auditing the release pipeline ahead of a tagged release. One-line clarification, no functional change.

## Test plan

- [x] Workflow YAML still parses
- [ ] Comment matches actual behaviour of `promote-to-prod.yml` (verified by inspection of the latter)