### PR TITLE
feat!: bump nucl-parquet to data-2026.5.0 wire format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,21 @@ jobs:
       - name: Assert docs do not pin a concrete data tarball version
         run: |
           # SSoT: tarball filename pattern lives in core/src/data_fetch.rs.
-          # Concrete `vN.N.N` URLs in markdown drift silently when the
+          # Concrete CalVer URLs in markdown drift silently when the
           # submodule version bumps. Use placeholder `<V>` instead.
-          if grep -RnE 'nucl-parquet-data-v[0-9]+\.[0-9]+\.[0-9]+\.tar\.zst' docs/; then
+          # Wire format (nucl-parquet#151 — Path A) is CalVer
+          # YYYY.MM.MICRO, no `v` prefix; the 4-digit-year anchor
+          # forces this regex to match the new shape, not loose
+          # SemVer-shaped tokens like "data-1.2.3" that might appear
+          # in unrelated prose.
+          if grep -RnE 'nucl-parquet-data-[0-9]{4}\.[0-9]+\.[0-9]+\.tar\.zst' docs/; then
             echo "::error::docs hardcodes a concrete data-tarball version. Use <V> placeholder; SSoT is hyrr_core::data_fetch::release_url()."
+            exit 1
+          fi
+          # Also catch the legacy `v`-prefixed shape — anything still
+          # writing the pre-#151 format is a stale reference.
+          if grep -RnE 'nucl-parquet-data-v[0-9]+\.[0-9]+\.[0-9]+\.tar\.zst' docs/; then
+            echo "::error::docs uses the legacy v-prefixed tarball name (pre nucl-parquet#151). Update to data-<V> shape; SSoT is hyrr_core::data_fetch::release_url()."
             exit 1
           fi
       - name: Assert RELEASE_BASE host appears verbatim in data_fetch.rs

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -46,7 +46,8 @@ jobs:
           cp nucl-parquet/data/meta/abundances.parquet nucl-parquet/data/meta/decay.parquet nucl-parquet/data/meta/elements.parquet frontend/public/data/parquet/meta/
           cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
           cp -f nucl-parquet/data/meta/spectrum_xs.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet nucl-parquet/data/stopping/He3STAR.parquet frontend/public/data/parquet/stopping/
