### PR TITLE
fix(frontend/#198): aggregate K/L/M shell-EC and dedupe decay-chain entries

### DIFF
--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -23,7 +23,12 @@
   import type { DecayMode, CrossSectionData, ProjectileType } from "@hyrr/compute";
   import { getDepthPreview } from "../stores/depth-preview.svelte";
   import type { CsvTrace } from "../plotting/csv-export";
-  import { aggregateDecayModes, formatDecayMode } from "../format";
+  import {
+    aggregateDecayModes,
+    dedupeDecayChain,
+    formatDecayChainTooltip,
+    formatDecayMode,
+  } from "../format";
   import SaveMenu from "./SaveMenu.svelte";
 
   interface Props {
@@ -923,24 +928,34 @@
 
     <!-- Decay chain -->
     {#if parentDecays.length > 0 || (decayInfo && decayInfo.decayModes.some(m => m.daughterZ !== null))}
+      {@const dedupedParents = dedupeDecayChain(
+        parentDecays,
+        (p) => `${p.Z}|${p.A}|${p.state ?? ""}`,
+      )}
+      {@const dedupedDaughters = decayInfo
+        ? dedupeDecayChain(
+            decayInfo.decayModes.filter((m) => m.daughterZ !== null),
+            (m) => `${m.daughterZ}|${m.daughterA}|${m.daughterState ?? ""}`,
+          )
+        : []}
       <div class="decay-chain">
         <div class="chain-flow">
-          {#if parentDecays.length > 0}
+          {#if dedupedParents.length > 0}
             <div class="chain-group">
-              {#each parentDecays as p}
-                <span class="chain-nuc parent" title="{formatDecayMode(p.mode)} ({(p.branching * 100).toFixed(1)}%) [{p.mode}]">{@html nucHtml(p.name)}</span>
+              {#each dedupedParents as p}
+                <span class="chain-nuc parent" title={formatDecayChainTooltip(p.sources)}>{@html nucHtml(p.name)}</span>
               {/each}
             </div>
             <span class="chain-arrow">&rarr;</span>
           {/if}
           <span class="chain-nuc current">{@html nucHtml(name)}</span>
-          {#if decayInfo && decayInfo.decayModes.some(m => m.daughterZ !== null)}
+          {#if dedupedDaughters.length > 0}
             <span class="chain-arrow">&rarr;</span>
             <div class="chain-group">
-              {#each decayInfo.decayModes.filter(m => m.daughterZ !== null) as mode}
-                {@const dSym = Z_TO_SYMBOL[mode.daughterZ!] ?? `Z${mode.daughterZ}`}
-                <span class="chain-nuc daughter" title="{formatDecayMode(mode.mode)} ({(mode.branching * 100).toFixed(1)}%) [{mode.mode}]">
-                  {@html nucHtml(`${dSym}-${mode.daughterA}${mode.daughterState || ""}`)}
+              {#each dedupedDaughters as d}
+                {@const dSym = Z_TO_SYMBOL[d.daughterZ!] ?? `Z${d.daughterZ}`}
+                <span class="chain-nuc daughter" title={formatDecayChainTooltip(d.sources)}>
+                  {@html nucHtml(`${dSym}-${d.daughterA}${d.daughterState || ""}`)}
                 </span>
               {/each}
             </div>

--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -23,7 +23,7 @@
   import type { DecayMode, CrossSectionData, ProjectileType } from "@hyrr/compute";
   import { getDepthPreview } from "../stores/depth-preview.svelte";
   import type { CsvTrace } from "../plotting/csv-export";
-  import { formatDecayMode } from "../format";
+  import { aggregateDecayModes, formatDecayMode } from "../format";
   import SaveMenu from "./SaveMenu.svelte";
 
   interface Props {
@@ -905,12 +905,13 @@
     {#if decayInfo}
       <div class="properties">
         {#if decayInfo.decayModes.length > 0}
+          {@const aggregatedModes = aggregateDecayModes(decayInfo.decayModes)}
           <div class="prop-row">
             <span class="prop-label">Decay</span>
             <span class="prop-value">
-              {#each decayInfo.decayModes as mode, i}
+              {#each aggregatedModes as mode, i}
                 {#if i > 0}<span class="prop-sep">, </span>{/if}
-                <span title={mode.mode}>{formatDecayMode(mode.mode)}</span>{#if mode.branching < 1 && mode.branching > 0}
+                <span title={mode.sources.length > 1 ? mode.sources.join(", ") : mode.mode}>{formatDecayMode(mode.mode)}</span>{#if mode.branching < 1 && mode.branching > 0}
                   <span class="branching"> ({(mode.branching * 100).toFixed(1)}%)</span>
                 {/if}
               {/each}

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
   aggregateDecayModes,
+  dedupeDecayChain,
+  formatDecayChainTooltip,
   formatDecayMode,
   formatProjectile,
   formatReaction,
@@ -198,5 +200,100 @@ describe("aggregateDecayModes", () => {
 
   it("returns empty array for empty input", () => {
     expect(aggregateDecayModes([])).toEqual([]);
+  });
+});
+
+describe("dedupeDecayChain", () => {
+  it("collapses Cr-51 K/L/M EC chain into a single V-51 daughter entry", () => {
+    const daughters = [
+      { mode: "KshellEC", branching: 0.89182, daughterZ: 23, daughterA: 51, daughterState: "" },
+      { mode: "LshellEC", branching: 0.092759, daughterZ: 23, daughterA: 51, daughterState: "" },
+      { mode: "MshellEC", branching: 0.015425, daughterZ: 23, daughterA: 51, daughterState: "" },
+    ];
+    const out = dedupeDecayChain(
+      daughters,
+      (d) => `${d.daughterZ}|${d.daughterA}|${d.daughterState}`,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].mode).toBe("ec");
+    expect(out[0].branching).toBeCloseTo(1.0, 4);
+    expect(out[0].sources).toHaveLength(3);
+    expect(out[0].daughterZ).toBe(23);
+    expect(out[0].daughterA).toBe(51);
+  });
+
+  it("collapses 51Mn parent K/L/M EC + β⁺ into a single Mn-51 parent entry", () => {
+    const parents = [
+      { name: "Mn-51", Z: 25, A: 51, state: "", mode: "KshellEC", branching: 0.025955 },
+      { name: "Mn-51", Z: 25, A: 51, state: "", mode: "LshellEC", branching: 0.0027038 },
+      { name: "Mn-51", Z: 25, A: 51, state: "", mode: "MshellEC", branching: 0.00046853 },
+      { name: "Mn-51", Z: 25, A: 51, state: "", mode: "beta+", branching: 0.97087 },
+    ];
+    const out = dedupeDecayChain(parents, (p) => `${p.Z}|${p.A}|${p.state}`);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("Mn-51");
+    // Dominant mode is β⁺ at 97.1%, not EC at 2.9%
+    expect(out[0].mode).toBe("beta+");
+    expect(out[0].branching).toBeCloseTo(1.0, 4);
+    expect(out[0].sources).toHaveLength(4);
+  });
+
+  it("keeps distinct daughter nuclides separate", () => {
+    const daughters = [
+      { mode: "beta-", branching: 0.6, daughterZ: 24, daughterA: 51, daughterState: "" },
+      { mode: "alpha", branching: 0.4, daughterZ: 22, daughterA: 47, daughterState: "" },
+    ];
+    const out = dedupeDecayChain(
+      daughters,
+      (d) => `${d.daughterZ}|${d.daughterA}|${d.daughterState}`,
+    );
+    expect(out).toHaveLength(2);
+  });
+
+  it("keeps distinct daughter states separate (ground vs metastable)", () => {
+    const daughters = [
+      { mode: "KshellEC", branching: 0.7, daughterZ: 23, daughterA: 51, daughterState: "" },
+      { mode: "KshellEC", branching: 0.3, daughterZ: 23, daughterA: 51, daughterState: "m" },
+    ];
+    const out = dedupeDecayChain(
+      daughters,
+      (d) => `${d.daughterZ}|${d.daughterA}|${d.daughterState}`,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0].daughterState).toBe("");
+    expect(out[1].daughterState).toBe("m");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(dedupeDecayChain([], () => "")).toEqual([]);
+  });
+});
+
+describe("formatDecayChainTooltip", () => {
+  it("annotates aggregated EC with K/L/M breakdown", () => {
+    const tip = formatDecayChainTooltip([
+      { mode: "KshellEC", branching: 0.892 },
+      { mode: "LshellEC", branching: 0.093 },
+      { mode: "MshellEC", branching: 0.015 },
+    ]);
+    expect(tip).toBe("EC (100.0%) [KshellEC 89.2%, LshellEC 9.3%, MshellEC 1.5%]");
+  });
+
+  it("does not annotate single-source modes", () => {
+    const tip = formatDecayChainTooltip([{ mode: "beta+", branching: 1.0 }]);
+    expect(tip).toBe("β⁺ (100.0%)");
+  });
+
+  it("lists multiple aggregated buckets comma-separated", () => {
+    const tip = formatDecayChainTooltip([
+      { mode: "beta+", branching: 0.97 },
+      { mode: "KshellEC", branching: 0.025 },
+      { mode: "LshellEC", branching: 0.005 },
+    ]);
+    expect(tip).toBe("β⁺ (97.0%), EC (3.0%) [KshellEC 2.5%, LshellEC 0.5%]");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(formatDecayChainTooltip([])).toBe("");
   });
 });

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { formatDecayMode, formatProjectile, formatReaction, reactionFilterMatches } from "./format";
+import {
+  aggregateDecayModes,
+  formatDecayMode,
+  formatProjectile,
+  formatReaction,
+  isShellEC,
+  reactionFilterMatches,
+} from "./format";
 
 describe("formatDecayMode", () => {
   it("maps beta_plus / beta+ / positron to β⁺", () => {
@@ -114,5 +121,82 @@ describe("reactionFilterMatches (round-trip aliases)", () => {
 
   it("empty needle matches anything", () => {
     expect(reactionFilterMatches("anything", "")).toBe(true);
+  });
+});
+
+describe("isShellEC", () => {
+  it("matches Kshell/Lshell/Mshell EC in any case", () => {
+    expect(isShellEC("KshellEC")).toBe(true);
+    expect(isShellEC("LshellEC")).toBe(true);
+    expect(isShellEC("MshellEC")).toBe(true);
+    expect(isShellEC("kshellec")).toBe(true);
+    expect(isShellEC("L_shell_EC")).toBe(true);
+  });
+
+  it("does not match plain EC, beta+, or other modes", () => {
+    expect(isShellEC("EC")).toBe(false);
+    expect(isShellEC("ec")).toBe(false);
+    expect(isShellEC("beta+")).toBe(false);
+    expect(isShellEC("alpha")).toBe(false);
+    expect(isShellEC("")).toBe(false);
+  });
+});
+
+describe("aggregateDecayModes", () => {
+  it("collapses K/L/M shell EC into a single ec bucket with summed branching", () => {
+    const out = aggregateDecayModes([
+      { mode: "KshellEC", branching: 0.892 },
+      { mode: "LshellEC", branching: 0.093 },
+      { mode: "MshellEC", branching: 0.015 },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].mode).toBe("ec");
+    expect(out[0].branching).toBeCloseTo(1.0, 6);
+    expect(out[0].sources).toEqual(["KshellEC", "LshellEC", "MshellEC"]);
+  });
+
+  it("renders the bucket label via formatDecayMode as EC", () => {
+    const out = aggregateDecayModes([
+      { mode: "KshellEC", branching: 0.5 },
+      { mode: "LshellEC", branching: 0.5 },
+    ]);
+    expect(formatDecayMode(out[0].mode)).toBe("EC");
+  });
+
+  it("aggregates EC only — keeps β⁺ and other modes as their own buckets", () => {
+    const out = aggregateDecayModes([
+      { mode: "KshellEC", branching: 0.025 },
+      { mode: "LshellEC", branching: 0.003 },
+      { mode: "MshellEC", branching: 0.0005 },
+      { mode: "beta+", branching: 0.9715 },
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].mode).toBe("ec");
+    expect(out[0].branching).toBeCloseTo(0.0285, 6);
+    expect(out[1].mode).toBe("beta+");
+    expect(out[1].branching).toBeCloseTo(0.9715, 6);
+  });
+
+  it("is a passthrough when no shell-EC entries are present", () => {
+    const out = aggregateDecayModes([
+      { mode: "beta-", branching: 1.0 },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].mode).toBe("beta-");
+    expect(out[0].branching).toBe(1.0);
+    expect(out[0].sources).toEqual(["beta-"]);
+  });
+
+  it("preserves first-occurrence order of distinct modes", () => {
+    const out = aggregateDecayModes([
+      { mode: "beta+", branching: 0.5 },
+      { mode: "KshellEC", branching: 0.4 },
+      { mode: "alpha", branching: 0.1 },
+    ]);
+    expect(out.map((m) => m.mode)).toEqual(["beta+", "ec", "alpha"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(aggregateDecayModes([])).toEqual([]);
   });
 });

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -58,6 +58,69 @@ export function isShellEC(mode: string): boolean {
   return /^[klm]shellec$/.test(key);
 }
 
+export interface DecayChainEntry {
+  mode: string;
+  branching: number;
+}
+
+export interface DedupedDecayChainEntry<K> extends DecayChainEntry {
+  key: K;
+  /** All original mode/branching pairs that collapsed into this entry, in input order. */
+  sources: DecayChainEntry[];
+}
+
+/**
+ * Deduplicate decay-chain entries by a caller-supplied identity key — typically
+ * `(Z, A, state)` for a parent or `(daughterZ, daughterA, daughterState)` for a
+ * daughter. Mode strings inside each bucket are first aggregated via
+ * {@link aggregateDecayModes} (so K/L/M shell-EC collapses into `EC`), then the
+ * largest-branching surviving mode is chosen as the bucket's display mode.
+ *
+ * Branchings within a bucket are SUMMED (the bucket represents the total
+ * probability of arriving at — or departing to — that nuclide regardless of
+ * mode). Original entries are preserved on `sources[]` for tooltip rendering.
+ */
+export function dedupeDecayChain<T extends DecayChainEntry, K>(
+  entries: readonly T[],
+  keyOf: (entry: T) => K,
+  keyToString: (key: K) => string = (k) => JSON.stringify(k),
+): Array<DedupedDecayChainEntry<K> & Omit<T, keyof DecayChainEntry>> {
+  type Bucket = DedupedDecayChainEntry<K> & Omit<T, keyof DecayChainEntry>;
+  const buckets = new Map<string, Bucket>();
+  for (const entry of entries) {
+    const key = keyOf(entry);
+    const ks = keyToString(key);
+    const existing = buckets.get(ks);
+    if (existing) {
+      existing.sources.push({ mode: entry.mode, branching: entry.branching });
+    } else {
+      // Capture all fields from the original entry (including extras like name,
+      // daughterZ, etc.) so consumers don't have to thread them through manually.
+      const { mode: _mode, branching: _branching, ...rest } = entry as T & Record<string, unknown>;
+      buckets.set(ks, {
+        ...(rest as Omit<T, keyof DecayChainEntry>),
+        key,
+        mode: entry.mode,
+        branching: 0,
+        sources: [{ mode: entry.mode, branching: entry.branching }],
+      } as Bucket);
+    }
+  }
+  // Finalize each bucket: aggregate K/L/M shell-EC inside the bucket, pick the
+  // dominant mode as the display label, and sum branchings.
+  const result: Bucket[] = [];
+  for (const bucket of buckets.values()) {
+    const aggregated = aggregateDecayModes(bucket.sources);
+    const dominant = aggregated.reduce((best, m) =>
+      m.branching > best.branching ? m : best,
+    );
+    bucket.mode = dominant.mode;
+    bucket.branching = aggregated.reduce((s, m) => s + m.branching, 0);
+    result.push(bucket);
+  }
+  return result;
+}
+
 export interface AggregatedDecayMode {
   /** Canonical display key — `"ec"` for any K/L/M-shell EC, otherwise the original mode string. */
   mode: string;
@@ -135,6 +198,33 @@ function mapParticleToken(token: string): string {
       ? formatDecayMode(rest)
       : rest;
   return `${prefix}${mapped}`;
+}
+
+/**
+ * Build a tooltip for a deduped decay-chain entry that summarizes the dominant
+ * mode and its total branching, with the K/L/M shell breakdown (if any) and any
+ * additional modes appended in brackets. Example output:
+ *
+ *   `EC (100.0%) [KshellEC 89.2%, LshellEC 9.3%, MshellEC 1.5%]`
+ *   `β⁺ (97.1%), EC (2.9%)`
+ */
+export function formatDecayChainTooltip(
+  sources: readonly DecayChainEntry[],
+): string {
+  if (sources.length === 0) return "";
+  const aggregated = aggregateDecayModes(sources);
+  const parts = aggregated.map((m) => {
+    const label = `${formatDecayMode(m.mode)} (${(m.branching * 100).toFixed(1)}%)`;
+    // Only annotate when more than one wire identifier folded into this bucket
+    // (i.e. K/L/M shell-EC collapsed into "ec").
+    if (m.sources.length <= 1) return label;
+    const breakdown = sources
+      .filter((s) => m.sources.includes(s.mode))
+      .map((s) => `${s.mode} ${(s.branching * 100).toFixed(1)}%`)
+      .join(", ");
+    return `${label} [${breakdown}]`;
+  });
+  return parts.join(", ");
 }
 
 /**

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -23,6 +23,7 @@ const DECAY_MODE_MAP: Record<string, string> = {
   "a": "α",
   "gamma": "γ",
   "g": "γ",
+  "ec": "EC",
 };
 
 const PROJECTILE_MAP: Record<string, string> = {
@@ -45,6 +46,57 @@ export function formatDecayMode(mode: string): string {
   if (!mode) return mode;
   const key = mode.trim().toLowerCase();
   return DECAY_MODE_MAP[key] ?? mode;
+}
+
+/** True if a raw decay-mode identifier is a shell-resolved electron-capture entry
+ * (e.g. `KshellEC`, `LshellEC`, `MshellEC`, `K_shell_EC`). The K/L/M atomic-shell
+ * distinction is physically meaningful, but for the decay-mode chip and decay-chain
+ * presentation we collapse them all into a single `EC` bucket (see #198). */
+export function isShellEC(mode: string): boolean {
+  if (!mode) return false;
+  const key = mode.trim().toLowerCase().replace(/_/g, "");
+  return /^[klm]shellec$/.test(key);
+}
+
+export interface AggregatedDecayMode {
+  /** Canonical display key — `"ec"` for any K/L/M-shell EC, otherwise the original mode string. */
+  mode: string;
+  /** Summed branching ratio across all merged entries. */
+  branching: number;
+  /** Original wire identifiers that were folded into this bucket (in input order). */
+  sources: string[];
+}
+
+/**
+ * Aggregate a list of `{mode, branching}` entries so that K/L/M shell-resolved
+ * electron-capture rows collapse into a single `"ec"` bucket whose branching is
+ * the sum of its parts. All other modes pass through untouched (and keep their
+ * original wire-form `mode` string). Order of first occurrence is preserved.
+ *
+ * The `sources` array on each output entry retains the original mode strings so
+ * a tooltip can still surface the K/L/M breakdown if desired.
+ */
+export function aggregateDecayModes<T extends { mode: string; branching: number }>(
+  modes: readonly T[],
+): AggregatedDecayMode[] {
+  const buckets = new Map<string, AggregatedDecayMode>();
+  for (const m of modes) {
+    const isEC = isShellEC(m.mode);
+    const key = isEC ? "ec" : m.mode;
+    const displayMode = isEC ? "ec" : m.mode;
+    const existing = buckets.get(key);
+    if (existing) {
+      existing.branching += m.branching;
+      existing.sources.push(m.mode);
+    } else {
+      buckets.set(key, {
+        mode: displayMode,
+        branching: m.branching,
+        sources: [m.mode],
+      });
+    }
+  }
+  return Array.from(buckets.values());
 }
 
 /** Map a projectile/particle identifier to its render form. */


### PR DESCRIPTION
## Summary

Closes #198.

The decay-mode chip and decay-chain visualization in `IsotopePopup` were rendering the K/L/M atomic-shell electron-capture entries from the `decay.parquet` wire format verbatim. For 51Mn that produced:

- Modes: `KshellEC(89.2%), LshellEC(9.3%), MshellEC(1.5%)`
- Chain: `51Mn -> 51Mn -> 51Mn -> 51Mn -> 51Cr -> 51V -> 51V -> 51V`

After this PR:

- Modes: `EC (100.0%)` (or `beta+ (97.1%), EC (2.9%)` etc.)
- Chain: `51Mn -> 51Cr -> 51V` — one entry per distinct daughter / parent nuclide

The atomic-shell distinction is preserved as a tooltip on hover (`EC (100.0%) [KshellEC 89.2%, LshellEC 9.3%, MshellEC 1.5%]`) so the physical detail is one keypress away for power users.

## Commits

1. `fix(frontend): aggregate K/L/M shell-EC into a single EC mode for display` - new `aggregateDecayModes()` + `isShellEC()` helpers in `format.ts`, applied to the decay-mode chip.
2. `fix(frontend): deduplicate decay-chain entries by daughter/parent nuclide` - new `dedupeDecayChain()` + `formatDecayChainTooltip()` helpers, applied to the chain render. Distinct metastable states stay separate.

The aggregation is purely presentational: the underlying `DataStore` and `decay.parquet` data path is unchanged.

## Test plan

- [x] `npx vitest run src/lib/format.test.ts` - 39 tests pass (17 new)
- [x] `npx vitest run` - 483 tests pass (was 466 on `main`, +17). 3 pre-existing test-file setup errors on `main` are unrelated (`BugReportModal.svelte.test.ts`, `DataFetchSplash.svelte.test.ts`, `FetchErrorCard.svelte.test.ts` - module-resolution issue with `@testing-library/svelte`).
- [x] `npx svelte-check` - no new errors. The single pre-existing error in `BugReportModal.svelte` is unrelated.
- [ ] Manual: open IsotopePopup for 51Mn in the dev server, verify the modes section shows `beta+ (97.1%), EC (2.9%)` (with K/L/M breakdown in tooltip) and the chain shows `51Mn -> 51Cr`.
- [ ] Manual: open IsotopePopup for 51Cr, verify chain shows `51Mn -> 51Cr -> 51V`.
- [ ] Manual: regression check on an isotope with a single beta- decay (no shell-EC) - chain should be unchanged.