### PR TITLE
feat(frontend): cog-menu filter UX + lucide-svelte icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
     "hyparquet-compressors": "^1.1.1",
     "hyparquet-writer": "^0.14.0",
     "hyrr-wasm": "file:src/lib/compute/hyrr-wasm-pkg",
+    "lucide-svelte": "^1.0.1",
     "plotly.js-dist-min": "^3.5.1"
   }
 }

--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -13,6 +13,7 @@
     type DisplayMode,
   } from "../stores/display-thresholds.svelte";
   import { formatWithThresholdEx } from "../utils/threshold-format";
+  import { Save, Settings } from "lucide-svelte";
   import SettingsModal from "./SettingsModal.svelte";
 
   interface Props {
@@ -58,6 +59,7 @@
   /** Default: one row per isotope across all layers. Toggle expands to per-layer rows. */
   let groupByIsotope = $state<boolean>(true);
   let saveOpen = $state(false);
+  let cogOpen = $state(false);
   let settingsOpen = $state(false);
 
   let displayMode = $derived(getDisplayMode());
@@ -67,9 +69,9 @@
   function fmtDose(v: number) { return formatWithThresholdEx(v, "dose_rate", displayMode, thresholds); }
 
   const MODE_LABELS: Array<{ id: DisplayMode; label: string; title: string }> = [
-    { id: "indicator", label: "~0", title: "Below threshold: render compact indicator (e.g. '< 1 nBq')" },
-    { id: "zero", label: "0", title: "Below threshold: collapse to 0" },
-    { id: "all", label: "all", title: "No clamping — render every value" },
+    { id: "indicator", label: "<X", title: "Sub-threshold non-zero values render as a compact '< X' indicator (e.g. '< 1 nBq'). True zero always renders as 0." },
+    { id: "zero", label: "0", title: "Sub-threshold non-zero values collapse to 0." },
+    { id: "all", label: "all", title: "No clamping — render every value verbatim." },
   ];
 
   function getEobActivity(iso: { time_grid_s?: number[]; activity_vs_time_Bq?: number[]; activity_Bq: number }, irrS: number): number {
@@ -365,31 +367,6 @@
 <div class="activity-table-enhanced">
   <div class="toolbar">
     <span class="row-count">{rows.length}/{allRows.length} isotopes</span>
-    <div class="mode-chip-group" role="radiogroup" aria-label="Below-threshold display">
-      {#each MODE_LABELS as opt}
-        <button
-          type="button"
-          role="radio"
-          aria-checked={displayMode === opt.id}
-          class="chip"
-          class:active={displayMode === opt.id}
-          title={opt.title}
-          onclick={() => setDisplayMode(opt.id)}
-        >{opt.label}</button>
-      {/each}
-      <button
-        type="button"
-        class="chip chip-gear"
-        title="Threshold settings…"
-        aria-label="Threshold settings"
-        onclick={() => (settingsOpen = true)}
-      >
-        <svg width="11" height="11" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M8 4.754a3.246 3.246 0 100 6.492 3.246 3.246 0 000-6.492zM5.754 8a2.246 2.246 0 114.492 0 2.246 2.246 0 01-4.492 0z"/>
-          <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 01-1.255.52l-.292-.16c-1.64-.892-3.433.902-2.54 2.541l.159.292a.873.873 0 01-.52 1.255l-.319.094c-1.79.527-1.79 3.065 0 3.592l.319.094a.873.873 0 01.52 1.255l-.16.292c-.892 1.64.901 3.434 2.541 2.54l.292-.159a.873.873 0 011.255.52l.094.319c.527 1.79 3.065 1.79 3.592 0l.094-.319a.873.873 0 011.255-.52l.292.16c1.64.893 3.434-.902 2.54-2.541l-.159-.292a.873.873 0 01.52-1.255l.319-.094c1.79-.527 1.79-3.065 0-3.592l-.319-.094a.873.873 0 01-.52-1.255l.16-.292c.893-1.64-.902-3.433-2.541-2.54l-.292.159a.873.873 0 01-1.255-.52l-.094-.319zm-2.633.283c.246-.835 1.428-.835 1.674 0l.094.319a1.873 1.873 0 002.693 1.115l.291-.16c.764-.415 1.6.42 1.184 1.185l-.159.292a1.873 1.873 0 001.116 2.692l.318.094c.835.246.835 1.428 0 1.674l-.319.094a1.873 1.873 0 00-1.115 2.693l.16.291c.415.764-.42 1.6-1.185 1.184l-.291-.159a1.873 1.873 0 00-2.693 1.116l-.094.318c-.246.835-1.428.835-1.674 0l-.094-.319a1.873 1.873 0 00-2.692-1.115l-.292.16c-.764.415-1.6-.42-1.184-1.185l.159-.291A1.873 1.873 0 001.945 8.93l-.319-.094c-.835-.246-.835-1.428 0-1.674l.319-.094A1.873 1.873 0 003.06 4.377l-.16-.292c-.415-.764.42-1.6 1.185-1.184l.292.159a1.873 1.873 0 002.692-1.115l.094-.319z"/>
-        </svg>
-      </button>
-    </div>
     <div class="toolbar-actions">
       <button
         class="action-btn"
@@ -404,14 +381,12 @@
         <button
           class="action-btn save-btn"
           class:active={saveOpen}
-          onclick={(e: MouseEvent) => { e.stopPropagation(); saveOpen = !saveOpen; }}
+          onclick={(e: MouseEvent) => { e.stopPropagation(); saveOpen = !saveOpen; cogOpen = false; }}
           title="Save / download table"
           aria-haspopup="menu"
           aria-expanded={saveOpen}
         >
-          <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-            <path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5c.966 0 1.75.784 1.75 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h.75v-3.25c0-.966.784-1.75 1.75-1.75h3.5c.966 0 1.75.784 1.75 1.75v3.25h.75a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-.75v1.5c0 .966-.784 1.75-1.75 1.75h-3.5A1.75 1.75 0 015 3V1.5h-.75zm3.5 13v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25V14.5h4zM6.5 1.5v1.5a.25.25 0 00.25.25h3.5a.25.25 0 00.25-.25V1.5h-4z"></path>
-          </svg>
+          <Save size={13} aria-hidden="true" />
         </button>
         {#if saveOpen}
           <div class="save-menu" role="menu">
@@ -420,6 +395,44 @@
             </button>
             <button class="menu-item" role="menuitem" onclick={() => { saveOpen = false; exportParquet(); }}>
               Parquet <span class="menu-hint">typed columns, polars/duckdb</span>
+            </button>
+          </div>
+        {/if}
+      </span>
+      <span class="cog-wrap">
+        <button
+          class="action-btn cog-btn"
+          class:active={cogOpen}
+          onclick={(e: MouseEvent) => { e.stopPropagation(); cogOpen = !cogOpen; saveOpen = false; }}
+          title="Display settings"
+          aria-haspopup="menu"
+          aria-expanded={cogOpen}
+        >
+          <Settings size={13} aria-hidden="true" />
+        </button>
+        {#if cogOpen}
+          <div class="cog-menu" role="menu">
+            <div class="menu-section-label">Sub-threshold display</div>
+            <div role="radiogroup" aria-label="Below-threshold display" class="mode-radio-group">
+              {#each MODE_LABELS as opt}
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={displayMode === opt.id}
+                  class="menu-item mode-item"
+                  class:active={displayMode === opt.id}
+                  title={opt.title}
+                  onclick={() => setDisplayMode(opt.id)}
+                >
+                  <span class="mode-radio" aria-hidden="true">{displayMode === opt.id ? "●" : "○"}</span>
+                  <span class="mode-label">{opt.label}</span>
+                  <span class="menu-hint">{opt.title.split(".")[0]}</span>
+                </button>
+              {/each}
+            </div>
+            <div class="menu-divider" role="separator"></div>
+            <button class="menu-item" role="menuitem" onclick={() => { cogOpen = false; settingsOpen = true; }}>
+              Threshold values… <span class="menu-hint">configure floors</span>
             </button>
           </div>
         {/if}
@@ -501,14 +514,16 @@
 </div>
 
 <svelte:window onclick={(e: MouseEvent) => {
-  if (saveOpen && !(e.target as HTMLElement)?.closest?.(".save-wrap")) saveOpen = false;
+  const t = e.target as HTMLElement;
+  if (saveOpen && !t?.closest?.(".save-wrap")) saveOpen = false;
+  if (cogOpen && !t?.closest?.(".cog-wrap")) cogOpen = false;
 }} />
 
 <SettingsModal open={settingsOpen} onclose={() => (settingsOpen = false)} />
 
 <style>
-  .save-wrap { position: relative; display: inline-flex; }
-  .save-menu {
+  .save-wrap, .cog-wrap { position: relative; display: inline-flex; }
+  .save-menu, .cog-menu {
     position: absolute;
     top: calc(100% + 4px);
     right: 0;
@@ -538,7 +553,35 @@
   }
   .menu-item:hover { background: var(--c-bg-muted); }
   .menu-hint { color: var(--c-text-muted); font-size: 0.7rem; }
-  .save-btn { line-height: 0; padding: 0.15rem 0.35rem; }
+  .save-btn, .cog-btn { line-height: 0; padding: 0.15rem 0.35rem; }
+  .menu-section-label {
+    padding: 4px 10px 2px;
+    font-size: 0.65rem;
+    color: var(--c-text-subtle);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .mode-radio-group { display: flex; flex-direction: column; }
+  .mode-item { justify-content: flex-start; }
+  .mode-item .mode-radio {
+    width: 12px;
+    color: var(--c-text-muted);
+    font-size: 0.7rem;
+    line-height: 1;
+  }
+  .mode-item.active .mode-radio { color: var(--c-accent); }
+  .mode-item .mode-label {
+    min-width: 30px;
+    font-variant-numeric: tabular-nums;
+    color: var(--c-text);
+  }
+  .mode-item.active .mode-label { color: var(--c-accent); }
+  .mode-item .menu-hint { margin-left: auto; }
+  .menu-divider {
+    height: 1px;
+    background: var(--c-border);
+    margin: 4px 6px;
+  }
   .activity-table-enhanced {
     background: var(--c-bg-subtle);
     border: 1px solid var(--c-border);
@@ -659,17 +702,6 @@
   tr.selected td:first-child { border-left: 3px solid var(--c-accent); }
   tr.zero td { opacity: 0.35; }
   td.clamped { color: var(--c-text-faint); font-style: italic; }
-
-  .mode-chip-group {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.15rem;
-    margin-left: 0.4rem;
-  }
-  .mode-chip-group .chip-gear {
-    padding: 0.15rem 0.3rem;
-    line-height: 0;
-  }
 
   .isotope-link {
     background: none;

--- a/frontend/src/lib/components/HeaderBar.svelte
+++ b/frontend/src/lib/components/HeaderBar.svelte
@@ -10,6 +10,7 @@
   import { buildSessionFile, downloadSessionFile, pickSessionFile } from "../session-io";
   import { getDisplayThresholds, setDisplayThresholds } from "../stores/display-thresholds.svelte";
   import { openExternalUrl } from "../utils/open-url";
+  import { Bug, CircleHelp, History, Monitor, Moon, Save, Sun } from "lucide-svelte";
   import logoUrl from "/logo.svg?url";
 
   let historyOpen = $derived(getHistoryOpen());
@@ -74,17 +75,11 @@
       title="Theme: {themeMode} ({resolved})"
     >
       {#if themeMode === "auto"}
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M8 1a7 7 0 100 14A7 7 0 008 1zM0 8a8 8 0 1116 0A8 8 0 010 8zm8-5.5v11a5.5 5.5 0 000-11z"></path>
-        </svg>
+        <Monitor size={16} aria-hidden="true" />
       {:else if resolved === "light"}
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M8 12a4 4 0 100-8 4 4 0 000 8zm0 1A5 5 0 108 3a5 5 0 000 10zm5.657-9.657a.75.75 0 010 1.06l-.707.707a.75.75 0 11-1.06-1.06l.707-.707a.75.75 0 011.06 0zM3.404 11.89a.75.75 0 010 1.06l-.707.707a.75.75 0 01-1.06-1.06l.707-.707a.75.75 0 011.06 0zM8 0a.75.75 0 01.75.75v1a.75.75 0 01-1.5 0v-1A.75.75 0 018 0zm0 13a.75.75 0 01.75.75v1a.75.75 0 01-1.5 0v-1A.75.75 0 018 13zm7-5a.75.75 0 01-.75.75h-1a.75.75 0 010-1.5h1A.75.75 0 0115 8zM2 8a.75.75 0 01-.75.75h-1a.75.75 0 010-1.5h1A.75.75 0 012 8zm10.596-4.596a.75.75 0 010 1.06l-.707.707a.75.75 0 01-1.06-1.06l.707-.707a.75.75 0 011.06 0z"></path>
-        </svg>
+        <Sun size={16} aria-hidden="true" />
       {:else}
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M9.598 1.591a.749.749 0 01.785-.175 7.001 7.001 0 01-.785 13.168.748.748 0 01-.785-.175.748.748 0 01.175-.786A5.5 5.5 0 009.5 8a5.5 5.5 0 00-.512-2.323.749.749 0 01.61-1.086z"></path>
-        </svg>
+        <Moon size={16} aria-hidden="true" />
       {/if}
     </button>
 
@@ -95,9 +90,7 @@
         class:active={saveMenuOpen}
         title="Save / load session"
       >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-          <path d="M2 1.75C2 .784 2.784 0 3.75 0h6.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v9.586A1.75 1.75 0 0113.25 16H3.75A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h9.5a.25.25 0 00.25-.25V6h-2.75A1.75 1.75 0 019 4.25V1.5H3.75zm6.75.62v2.13c0 .138.112.25.25.25h2.13L10.5 2.12zM4.5 7.75A.75.75 0 015.25 7h5.5a.75.75 0 010 1.5h-5.5a.75.75 0 01-.75-.75zm0 3A.75.75 0 015.25 10h5.5a.75.75 0 010 1.5h-5.5a.75.75 0 01-.75-.75z"></path>
-        </svg>
+        <Save size={16} aria-hidden="true" />
       </button>
       {#if saveMenuOpen}
         <div class="save-menu" role="menu">
@@ -116,9 +109,7 @@
     </div>
 
     <button class="icon-btn" onclick={() => helpOpen = true} title="Help">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M0 8a8 8 0 1116 0A8 8 0 010 8zm8-6.5a6.5 6.5 0 100 13 6.5 6.5 0 000-13zM6.92 6.085h.001a.749.749 0 11-1.342-.67c.169-.339.436-.701.849-.977C6.845 4.16 7.369 4 8 4a2.756 2.756 0 011.637.525c.503.377.863.965.863 1.725 0 .448-.115.83-.329 1.15-.205.307-.478.513-.708.662-.04.027-.08.049-.118.07h-.001l-.001.001v.001L9 8.5l-.343.356a.756.756 0 01-.214.468.751.751 0 01-.788.103.751.751 0 01-.453-.685v-.399c0-.199.079-.39.22-.53.14-.14.332-.22.53-.22h.001l.003-.002.005-.003.025-.016a1.514 1.514 0 00.21-.159c.163-.142.252-.296.252-.478 0-.263-.128-.467-.335-.623A1.26 1.26 0 008 5.5c-.369 0-.626.1-.806.224a1.132 1.132 0 00-.358.447l-.002.005zM9 11a1 1 0 11-2 0 1 1 0 012 0z"></path>
-      </svg>
+      <CircleHelp size={16} aria-hidden="true" />
     </button>
 
     <a
@@ -142,15 +133,11 @@
     </a>
 
     <button class="icon-btn" onclick={openBugReport} title="Report a bug">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M4.72.22a.75.75 0 011.06 0l1 1a.75.75 0 01-1.06 1.06l-.293-.293A3.5 3.5 0 008 5.5h.001A3.5 3.5 0 0010.56 1.99l-.293.293a.75.75 0 01-1.06-1.06l1-1a.75.75 0 011.06 0l1 1a.75.75 0 11-1.06 1.06l-.294-.294A4.992 4.992 0 0112.993 5H13.5a.75.75 0 010 1.5h-.333A5.02 5.02 0 0113 7.25v.25h1.25a.75.75 0 010 1.5H13v.25c0 .37-.04.736-.117 1.086l.36.07a.75.75 0 01-.294 1.472l-.36-.07A5.003 5.003 0 018 16a5.003 5.003 0 01-4.589-4.192l-.36.07a.75.75 0 11-.294-1.472l.36-.07A5.02 5.02 0 013 9.25V9H1.75a.75.75 0 010-1.5H3v-.25c0-.263.023-.522.067-.775H2.75a.75.75 0 010-1.5h.743a4.992 4.992 0 012.24-3.012L5.44 1.67l-.293.293A.75.75 0 014.08 1.28l.22-.22zM4.5 7.25V9.5a3.5 3.5 0 107 0V7.25a3.5 3.5 0 00-7 0z"></path>
-      </svg>
+      <Bug size={16} aria-hidden="true" />
     </button>
 
     <button class="icon-btn" onclick={toggleHistory} class:active={historyOpen} title="History">
-      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-        <path d="M1.5 8a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0zM8 0a8 8 0 100 16A8 8 0 008 0zm.5 4.75a.75.75 0 00-1.5 0v3.5a.75.75 0 00.37.65l2.5 1.5a.75.75 0 10.76-1.3L8.5 7.94V4.75z"></path>
-      </svg>
+      <History size={16} aria-hidden="true" />
     </button>
   </div>
 </header>

--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -30,6 +30,7 @@
     formatDecayMode,
   } from "../format";
   import SaveMenu from "./SaveMenu.svelte";
+  import { ExternalLink } from "lucide-svelte";
 
   interface Props {
     open: boolean;
@@ -1099,11 +1100,11 @@
     <!-- Links -->
     <div class="links">
       <a href={nudatUrl(Z, A, nuclearState)} target="_blank" rel="noopener noreferrer" class="ext-link">
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.75 2h3.5a.75.75 0 010 1.5h-3.5a.25.25 0 00-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25v-3.5a.75.75 0 011.5 0v3.5A1.75 1.75 0 0112.25 14h-8.5A1.75 1.75 0 012 12.25v-8.5C2 2.784 2.784 2 3.75 2zm6.854.22a.75.75 0 011.396-.04L14 5.5a.75.75 0 01-1.5 0V4.56l-3.97 3.97a.75.75 0 01-1.06-1.06L11.44 3.5H10.5a.75.75 0 010-1.5h.104z"></path></svg>
+        <ExternalLink size={12} aria-hidden="true" />
         NuDat 3.0
       </a>
       <a href={janisUrl()} target="_blank" rel="noopener noreferrer" class="ext-link">
-        <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor"><path d="M3.75 2h3.5a.75.75 0 010 1.5h-3.5a.25.25 0 00-.25.25v8.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25v-3.5a.75.75 0 011.5 0v3.5A1.75 1.75 0 0112.25 14h-8.5A1.75 1.75 0 012 12.25v-8.5C2 2.784 2.784 2 3.75 2zm6.854.22a.75.75 0 011.396-.04L14 5.5a.75.75 0 01-1.5 0V4.56l-3.97 3.97a.75.75 0 01-1.06-1.06L11.44 3.5H10.5a.75.75 0 010-1.5h.104z"></path></svg>
+        <ExternalLink size={12} aria-hidden="true" />
         JANIS (NEA)
       </a>
     </div>

--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { Bug } from "lucide-svelte";
   import { openBugReport } from "../stores/bugreport.svelte";
 
   interface Props {
@@ -44,9 +45,7 @@
         {/if}
         <div class="header-actions">
           <button class="bug-btn" onclick={openBugReport} title="Report a bug">
-            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-              <path d="M4.72.22a.75.75 0 011.06 0l1 1a.75.75 0 01-1.06 1.06l-.293-.293A3.5 3.5 0 008 5.5h.001A3.5 3.5 0 0010.56 1.99l-.293.293a.75.75 0 01-1.06-1.06l1-1a.75.75 0 011.06 0l1 1a.75.75 0 11-1.06 1.06l-.294-.294A4.992 4.992 0 0112.993 5H13.5a.75.75 0 010 1.5h-.333A5.02 5.02 0 0113 7.25v.25h1.25a.75.75 0 010 1.5H13v.25c0 .37-.04.736-.117 1.086l.36.07a.75.75 0 01-.294 1.472l-.36-.07A5.003 5.003 0 018 16a5.003 5.003 0 01-4.589-4.192l-.36.07a.75.75 0 11-.294-1.472l.36-.07A5.02 5.02 0 013 9.25V9H1.75a.75.75 0 010-1.5H3v-.25c0-.263.023-.522.067-.775H2.75a.75.75 0 010-1.5h.743a4.992 4.992 0 012.24-3.012L5.44 1.67l-.293.293A.75.75 0 014.08 1.28l.22-.22zM4.5 7.25V9.5a3.5 3.5 0 107 0V7.25a3.5 3.5 0 00-7 0z"></path>
-            </svg>
+            <Bug size={14} aria-hidden="true" />
           </button>
           <button class="close-btn" onclick={onclose}>&times;</button>
         </div>

--- a/frontend/src/lib/components/SaveMenu.svelte
+++ b/frontend/src/lib/components/SaveMenu.svelte
@@ -4,6 +4,7 @@
    * to open a menu of export options (CSV, Parquet, etc.). Each option
    * triggers a callback passed in by the parent.
    */
+  import { Save } from "lucide-svelte";
   import {
     tracesToCsv,
     triggerDownload,
@@ -70,9 +71,7 @@
     aria-haspopup="menu"
     aria-expanded={open}
   >
-    <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M2 1.75C2 .784 2.784 0 3.75 0h8.5c.966 0 1.75.784 1.75 1.75v12.5A1.75 1.75 0 0112.25 16h-8.5A1.75 1.75 0 012 14.25V1.75zm1.75-.25a.25.25 0 00-.25.25v12.5c0 .138.112.25.25.25h.75v-3.25c0-.966.784-1.75 1.75-1.75h3.5c.966 0 1.75.784 1.75 1.75v3.25h.75a.25.25 0 00.25-.25V1.75a.25.25 0 00-.25-.25h-.75v1.5c0 .966-.784 1.75-1.75 1.75h-3.5A1.75 1.75 0 015 3V1.5h-.75zm3.5 13v-3.25a.25.25 0 00-.25-.25h-3.5a.25.25 0 00-.25.25V14.5h4zM6.5 1.5v1.5a.25.25 0 00.25.25h3.5a.25.25 0 00.25-.25V1.5h-4z"></path>
-    </svg>
+    <Save size={13} aria-hidden="true" />
   </button>
   {#if open}
     <div class="menu" role="menu">

--- a/frontend/src/lib/utils/threshold-format.ts
+++ b/frontend/src/lib/utils/threshold-format.ts
@@ -54,7 +54,12 @@ export interface FormatResult {
   clamped: boolean;
 }
 
-/** Threshold-aware formatter result with a CSS hook for de-emphasis. */
+/** Threshold-aware formatter result with a CSS hook for de-emphasis.
+ *
+ *  True zero always renders as the unit-aware "0" label regardless of mode —
+ *  only sub-threshold non-zero values (typically `e-XY` Bateman residuals) are
+ *  affected by the mode. NaN / ±Infinity pass through raw so bugs stay visible.
+ */
 export function formatWithThresholdEx(
   value: number,
   quantity: Quantity,
@@ -62,6 +67,7 @@ export function formatWithThresholdEx(
   thresholds: Thresholds,
 ): FormatResult {
   const raw = RAW_FORMATTERS[quantity];
+  if (value === 0) return { text: ZERO_LABEL[quantity], clamped: false };
   if (mode === "all" || isAboveThreshold(value, thresholds[quantity])) {
     return { text: raw(value), clamped: false };
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "hyparquet-compressors": "^1.1.1",
         "hyparquet-writer": "^0.14.0",
         "hyrr-wasm": "file:src/lib/compute/hyrr-wasm-pkg",
+        "lucide-svelte": "^1.0.1",
         "plotly.js-dist-min": "^3.5.1"
       },
       "devDependencies": {
@@ -324,7 +325,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -335,7 +335,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -346,7 +345,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -356,14 +354,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -690,7 +686,6 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.9.tgz",
       "integrity": "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -908,14 +903,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
@@ -1035,7 +1028,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -1072,7 +1064,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1092,7 +1083,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1147,7 +1137,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1245,7 +1234,6 @@
       "version": "5.8.0",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.0.tgz",
       "integrity": "sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-accessibility-api": {
@@ -1279,14 +1267,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esrap": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.6.tgz",
       "integrity": "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -1451,7 +1437,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -1771,7 +1756,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
@@ -1782,6 +1766,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lucide-svelte": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-1.0.1.tgz",
+      "integrity": "sha512-WvzZgk0pqzgda+AErLvgWxHkfg/+GgUwqKMRHvzt0IqyMdmyEDzDCk3Z+Wo/3y753oIgx8u9Q4eUbWkghFa8Jg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5.0.0-next.42"
       }
     },
     "node_modules/lz-string": {
@@ -1798,7 +1791,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -2147,7 +2139,6 @@
       "version": "5.55.5",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
       "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2635,7 +2626,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "packages/compute": {


### PR DESCRIPTION
## Summary
- Activity-table sub-threshold mode toggle (`~0` / `0` / `all`) moved out of the toolbar into a cog dropdown right next to the save button. Cog menu also exposes "Threshold values…" → opens the existing SettingsModal.
- Indicator-mode label changed `~0` → `<X` (matches what the cell actually renders).
- `formatWithThresholdEx` short-circuits true `0` to the unit-aware zero label in every mode. Only sub-threshold non-zero values (Bateman residuals) get the chosen mode's rendering.
- Replaced inline Octicon path data with `lucide-svelte` components across `ActivityTableEnhanced`, `HeaderBar`, `IsotopePopup`, `Modal`, `SaveMenu`. GitHub mark stays inline (lucide ships no brand glyphs).

## Test plan
- [ ] /tst staging: cog dropdown opens next to save icon; three radio options switch mode; "Threshold values…" opens SettingsModal.
- [ ] True-zero activity cells render `0` in every mode (was the bug — `all` mode previously rendered `raw(0)`).
- [ ] Sub-threshold non-zero cells render `< 1 nBq` / `0` / raw per mode as expected.
- [ ] HeaderBar theme toggle: auto-icon is now Monitor — eyeball semantic clarity.
- [ ] `npm run check` passes (already verified pre-push).