+          # He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through ASTAR with velocity-scaling at lookup time (see packages/compute/src/_energy-loss.ts and core/src/stopping.rs).
+          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet nucl-parquet/data/stopping/catima_O16.parquet nucl-parquet/data/stopping/catima_Ne20.parquet nucl-parquet/data/stopping/catima_Si28.parquet nucl-parquet/data/stopping/catima_Ar40.parquet nucl-parquet/data/stopping/catima_Fe56.parquet frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/tendl-2025/xs/*.parquet frontend/public/data/parquet/xs/
           cp nucl-parquet/data/hi-xs-prod/xs/*.parquet frontend/public/data/parquet/hi-xs-prod/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -66,7 +66,6 @@ jobs:
              nucl-parquet/data/stopping/ASTAR.parquet \
              nucl-parquet/data/stopping/dSTAR.parquet \
              nucl-parquet/data/stopping/tSTAR.parquet \
-             nucl-parquet/data/stopping/He3STAR.parquet \
              frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet \
              nucl-parquet/data/stopping/catima_O16.parquet \
@@ -249,7 +248,6 @@ jobs:
              nucl-parquet/data/stopping/ASTAR.parquet \
              nucl-parquet/data/stopping/dSTAR.parquet \
              nucl-parquet/data/stopping/tSTAR.parquet \
-             nucl-parquet/data/stopping/He3STAR.parquet \
              frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet \
              nucl-parquet/data/stopping/catima_O16.parquet \
@@ -338,7 +336,6 @@ jobs:
              nucl-parquet/data/stopping/ASTAR.parquet \
              nucl-parquet/data/stopping/dSTAR.parquet \
              nucl-parquet/data/stopping/tSTAR.parquet \
-             nucl-parquet/data/stopping/He3STAR.parquet \
              frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet \
              nucl-parquet/data/stopping/catima_O16.parquet \

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -62,7 +62,8 @@ jobs:
           cp nucl-parquet/data/meta/abundances.parquet nucl-parquet/data/meta/decay.parquet nucl-parquet/data/meta/elements.parquet frontend/public/data/parquet/meta/
           cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
           cp -f nucl-parquet/data/meta/spectrum_xs.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet nucl-parquet/data/stopping/He3STAR.parquet frontend/public/data/parquet/stopping/
+          # He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through ASTAR with velocity-scaling at lookup time.
+          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/stopping/catima_C12.parquet nucl-parquet/data/stopping/catima_O16.parquet nucl-parquet/data/stopping/catima_Ne20.parquet nucl-parquet/data/stopping/catima_Si28.parquet nucl-parquet/data/stopping/catima_Ar40.parquet nucl-parquet/data/stopping/catima_Fe56.parquet frontend/public/data/parquet/stopping/
           cp nucl-parquet/data/tendl-2025/xs/*.parquet frontend/public/data/parquet/xs/
           cp nucl-parquet/data/hi-xs-prod/xs/*.parquet frontend/public/data/parquet/hi-xs-prod/

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,11 +1,19 @@
 //! Sync `DATA_VERSION` (used by `data_fetch.rs` to build the GitHub
 //! Releases URL) from the pinned `nucl-parquet/` submodule's
-//! pyproject.toml. The submodule is the single source of truth.
+//! `data/catalog.json::data_version`. The submodule is the single
+//! source of truth.
 //!
 //! Why this exists: the previous setup had `DATA_VERSION` as a
 //! hand-maintained `pub const` next to a submodule pin. The same class
 //! of drift just bit us in #117 (default library `tendl-2024` vs docs
 //! `tendl-2025`); this prevents the analogous bug for data version.
+//!
+//! Upstream wire-format note (nucl-parquet PR #151 — "Path A"): the
+//! data version split off from the Python package version. It now
+//! lives in `data/catalog.json` (CalVer YYYY.MM.MICRO, e.g.
+//! `2026.5.0`) rather than `pyproject.toml::[project].version`
+//! (SemVer). The release tag (`data-2026.5.0`) and tarball filename
+//! (`nucl-parquet-data-2026.5.0.tar.zst`) follow the same CalVer.
 //!
 //! On a fresh clone without `--recurse-submodules` the file is missing
 //! — we emit a warning and fall back to a sentinel version so wasm/CI
@@ -16,15 +24,15 @@
 use std::path::Path;
 
 fn main() {
-    let pyproject = Path::new("../nucl-parquet/pyproject.toml");
-    println!("cargo:rerun-if-changed=../nucl-parquet/pyproject.toml");
+    let catalog = Path::new("../nucl-parquet/data/catalog.json");
+    println!("cargo:rerun-if-changed=../nucl-parquet/data/catalog.json");
 
-    let version = match std::fs::read_to_string(pyproject) {
-        Ok(s) => extract_project_version(&s).unwrap_or_else(|| {
+    let version = match std::fs::read_to_string(catalog) {
+        Ok(s) => extract_data_version(&s).unwrap_or_else(|| {
             println!(
-                "cargo:warning=core/build.rs: could not parse [project].version from {}; \
+                "cargo:warning=core/build.rs: could not parse top-level \"data_version\" from {}; \
                  falling back to 0.0.0-unknown. Bump the submodule cleanly.",
-                pyproject.display()
+                catalog.display()
             );
             "0.0.0-unknown".to_string()
         }),
@@ -32,7 +40,7 @@ fn main() {
             println!(
                 "cargo:warning=core/build.rs: {} not found — submodule not checked out? \
                  Falling back to 0.0.0-unknown. Run `git submodule update --init --recursive`.",
-                pyproject.display()
+                catalog.display()
             );
             "0.0.0-unknown".to_string()
         }
@@ -41,34 +49,28 @@ fn main() {
     println!("cargo:rustc-env=HYRR_DATA_VERSION={version}");
 }
 
-/// Tiny TOML walker — avoids pulling a `toml` build-dep for one
-/// version string. Handles the standard pyproject layout: top-level
-/// `[project]` section with `version = "..."`. Tolerates leading
-/// whitespace and inline comments after the value.
-fn extract_project_version(content: &str) -> Option<String> {
-    let mut in_project = false;
-    for raw in content.lines() {
-        let line = raw.trim();
-        if line.starts_with('[') && line.ends_with(']') {
-            in_project = line == "[project]";
-            continue;
-        }
-        if !in_project {
-            continue;
-        }
-        let Some(rest) = line.strip_prefix("version") else {
-            continue;
-        };
-        let rest = rest.trim_start();
-        let Some(after_eq) = rest.strip_prefix('=') else {
-            continue;
-        };
-        // Strip trailing comment, then surrounding quotes/whitespace.
-        let value = after_eq.split('#').next()?.trim();
-        let trimmed = value.trim_matches('"').trim_matches('\'').trim();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
-        }
+/// Tiny JSON walker — avoids pulling a `serde_json` build-dep for one
+/// string field. Matches the top-level `"data_version": "..."` pair.
+/// Tolerates whitespace variation around `:` and between the key and
+/// its value. JSON is unambiguous about string quoting (always `"`),
+/// so this is simpler than the previous hand-rolled TOML walker.
+fn extract_data_version(content: &str) -> Option<String> {
+    // Quick-and-dirty: scan for the `"data_version"` key, then read the
+    // following quoted string. Sufficient for a fixed top-level field
+    // in a generated catalog.json — we don't need to parse nested
+    // objects or escape sequences.
+    let key = "\"data_version\"";
+    let idx = content.find(key)?;
+    let rest = &content[idx + key.len()..];
+    // Skip whitespace and the colon.
+    let after_colon = rest.trim_start().strip_prefix(':')?.trim_start();
+    // Read the quoted value.
+    let after_open_quote = after_colon.strip_prefix('"')?;
+    let close = after_open_quote.find('"')?;
+    let value = &after_open_quote[..close];
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
     }
-    None
 }

--- a/core/src/data_fetch.rs
+++ b/core/src/data_fetch.rs
@@ -2,7 +2,18 @@
 //!
 //! Populates `~/.hyrr/nucl-parquet/v{DATA_VERSION}/` from GitHub Releases on
 //! demand. Hardened against the known failure modes of the simpler upstream
-//! pattern (see #52 spike review):
+//! pattern (see #52 spike review).
+//!
+//! Wire-format note (nucl-parquet PR #151 — "Path A"): the upstream
+//! release tag is `data-{V}` (CalVer YYYY.MM.MICRO, e.g.
+//! `data-2026.5.0`) and the tarball asset is
+//! `nucl-parquet-data-{V}.tar.zst` — note no leading `v` on either,
+//! since the data version is no longer SemVer. The local cache
+//! directory keeps its `v{V}/` prefix (`~/.hyrr/nucl-parquet/v2026.5.0/`)
+//! intentionally: it's our internal layout, not an upstream-naming
+//! contract, and the `v` prefix is what the cache-dir parser
+//! ([`parse_version_dir`]) and prune logic key off. Changing the
+//! cache layout would invalidate every user's cache for no gain.
 //!
 //! - **Concurrent invocations**: an exclusive `fs2` file-lock on
 //!   `<cache_root>/.lock` serialises competing extract attempts, so the
@@ -65,8 +76,10 @@ pub fn data_version() -> &'static str {
 }
 
 /// Tarball filename for the current [`DATA_VERSION`], e.g.
-/// `nucl-parquet-data-v0.10.0.tar.zst`. Single source of truth for the
-/// pattern — `ensure_*` and the install path consume this.
+/// `nucl-parquet-data-2026.5.0.tar.zst`. Single source of truth for the
+/// pattern — `ensure_*` and the install path consume this. Note: no `v`
+/// prefix on the version since nucl-parquet PR #151 (Path A) moved data
+/// versioning to CalVer.
 pub fn tarball_filename() -> String {
     tarball_filename_for(DATA_VERSION)
 }
@@ -74,26 +87,33 @@ pub fn tarball_filename() -> String {
 /// Tarball filename for an arbitrary version. Exposed for offline-bundle
 /// docs/tooling that need to spell a non-current version.
 pub fn tarball_filename_for(version: &str) -> String {
-    format!("nucl-parquet-data-v{version}.tar.zst")
+    format!("nucl-parquet-data-{version}.tar.zst")
 }
 
-/// Full release-tarball URL for the current [`DATA_VERSION`].
+/// Full release-tarball URL for the current [`DATA_VERSION`], e.g.
+/// `https://github.com/exoma-ch/nucl-parquet/releases/download/data-2026.5.0/nucl-parquet-data-2026.5.0.tar.zst`.
 pub fn release_url() -> String {
     release_url_for(DATA_VERSION)
 }
 
-/// Full release-tarball URL for an arbitrary version.
+/// Full release-tarball URL for an arbitrary version. Upstream tag
+/// shape is `data-{V}` (no `v` prefix) per nucl-parquet PR #151.
 pub fn release_url_for(version: &str) -> String {
     format!(
-        "{RELEASE_BASE}/v{version}/{filename}",
+        "{RELEASE_BASE}/data-{version}/{filename}",
         filename = tarball_filename_for(version),
     )
 }
 
 /// Human-readable cache-root pattern for diagnostics / UX, e.g.
-/// `~/.hyrr/nucl-parquet/v0.10.0/data`. The literal returned here is
+/// `~/.hyrr/nucl-parquet/v2026.5.0/data`. The literal returned here is
 /// always interpolated against the live [`DATA_VERSION`]; callers that
 /// need an actual filesystem path should use [`cache_dir`] instead.
+///
+/// Note: the `v` prefix on the cache dir is deliberate — it's our
+/// internal layout (matches [`parse_version_dir`] / prune logic) and
+/// is decoupled from the upstream release-tag shape (`data-{V}`, no
+/// `v`) since nucl-parquet PR #151 split data versioning to CalVer.
 pub fn cache_root_pattern() -> String {
     format!("~/.hyrr/nucl-parquet/v{DATA_VERSION}/data")
 }
@@ -1391,7 +1411,7 @@ mod tests {
     fn release_url_pattern_is_canonical() {
         let url = release_url();
         assert!(
-            url.starts_with("https://github.com/exoma-ch/nucl-parquet/releases/download/v"),
+            url.starts_with("https://github.com/exoma-ch/nucl-parquet/releases/download/data-"),
             "release_url() = {url:?} drifted from the canonical host/path"
         );
         assert!(
@@ -1400,8 +1420,14 @@ mod tests {
         );
         let fname = tarball_filename();
         assert!(
-            fname.starts_with("nucl-parquet-data-v") && fname.ends_with(".tar.zst"),
+            fname.starts_with("nucl-parquet-data-") && fname.ends_with(".tar.zst"),
             "tarball_filename() = {fname:?} drifted"
+        );
+        // The new wire format has no `v` prefix on the version segment
+        // of the filename (nucl-parquet#151 — Path A, data on CalVer).
+        assert!(
+            !fname.starts_with("nucl-parquet-data-v"),
+            "tarball_filename() = {fname:?} retained the legacy `v` prefix"
         );
         assert!(
             url.ends_with(&fname),

--- a/core/tests/alpha_stopping_nist_canary.rs
+++ b/core/tests/alpha_stopping_nist_canary.rs
@@ -10,12 +10,10 @@
 //!
 //! This test pins the EXPECTED NIST values (verified against
 //! `https://physics.nist.gov/PhysRefData/Star/Text/ASTAR.html`, Aluminum,
-//! 2026-05-05) within ±5%. It will FAIL today against the broken parquet
-//! and PASS once the data is regenerated from a correct upstream
-//! (libdEdx PSTAR/ASTAR or a fresh NIST scrape).
-//!
-//! Marked `#[ignore]` so default CI stays green; run with
-//! `cargo test --include-ignored alpha_stopping_nist_canary`.
+//! 2026-05-05) within ±5%. It now PASSES against the corrected
+//! `ASTAR.parquet` shipped in the `data-2026.5.0` nucl-parquet release
+//! (nucl-parquet PR #143 — α routes through real NIST ASTAR, no
+//! Z²-scaled proton-energy garbage).
 
 use hyrr_core::db::{DatabaseProtocol, ParquetDataStore};
 use hyrr_core::stopping::elemental_dedx;
@@ -94,13 +92,11 @@ fn check_alpha_against_nist(label: &str, target_z: u32, expected: &[(f64, f64)])
 }
 
 #[test]
-#[ignore = "regression canary for #63 — fails today against broken bundled ASTAR.parquet"]
 fn alpha_on_al_matches_nist_within_5pct() {
     check_alpha_against_nist("Al(Z=13)", 13, NIST_ASTAR_AL);
 }
 
 #[test]
-#[ignore = "regression canary for #63 — fails today against broken bundled ASTAR.parquet"]
 fn alpha_on_cu_matches_nist_within_5pct() {
     check_alpha_against_nist("Cu(Z=29)", 29, NIST_ASTAR_CU);
 }

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -77,8 +77,9 @@ Both machines must run matching `hyrr` versions for the bundle to apply cleanly 
 
 ```bash
 # On a connected machine — substitute <V> with the version printed above
-curl -LO "https://github.com/exoma-ch/nucl-parquet/releases/download/v<V>/nucl-parquet-data-v<V>.tar.zst"
+# (data version is CalVer YYYY.MM.MICRO, e.g. 2026.5.0; no `v` prefix)
+curl -LO "https://github.com/exoma-ch/nucl-parquet/releases/download/data-<V>/nucl-parquet-data-<V>.tar.zst"
 
 # On the air-gapped machine
-hyrr fetch-data --from "nucl-parquet-data-v<V>.tar.zst"
+hyrr fetch-data --from "nucl-parquet-data-<V>.tar.zst"
 ```

--- a/frontend/src/lib/components/FetchErrorCard.svelte.test.ts
+++ b/frontend/src/lib/components/FetchErrorCard.svelte.test.ts
@@ -20,12 +20,12 @@ vi.mock("../utils/platform", () => ({
 // (non-existent in jsdom) Tauri invoke surface.
 vi.mock("../compute/data-fetch-meta", () => ({
   getReleaseUrl: vi.fn(async () =>
-    "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst",
+    "https://github.com/exoma-ch/nucl-parquet/releases/download/data-2026.5.0/nucl-parquet-data-2026.5.0.tar.zst",
   ),
   getCacheRootPattern: vi.fn(async () => "~/.hyrr/nucl-parquet/<version>"),
-  getTarballFilename: vi.fn(async () => "nucl-parquet-data-v0.10.0.tar.zst"),
+  getTarballFilename: vi.fn(async () => "nucl-parquet-data-2026.5.0.tar.zst"),
   getReleaseBaseUrl: vi.fn(async () => "https://github.com/exoma-ch/nucl-parquet"),
-  getDataVersion: vi.fn(async () => "v0.10.0"),
+  getDataVersion: vi.fn(async () => "2026.5.0"),
   DEFAULT_LIBRARY: "tendl-2025",
 }));
 
@@ -43,8 +43,8 @@ import { isTauri } from "../utils/platform";
 
 const mockedIsTauri = vi.mocked(isTauri);
 
-const CACHE = "/Users/x/.hyrr/nucl-parquet/v0.10.0";
-const URL_ = "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst";
+const CACHE = "/Users/x/.hyrr/nucl-parquet/v2026.5.0";
+const URL_ = "https://github.com/exoma-ch/nucl-parquet/releases/download/data-2026.5.0/nucl-parquet-data-2026.5.0.tar.zst";
 
 /** One representative payload per parsed-error variant. Seven entries. */
 const variants: Array<{ name: string; payload: ParsedFetchError; carriesUrl: boolean }> = [

--- a/frontend/src/lib/utils/parse-fetch-error.test.ts
+++ b/frontend/src/lib/utils/parse-fetch-error.test.ts
@@ -11,8 +11,8 @@ describe("parseFetchError — every Rust variant round-trips", () => {
       kind: "FetchError",
       variant: "HttpStatus",
       status: 404,
-      url: "https://github.com/exoma-ch/nucl-parquet/releases/download/v0.10.0/nucl-parquet-data-v0.10.0.tar.zst",
-      cache_dir: "/Users/x/.hyrr/nucl-parquet/v0.10.0",
+      url: "https://github.com/exoma-ch/nucl-parquet/releases/download/data-2026.5.0/nucl-parquet-data-2026.5.0.tar.zst",
+      cache_dir: "/Users/x/.hyrr/nucl-parquet/v2026.5.0",
       message: "HTTP 404",
     };
     const result = parseFetchError(payload);
@@ -21,7 +21,7 @@ describe("parseFetchError — every Rust variant round-trips", () => {
       throw new Error("expected HttpStatus variant");
     }
     expect(result.status).toBe(404);
-    expect(result.url).toContain("nucl-parquet-data-v0.10.0.tar.zst");
+    expect(result.url).toContain("nucl-parquet-data-2026.5.0.tar.zst");
     expect(result.cache_dir).toContain(".hyrr");
   });
 
@@ -31,7 +31,7 @@ describe("parseFetchError — every Rust variant round-trips", () => {
       variant: "Network",
       detail: "dns lookup failed",
       url: "https://example.com/x.tar.zst",
-      cache_dir: "/home/x/.hyrr/nucl-parquet/v0.10.0",
+      cache_dir: "/home/x/.hyrr/nucl-parquet/v2026.5.0",
       message: "network error: dns lookup failed",
     };
     const result = parseFetchError(payload);

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -118,8 +118,14 @@ export class DataStore implements DatabaseProtocol {
     }
 
     onProgress?.("Loading stopping power data...", 0.75);
-    // Load per-source light-ion stopping files (PSTAR, ASTAR, dSTAR, tSTAR, He3STAR)
-    const lightIonSources = ["PSTAR", "ASTAR", "dSTAR", "tSTAR", "He3STAR"];
+    // Load per-source light-ion stopping files (PSTAR, ASTAR, dSTAR, tSTAR).
+    // He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through
+    // ASTAR with velocity-scaling at lookup time (see _energy-loss.ts: Z=2
+    // uses ASTAR for both α and ³He; ³He uses E × 4/3 to match α at same
+    // MeV/u). The He3STAR.parquet file was a redundant precomputed cache
+    // that this compute path never queried; this list also never queried
+    // it. Removing matches the upstream layout.
+    const lightIonSources = ["PSTAR", "ASTAR", "dSTAR", "tSTAR"];
     const stoppingFiles = await Promise.all(
       lightIonSources.map((src) =>
         readParquetRows(`${this.baseUrl}/stopping/${src}.parquet`).catch(() => [] as ParquetRow[]),


### PR DESCRIPTION
## Summary

Adopt nucl-parquet's `data-2026.5.0` release. Two upstream changes drove this:

- **PR #151 (Path A)** — data version split off from code version. The release tag is now `data-{V}` (CalVer YYYY.MM.MICRO), the tarball asset is `nucl-parquet-data-{V}.tar.zst` (no `v` prefix), and the SSoT for the version is `data/catalog.json::data_version` (not `pyproject.toml`).
- **PR #143** — α-particle stopping power now routes through real NIST ASTAR (was Z²-scaled garbage off the proton-energy axis — root cause of #63). The He3STAR.parquet file is also gone; we don't use it (³He uses ASTAR + velocity scaling in `core/src/stopping.rs`), so no runtime impact.

Release: https://github.com/exoma-ch/nucl-parquet/releases/tag/data-2026.5.0

## Changes (4 commits)

1. **build(core)** — `core/build.rs` reads `DATA_VERSION` from `nucl-parquet/data/catalog.json::data_version` (new SSoT) via a quick-and-dirty JSON walker. Bumps the submodule pin to tag `data-2026.5.0` (this is co-located with the build.rs change because the build.rs test asserts the version resolves cleanly, and the old submodule's catalog.json had no `data_version` field — slight deviation from the originally-staged "submodule bump in commit 4" plan).
2. **feat(core)!** — `tarball_filename_for` drops the `v` prefix; `release_url_for` uses the `data-{V}` tag shape. Cache directory keeps `v{V}` (e.g. `~/.hyrr/nucl-parquet/v2026.5.0/`) — this is our internal layout that `parse_version_dir`/prune key off; changing it would invalidate every user's cache for no upstream-naming benefit. Documented in the module preamble. Hard wire-format break: pre-#151 hyrr can't fetch post-#151 data and vice versa (data is incompatible across the split anyway).
3. **ci** — `data-fetch-ssot` job's docs guard now matches the CalVer shape (`[0-9]{4}\.[0-9]+\.[0-9]+`) plus a belt-and-braces clause that still flags any lingering legacy `v`-prefixed filenames.
4. **chore(tests)** — Un-ignore `alpha_stopping_nist_canary` (Al + Cu). Both pass against the corrected ASTAR.parquet within the ±5% tolerance.

This **closes the deferral on #163** — that dependabot bump was held until the α-stopping fix landed; we skip past 0.13.0 directly to `data-2026.5.0`, which includes the fix.

Refs: #63, nucl-parquet#137, nucl-parquet#143, nucl-parquet#151

## Test plan
- [x] `cargo test --lib data_fetch -- --test-threads=1` — 35 passed
- [x] `cargo test --test alpha_stopping_nist_canary` — 2 passed (was `#[ignore]`d, now runs by default)
- [x] `cargo check` on py/ + hyrr-mcp/ — clean
- [x] Frontend `parse-fetch-error` + `FetchErrorCard` vitest — 49 passed
- [x] CI guard regex hand-tested against docs/
- [ ] Wait for CI to run full matrix (Linux/macOS, frontend, MCP)