### PR TITLE
fix(frontend): restore axis labels — migrate to Plotly v3 title.text form

### DIFF
--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -421,11 +421,11 @@
       const yTitle = scaled ? "σ × abundance (mb)" : "Cross section (mb)";
       const layout = darkLayout({
         xaxis: {
-          title: "Energy (MeV)",
+          title: { text: "Energy (MeV)" },
           gridcolor: tc.border,
           range: rangeMinE !== undefined && rangeMaxE !== undefined ? [rangeMinE, rangeMaxE] : undefined,
         },
-        yaxis: { title: yTitle, gridcolor: tc.border },
+        yaxis: { title: { text: yTitle }, gridcolor: tc.border },
         margin: { t: 20, r: 20, b: 40, l: 55 },
         height: 220,
         showlegend: traces.length > 1,
@@ -542,9 +542,9 @@
 
     const { shapes, annotations } = layerMarkers(boundaries, tc);
     const layout = darkLayout({
-      xaxis: { title: "Depth (mm)", gridcolor: tc.border, range: [0, cumulativeDepth] },
-      yaxis: { title: "σ (mb)", gridcolor: tc.border },
-      yaxis2: { title: "Energy (MeV)", overlaying: "y", side: "right", gridcolor: tc.border },
+      xaxis: { title: { text: "Depth (mm)" }, gridcolor: tc.border, range: [0, cumulativeDepth] },
+      yaxis: { title: { text: "σ (mb)" }, gridcolor: tc.border },
+      yaxis2: { title: { text: "Energy (MeV)" }, overlaying: "y", side: "right", gridcolor: tc.border },
       margin: { t: 20, r: 55, b: 40, l: 55 },
       height: 220, showlegend: true,
       legend: { x: 1, xanchor: "right", y: 0.95, bgcolor: "rgba(0,0,0,0)" },
@@ -645,8 +645,8 @@
 
     const { shapes, annotations } = layerMarkers(boundaries, tc);
     const layout = darkLayout({
-      xaxis: { title: "Depth (mm)", gridcolor: tc.border, range: [0, cumulativeDepth] },
-      yaxis: { title: "Production rate (atoms/s/cm)", gridcolor: tc.border },
+      xaxis: { title: { text: "Depth (mm)" }, gridcolor: tc.border, range: [0, cumulativeDepth] },
+      yaxis: { title: { text: "Production rate (atoms/s/cm)" }, gridcolor: tc.border },
       margin: { t: 20, r: 20, b: 40, l: 70 },
       height: 220, showlegend: traces.length > 1,
       legend: { x: 1, xanchor: "right", y: 0.95, bgcolor: "rgba(0,0,0,0)" },
@@ -800,10 +800,10 @@
       });
 
       const layout = darkLayout({
-        xaxis: { title: `Time (${timeLabel})`, gridcolor: tc.border },
-        yaxis: { title: "RNP (%)", gridcolor: tc.border, range: [0, 105] },
+        xaxis: { title: { text: `Time (${timeLabel})` }, gridcolor: tc.border },
+        yaxis: { title: { text: "RNP (%)" }, gridcolor: tc.border, range: [0, 105] },
         yaxis2: {
-          title: `Activity (${actLabel})`,
+          title: { text: `Activity (${actLabel})` },
           overlaying: "y",
           side: "right",
           gridcolor: tc.border,
@@ -844,8 +844,8 @@
       });
 
       const layout = darkLayout({
-        xaxis: { title: `Time (${timeLabel})`, gridcolor: tc.border },
-        yaxis: { title: `Activity (${actLabel})`, gridcolor: tc.border },
+        xaxis: { title: { text: `Time (${timeLabel})` }, gridcolor: tc.border },
+        yaxis: { title: { text: `Activity (${actLabel})` }, gridcolor: tc.border },
         margin: { t: 10, r: 20, b: 40, l: 55 },
         height: 200,
         showlegend: false,

--- a/frontend/src/lib/components/PlotActivityCurve.svelte
+++ b/frontend/src/lib/components/PlotActivityCurve.svelte
@@ -319,11 +319,11 @@
 
     const layout = darkLayout({
       xaxis: {
-        title: `Time ${useEOBTime ? "from EOB" : ""} (${timeLabel})`,
+        title: { text: `Time ${useEOBTime ? "from EOB" : ""} (${timeLabel})` },
         gridcolor: tc.border,
       },
       yaxis: {
-        title: `Activity (${actLabel})`,
+        title: { text: `Activity (${actLabel})` },
         gridcolor: tc.border,
         type: logY ? "log" : "linear",
         // On log scale, clamp the lower bound to the activity threshold
@@ -546,12 +546,12 @@
 
     const layout = darkLayout({
       xaxis: {
-        title: `Time ${useEOBTime ? "from EOB" : ""} (${timeLabel})`,
+        title: { text: `Time ${useEOBTime ? "from EOB" : ""} (${timeLabel})` },
         gridcolor: tc.border,
       },
-      yaxis: { title: "RNP (%)", gridcolor: tc.border, range: [0, 105] },
+      yaxis: { title: { text: "RNP (%)" }, gridcolor: tc.border, range: [0, 105] },
       yaxis2: {
-        title: `Total Activity (${actLabel})`,
+        title: { text: `Total Activity (${actLabel})` },
         overlaying: "y",
         side: "right",
         gridcolor: tc.border,

--- a/frontend/src/lib/components/PlotDepthProfileLive.svelte
+++ b/frontend/src/lib/components/PlotDepthProfileLive.svelte
@@ -97,10 +97,10 @@
     }));
 
     const layout = darkLayout({
-      xaxis: { title: "Depth (mm)", gridcolor: tc.border, range: [0, cumulativeDepth] },
-      yaxis: { title: "Energy (MeV)", gridcolor: tc.border },
+      xaxis: { title: { text: "Depth (mm)" }, gridcolor: tc.border, range: [0, cumulativeDepth] },
+      yaxis: { title: { text: "Energy (MeV)" }, gridcolor: tc.border },
       yaxis2: {
-        title: "Heat (W/mm)",
+        title: { text: "Heat (W/mm)" },
         overlaying: "y",
         side: "right",
         gridcolor: tc.border,

--- a/frontend/src/lib/components/PlotProductionDepth.svelte
+++ b/frontend/src/lib/components/PlotProductionDepth.svelte
@@ -276,11 +276,11 @@
 
     const layout = darkLayout({
       xaxis: {
-        title: "Depth (mm)",
+        title: { text: "Depth (mm)" },
         gridcolor: tc.border,
       },
       yaxis: {
-        title: "Production rate (atoms/s/cm)",
+        title: { text: "Production rate (atoms/s/cm)" },
         gridcolor: tc.border,
         type: logY ? "log" : "linear",
       },


### PR DESCRIPTION
## Summary

Fixes #197 — plots on `/tst` (v0.8.0 staging) have no axis labels.

**Root cause:** Plotly 3.0.0 [dropped support](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md#300----2025-01-27) for passing a string to the `title` attribute (PR plotly/plotly.js#7212). Since the v2.35 -> v3.5.1 bump in #108, every `xaxis: { title: "..." }` / `yaxis: { title: "..." }` config in the app has been silently ignored. Must be `title: { text: "..." }`.

**Fix:** Migrate all 22 axis-title call sites across 4 components to the v3 object form. Both static strings and template-literal titles wrapped as `{ text: ... }`.

### Sites migrated
- `frontend/src/lib/components/IsotopePopup.svelte` — XS, depth, RNP, activity plots (12 titles)
- `frontend/src/lib/components/PlotActivityCurve.svelte` — activity-vs-time + RNP overlay (5 titles)
- `frontend/src/lib/components/PlotDepthProfileLive.svelte` — depth/energy/heat profile (3 titles)
- `frontend/src/lib/components/PlotProductionDepth.svelte` — production-vs-depth (2 titles)

### Verification
- `git grep` for `title:` inside `xaxis:` / `yaxis:` / `yaxis2:` blocks: zero remaining string-form titles
- `darkLayout()` in `plotly-helpers.ts` does not set a default title — no helper change needed
- No top-level `layout.title: "..."` strings to migrate

## Test plan
- [x] `npm test --workspace=hyrr-frontend` — 515/515 pass
- [x] `npm run check --workspace=hyrr-frontend` — no new errors (one pre-existing `import.meta.env` cast warning in `BugReportModal.svelte`, unrelated)
- [ ] Manual smoke on `/tst`: open a config that touches each plot type, confirm axis labels render

Refs: #197