### PR TITLE
chore(release): 0.8.0 — local-first

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,11 @@
-# Docs are now built as part of deploy-frontend.yml and served at /docs/
-# This workflow only validates the docs build (no deploy).
+# Docs deploy lives in `promote-to-prod.yml` (manual workflow_dispatch):
+# mkdocs builds into `frontend/dist/docs/` and the whole tree ships to the
+# gh-pages branch root, served at https://exoma-ch.github.io/hyrr/docs/.
+# `deploy-frontend.yml` (auto on push to main) only deploys the frontend to
+# /hyrr/tst/ — docs are NOT in the staging slot.
+#
+# This workflow is PR-time validation only: catches docs breakage before
+# merge so a future promote-to-prod doesn't fail half-way through.
 name: Validate docs
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,76 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] — 2026-05-12
+
+The **Local-first** release. Three architectural shifts let HYRR run as an
+honest offline-first tool: a lazy nuclear-data cache that no longer ships
+the 380 MB blob inside the installer, a typed-error chain that surfaces
+recoverable failures to the user instead of crashing the splash, and a
+real Tauri desktop app with auto-updater + cross-platform Playwright
+coverage. The MCP server is now a first-class entry point distributed via
+`uvx`. ~80 merged PRs since v0.7.0.
+
+### Added
+
+- **Tauri desktop app** with auto-updater (minisign-signed, build attestations) and external-link routing through `tauri-plugin-opener`. Ships as `.dmg` / `.msi` / `.deb` / `.AppImage` via GitHub Releases (#125, #129, #116).
+- **Lazy nuclear-data cache** — desktop and CLI fetch `nucl-parquet-data-v{V}.tar.zst` from GitHub Releases on first launch into `~/.hyrr/nucl-parquet/v{V}/`, with atomic install semantics (sentinel-last, partial-dir promotion, flock + process-mutex serialisation). The installer no longer bundles 380 MB of data (#52, #117, #121, #122, #123).
+- **Splash-screen recovery UI** — when `ensure_data` fails on first launch, a typed `FetchErrorCard` surfaces Retry / Open URL / Install from local tarball / Use bundled-data-only with the actual GitHub URL inline. Push-based `FetchProgress` events drive a live progress bar (`Connecting → Downloading → Extracting → Verifying`) so users can distinguish a slow download from a hang (#118, #160).
+- **Staging deploy slot** — every push to main lands at `https://exoma-ch.github.io/hyrr/tst/`. Promotion to prod (`/hyrr/`) is manual workflow_dispatch, gated by a post-deploy smoke test. Broken main commits can no longer reach the user-facing URL (#156, #187).
+- **MCP server as first-class entry** — `hyrr-mcp` PyPI package distributed via `uvx`, wheel matrix across Linux/macOS/Windows, trusted PyPI publishing. Library override via `--library` / `HYRR_LIBRARY`, parity coverage with the Python core, stopping-only fast path for `get_stack_energy_budget` (#67, #70, #71, #73, #79, #80, #82, #83, #84).
+- **Material-popup unified redesign** — rows-based DefineForm with paste-formula auto-detection (single-formula / mass-mixture / mole-mixture / by-atom), standalone PeriodicTable component, per-row enrichment "E" button, balance toggle, mode-switch undo strip, supplier links for enriched isotopes, gas-target catalog entries (#64 epic, #75, #77, #86, #88, #92, #93, #94, #95, #96, #97, #98).
+- **PWA installability** — manifest + iOS meta tags for "Add to Home Screen" on the web frontend (#34, #115).
+- **Bug-report modal Title field** with auto-derivation from description; "Open on GitHub" button greyed-with-hover-info until description has content; layer-stack clear-all × button (#144, #161-fix, #182).
+- **CLI progress bar** — `hyrr fetch-data` shows tqdm progress on TTY, one-line-per-stage on non-TTY. PyO3 binding accepts an optional Python callable that's invoked with throttled `FetchProgress` events (#172).
+- **Plot/table export** — CSV export on every plot, parquet session save/restore, save-icon dropdown unifying the surface.
+- **Greek-symbol decay/reaction labels** in the activity table (α, β−, β+, EC, γ) for compactness (#131).
+- **Display-layer value clamping** with configurable thresholds so the activity table doesn't render `1e-42 Bq` rows (#130).
+- **RNP%-multi-select** with searchable picker and per-curve max markers; grouped/per-layer toggle on the activity table.
+- **Test infrastructure tiers** — Tier 1 Rust projectile-matrix smoke (`core/tests/projectile_matrix.rs`), Tier 2 cross-platform Playwright E2E across Ubuntu/Windows/macOS + Linux distros (Arch/Fedora/Debian), `@testing-library/svelte` component-render coverage. 515 frontend tests, 30 Rust core lib tests (#148, #136, #169, #178).
+- **CI guards** — `cargo check -p hyrr-py` (catches PyO3 binding drift), `data-fetch-ssot` grep guard (no hardcoded release URLs in docs/code), `supplier-catalog-freshness` warning at >90 days stale (#180/#181/#183).
+
+### Changed
+
+- **nucl-parquet** bumped to v0.10.x — TENDL-2025 default across all surfaces, hi-xs-prod heavy-ion data, catima-derived stopping for Z≥6 projectiles (#91, #113, #127, #128).
+- **Default cross-section library** is `tendl-2025` everywhere; configurable via `--library`, `HYRR_LIBRARY`, or `DataStore(library=…)` (#91).
+- **Typed `StoppingError` / `FetchError` chains** replace `Result<_, String>` at all IPC boundaries. Frontend `parseStoppingError` / `parseFetchError` decode the JSON wire format into discriminated unions; recovery cards render variant-specific titles (`Couldn't download nuclear data — HTTP 404`, `Energy out of table range`, etc.) (#142, #150).
+- **Single source of truth for data-fetch constants** — `hyrr_core::data_fetch::{release_url,tarball_filename,cache_root_pattern,data_version}` plus mirror Tauri commands and frontend `data-fetch-meta.ts` getters. No more concrete `v0.10.0/nucl-parquet-data-v0.10.0.tar.zst` literals scattered across docs/CI/code (#118-contract, #157).
+- **Shared `FetchProgressThrottle`** — desktop and PyO3 binding both use one canonical 100 ms / 256 KiB combinator in `hyrr_core::data_fetch`. Replaced two ~60-LOC inline copies (#180).
+- **Activity-plot legend behaviour** — selection persists across `Plotly.react()` calls via a `Map<string, boolean | "legendonly">` instead of being clobbered on every re-render.
+- **`init_data_store` and `FetchErrorPayload`** redact `$HOME` to `~/…` before crossing the IPC boundary, so bug-report attachments don't leak the OS username (#173, #176).
+
+### Fixed
+
+- **Heavy-ion crashes** — `compute_stack` for C-12 / O-16 / Ne-20 / Si-28 / Ar-40 / Fe-56 hit a catima parquet-key mismatch (`catima_O-16` vs `catima_O16`); fixed by stripping the dash in the source-key construction and adding a typed-error path when the table lookup misses (#137-fix, #141, #142, #150, #161).
+- **Stale results displayed after compute failure** — the previous successful run's stats no longer mask a freshly-failed run; both `setResultErrored` and `setComputeError` fire from the scheduler's single funnel (#143).
+- **Activity clamp too loose** — `R × λt` allowed 40× spurious peaks mid-irradiation; replaced with the analytical saturation envelope `R × (1 − exp(−λt_irr))` (closes #55).
+- **Activity plot 1 trace per layer × N layers** — aggregated by isotope name; the per-layer view is now opt-in via a toggle (closes #54).
+- **Save-menu invisible** — dropdown was clipped by `overflow: hidden` on `.header-bar`; window-event handler had a flip race with the toggle button.
+- **External links no-op in WKWebView** — bug-report and GitHub buttons now route through `tauri-plugin-opener` instead of `window.open` (#129).
+- **Stale WASM binary** — checked-in `hyrr_wasm_bg.wasm` was 5 weeks behind the Rust source; rebuild + CI guard so future drift is caught (#152).
+- **Tarball extract refuses non-regular entries** — symlinks, hardlinks, devices, etc. are rejected before extraction (#122).
+- **Decay chain solver** — bypassed broken matrix-exp on chains of mixed half-lives, falls back to analytical Bateman per isotope (closes #58).
+- **`init_data_store` IPC error** no longer leaks the resolved data dir's absolute path (#176).
+- **Bug-report "Open on GitHub" silently failed** when description was empty — getSerializableConfig fallthrough fixed, plus an enable-gate with hover info on the disabled state (#137-related).
+
+### Removed
+
+- **Bundled 380 MB nuclear data from the installer** — replaced by lazy fetch on first launch (#52, #117). Air-gapped installs use `hyrr fetch-data --offline-bundle <path>`.
+- **Duplicate physics implementations in Python and TypeScript** — `hyrr_core` Rust crate is now the SSoT for stopping/compute/Bateman; PyO3 + WASM bindings expose it. The legacy Python core and TS port survived as compat shims through earlier releases; in 0.8 they're gone (#67-era rust-ssot-cutover).
+- **`feat/v0.7.1-batch`-era inline material picker** — superseded by the unified material-form redesign (#92, #98).
+
+### Security
+
+- **Tarball extraction** rejects symlinks/hardlinks/devices, eliminating a class of path-traversal vectors when installing from an untrusted offline bundle (#122).
+- **Tauri auto-updater** signs releases with minisign + verifies build attestations; the updater refuses unsigned releases (#116, #125).
+- **IPC payload redaction** — `$HOME` stripped from cache paths in error payloads so bug-report attachments don't carry the OS username (#173, #176).
+
+### Infrastructure
+
+- **CI matrix** now covers: Python (pyright + ruff + pytest), Rust projectile-matrix (Tier 1), cross-platform Playwright E2E (Tier 2: Ubuntu 22/24, Windows 22/25, macOS 15, Linux distros Arch/Fedora/Debian), `cargo check -p hyrr-py` (PyO3 drift), data-fetch SSoT grep, supplier-catalog freshness, docs build validation. ~15 jobs per PR depending on touched paths.
+- **Cross-platform Tauri builds** ship signed installers via GitHub Releases; minisign keys + auto-updater plumbing wired end-to-end.
+- **Staging slot** at `/hyrr/tst/` decouples broken main commits from the user-facing prod URL. Manual promotion via workflow_dispatch.
+
 ## [0.7.0] — 2026-03-27
 
 ### Changed

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "hyrr-desktop"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "hyrr-core",
  "serde",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyrr-desktop"
-version = "0.7.0"
+version = "0.8.0"
 description = "HYRR Desktop — offline nuclear data simulation"
 edition = "2021"
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "HYRR",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "ch.exoma.hyrr",
   "build": {
     "frontendDist": "../../frontend/dist",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hyrr-frontend",
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a17d1df96a6384b45",
+  "name": "hyrr",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -15,7 +15,7 @@
     },
     "frontend": {
       "name": "hyrr-frontend",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@hyrr/compute": "*",
         "@tauri-apps/api": "^2.10.1",
@@ -28,7 +28,7 @@
         "html2canvas": "^1.4.1",
         "hyparquet": "^1.7.0",
         "hyparquet-compressors": "^1.1.1",
-        "hyparquet-writer": "^0.13.1",
+        "hyparquet-writer": "^0.14.0",
         "hyrr-wasm": "file:src/lib/compute/hyrr-wasm-pkg",
         "plotly.js-dist-min": "^3.5.1"
       },
@@ -1408,9 +1408,9 @@
       }
     },
     "node_modules/hyparquet-writer": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/hyparquet-writer/-/hyparquet-writer-0.13.1.tgz",
-      "integrity": "sha512-ZnmCa9cfPWkMjnoBa7Fe6jlljT2MA199lpvZVyhwqpQ3WIkh04bYgeywYtPvLXPJAcpn5mefsdP88TgXs2XCjA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/hyparquet-writer/-/hyparquet-writer-0.14.0.tgz",
+      "integrity": "sha512-XRDZcw5pcoZoazLsKGnISGKzm8ql0dWwO9MamyU2sGOotypM8JW95J3oaLCroiCcO0sexfoI8naAK6KASFtNjg==",
       "license": "MIT",
       "dependencies": {
         "hyparquet": "1.25.6"
@@ -2640,7 +2640,7 @@
     },
     "packages/compute": {
       "name": "@hyrr/compute",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "hyparquet": "^1.7.0",
         "hyparquet-compressors": "^1.1.1"

--- a/packages/compute/package.json
+++ b/packages/compute/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyrr/compute",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyrr"
-version = "0.7.0"
+version = "0.8.0"
 description = "Hierarchical Yield and Radionuclide Rates — isotope production in stacked target assemblies"
 authors = [
     {name = "MorePET"},


### PR DESCRIPTION
Prepares the v0.8.0 release. Two parts:

## 1. Version bump across all surface manifests

| File | from → to |
|---|---|
| `pyproject.toml` | 0.7.0 → 0.8.0 |
| `frontend/package.json` | 0.7.0 → 0.8.0 |
| `packages/compute/package.json` | 0.7.0 → 0.8.0 |
| `desktop/src-tauri/Cargo.toml` | 0.7.0 → 0.8.0 |
| `desktop/src-tauri/tauri.conf.json` | 0.7.0 → 0.8.0 |

Lockfiles (`Cargo.lock`, `package-lock.json`) regenerated to match.

## 2. CHANGELOG entry for 0.8.0

Hand-written against the ~80 PRs landed since v0.7.0 (2026-03-27). Structured as Added / Changed / Fixed / Removed / Security / Infrastructure per Keep-a-Changelog, but grouped semantically rather than chronologically — major themes:

- **Lazy nuclear-data cache** — installer no longer ships 380 MB; first-launch fetch from GitHub Releases into `~/.hyrr/nucl-parquet/v{V}/` with atomic install semantics
- **Splash-screen recovery UI** — typed `FetchErrorPayload` drives a 4-button recovery card; push-based `FetchProgress` events drive a live progress bar
- **Tauri desktop app** — auto-updater (minisign + build attestations), external-link routing, cross-platform Playwright E2E coverage
- **MCP server productization** — `hyrr-mcp` PyPI package distributed via `uvx`, library override, parity coverage
- **Material-popup unified redesign** (#64 epic + #92) — rows-based DefineForm, PeriodicTable component, paste-formula auto-detection, supplier links, gas-target entries
- **Typed error chains** at all IPC boundaries — `StoppingError` (#142), `FetchError` (#118-contract), `$HOME` redaction (#173, #176)
- **Test infrastructure tiers** (#148) — Tier 1 Rust projectile-matrix, Tier 2 cross-platform Playwright, component-render coverage. 515 frontend tests, 30 Rust core lib tests
- **Staging-slot deploys** (#156, #187) — broken main commits can't reach the user-facing prod URL anymore

Follow-up: filing a separate spike to adopt `release-please` (or equivalent) for the v0.9 cycle so future CHANGELOGs aren't a one-person hand-edit job.

## Test plan

- [ ] CI green across all jobs
- [ ] After merge: `git tag v0.8.0 <merge-sha>` + `git push --tags` → triggers `release.yml` (PyPI publish + GH release) + `tauri-build.yml` (installers)
- [ ] After release: `promote-to-prod.yml` workflow_dispatch to ship the corresponding `/hyrr/` build with mkdocs

## Notes for the tag-cutter

- This PR is **only** prep — the actual release tag should be cut from the merge commit, not from `release/v0.8.0-changelog`.
- The deferred `dependabot/submodules/nucl-parquet-90ba544` PR (#163) should stay deferred until nucl-parquet ships the α-stopping fix (exoma-ch/nucl-parquet#137) — bumping DATA_VERSION before that fix lands forces all users into a re-download for a release that still has the known-bad ASTAR data.