### PR TITLE
fix(frontend): sub-Bq SI prefixes, shell-EC dedup in table, plot save alignment

### DIFF
--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -495,7 +495,7 @@
             <td class="col-a">{row.A}</td>
             <td class="col-hl">{formatHalfLife(row.half_life_s)}</td>
             <td class="col-reaction">
-              {#each [...row.reactions, ...row.decayNotations] as rxn, i}{#if i > 0}, {/if}{formatReaction(rxn)}{/each}
+              {#each [...new Set([...row.reactions, ...row.decayNotations].map(formatReaction))] as rxn, i}{#if i > 0}, {/if}{rxn}{/each}
               {#if row.reactions.length === 0 && row.decayNotations.length === 0 && row.source === "daughter"}decay{/if}
             </td>
             <td class="col-act" class:clamped={eob.clamped}>{eob.text}</td>
@@ -625,28 +625,6 @@
     font-variant-numeric: tabular-nums;
   }
 
-  .chip {
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text-subtle);
-    padding: 0.15rem 0.35rem;
-    font-size: 0.65rem;
-    cursor: pointer;
-    white-space: nowrap;
-    line-height: 1.2;
-  }
-
-  .chip:hover {
-    border-color: var(--c-accent);
-    color: var(--c-text-muted);
-  }
-
-  .chip.active {
-    background: var(--c-bg-active);
-    border-color: var(--c-accent);
-    color: var(--c-accent);
-  }
 
   /* Table */
   .table-wrapper {

--- a/frontend/src/lib/components/PlotActivityCurve.svelte
+++ b/frontend/src/lib/components/PlotActivityCurve.svelte
@@ -669,19 +669,21 @@
       </div>
     {/if}
 
-    <SaveMenu
-      filenamePrefix="hyrr-activity"
-      xLabel={lastExport?.xLabel ?? "Time"}
-      yLabel={lastExport?.yLabel ?? "Activity"}
-      getTraces={() => lastExport?.traces ?? []}
-      notes={() => [`HYRR activity plot export`, `generated ${new Date().toISOString()}`]}
-      title="Save / download plot data"
-    />
-    {#if selected.size > 0}
-      <button class="ctrl-btn clear" onclick={clearSelection}>
-        Clear ({selected.size})
-      </button>
-    {/if}
+    <span class="right-actions">
+      {#if selected.size > 0}
+        <button class="ctrl-btn clear" onclick={clearSelection}>
+          Clear ({selected.size})
+        </button>
+      {/if}
+      <SaveMenu
+        filenamePrefix="hyrr-activity"
+        xLabel={lastExport?.xLabel ?? "Time"}
+        yLabel={lastExport?.yLabel ?? "Activity"}
+        getTraces={() => lastExport?.traces ?? []}
+        notes={() => [`HYRR activity plot export`, `generated ${new Date().toISOString()}`]}
+        title="Save / download plot data"
+      />
+    </span>
   </div>
 
   <div bind:this={plotDiv} class="plot"></div>
@@ -701,6 +703,13 @@
     gap: 0.4rem;
     padding: 0.25rem 0.5rem;
     flex-wrap: wrap;
+  }
+
+  .right-actions {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
   }
 
   .separator {

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -34,6 +34,15 @@ describe("formatDecayMode", () => {
     expect(formatDecayMode("EC")).toBe("EC");
   });
 
+  it("collapses K/L/M-shell EC variants to plain EC", () => {
+    expect(formatDecayMode("KshellEC")).toBe("EC");
+    expect(formatDecayMode("LshellEC")).toBe("EC");
+    expect(formatDecayMode("MshellEC")).toBe("EC");
+    expect(formatDecayMode("K_shell_EC")).toBe("EC");
+    expect(formatDecayMode("L_shell_EC")).toBe("EC");
+    expect(formatDecayMode("M_shell_EC")).toBe("EC");
+  });
+
   it("passes unknown / empty modes through", () => {
     expect(formatDecayMode("")).toBe("");
     expect(formatDecayMode("unknown_mode")).toBe("unknown_mode");
@@ -86,6 +95,12 @@ describe("formatReaction", () => {
   it("is idempotent on already-Greek input", () => {
     expect(formatReaction("(α,γ)")).toBe("(α,γ)");
     expect(formatReaction("²⁷Al(p,αn)²²Na")).toBe("²⁷Al(p,αn)²²Na");
+  });
+
+  it("collapses K/L/M-shell EC notations to (EC)", () => {
+    expect(formatReaction("⁵¹Mn(KshellEC)")).toBe("⁵¹Mn(EC)");
+    expect(formatReaction("⁵¹Mn(LshellEC)")).toBe("⁵¹Mn(EC)");
+    expect(formatReaction("⁵¹Mn(MshellEC)")).toBe("⁵¹Mn(EC)");
   });
 
   it("maps decay-arrow notation", () => {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -24,6 +24,12 @@ const DECAY_MODE_MAP: Record<string, string> = {
   "gamma": "γ",
   "g": "γ",
   "ec": "EC",
+  "kshellec": "EC",
+  "lshellec": "EC",
+  "mshellec": "EC",
+  "k_shell_ec": "EC",
+  "l_shell_ec": "EC",
+  "m_shell_ec": "EC",
 };
 
 const PROJECTILE_MAP: Record<string, string> = {

--- a/packages/compute/src/format.test.ts
+++ b/packages/compute/src/format.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { fmtActivity, fmtYield, fmtDoseRate, bestActivityUnit } from "./format";
+
+describe("fmtActivity SI prefixes", () => {
+  it("scales values ≥ 1 Bq into k/M/G/T", () => {
+    expect(fmtActivity(1)).toBe("1.000 Bq");
+    expect(fmtActivity(1500)).toBe("1.500 kBq");
+    expect(fmtActivity(2.3e6)).toBe("2.300 MBq");
+    expect(fmtActivity(4.5e9)).toBe("4.500 GBq");
+    expect(fmtActivity(7.8e12)).toBe("7.800 TBq");
+  });
+
+  it("scales sub-Bq values into m/µ/n/p", () => {
+    expect(fmtActivity(1e-3)).toBe("1.000 mBq");
+    expect(fmtActivity(7.63e-6)).toBe("7.630 µBq");
+    expect(fmtActivity(2.5e-9)).toBe("2.500 nBq");
+    expect(fmtActivity(4e-12)).toBe("4.000 pBq");
+  });
+
+  it("handles edge cases", () => {
+    expect(fmtActivity(0)).toBe("0");
+    expect(fmtActivity(NaN)).toBe("—");
+    expect(fmtActivity(Infinity)).toBe("—");
+  });
+
+  it("falls back to scientific for sub-pBq", () => {
+    expect(fmtActivity(1e-15)).toBe("1.00e-15 Bq");
+  });
+});
+
+describe("fmtYield SI prefixes", () => {
+  it("scales sub-Bq/µA values", () => {
+    expect(fmtYield(5e-6)).toBe("5.00 µBq/µA");
+    expect(fmtYield(2e-9)).toBe("2.00 nBq/µA");
+  });
+
+  it("keeps existing kBq/µA / MBq/µA behavior", () => {
+    expect(fmtYield(2.5e3)).toBe("2.50 kBq/µA");
+    expect(fmtYield(1.2e6)).toBe("1.20 MBq/µA");
+  });
+});
+
+describe("fmtDoseRate SI prefixes", () => {
+  it("scales µSv/h input into Sv → mSv → µSv → nSv → pSv", () => {
+    expect(fmtDoseRate(2e6)).toBe("2.00 Sv/h");
+    expect(fmtDoseRate(5e3)).toBe("5.00 mSv/h");
+    expect(fmtDoseRate(1)).toBe("1.00 µSv/h");
+    expect(fmtDoseRate(2e-3)).toBe("2.00 nSv/h");
+    expect(fmtDoseRate(3e-6)).toBe("3.00 pSv/h");
+  });
+
+  it("handles zero and non-finite", () => {
+    expect(fmtDoseRate(0)).toBe("0");
+    expect(fmtDoseRate(NaN)).toBe("—");
+  });
+});
+
+describe("bestActivityUnit", () => {
+  it("now supports sub-Bq tiers", () => {
+    expect(bestActivityUnit(2e6)).toEqual({ label: "MBq", divisor: 1e6 });
+    expect(bestActivityUnit(2.5)).toEqual({ label: "Bq", divisor: 1 });
+    expect(bestActivityUnit(5e-7)).toEqual({ label: "nBq", divisor: 1e-9 });
+  });
+});

--- a/packages/compute/src/format.ts
+++ b/packages/compute/src/format.ts
@@ -4,39 +4,57 @@
 
 import { Z_TO_SYMBOL } from "./formula";
 
+/** SI prefix table — descending so the first row ≤ |v| wins. */
+const SI_PREFIXES: ReadonlyArray<readonly [number, string]> = [
+  [1e12, "T"], [1e9, "G"], [1e6, "M"], [1e3, "k"],
+  [1, ""],
+  [1e-3, "m"], [1e-6, "µ"], [1e-9, "n"], [1e-12, "p"],
+];
+
+/**
+ * Format a value with the best SI-prefixed unit. `precision` is passed to
+ * `toPrecision`. Falls back to scientific notation outside the prefix range.
+ * Returns `"—"` for non-finite input and `"0"` for exact zero.
+ */
+function fmtSI(value: number, baseUnit: string, precision: number): string {
+  if (typeof value !== "number" || !isFinite(value)) return "—";
+  if (value === 0) return "0";
+  const abs = Math.abs(value);
+  for (const [factor, prefix] of SI_PREFIXES) {
+    if (abs >= factor) return `${(value / factor).toPrecision(precision)} ${prefix}${baseUnit}`;
+  }
+  return `${value.toExponential(2)} ${baseUnit}`;
+}
+
+/** Pick the SI prefix label + divisor for a magnitude (for plot axes / column headers). */
+function bestSIUnit(maxAbs: number, baseUnit: string): { label: string; divisor: number } {
+  for (const [factor, prefix] of SI_PREFIXES) {
+    if (maxAbs >= factor) return { label: `${prefix}${baseUnit}`, divisor: factor };
+  }
+  return { label: baseUnit, divisor: 1 };
+}
+
 /** Auto-scale activity to the best human-readable unit. */
 export function fmtActivity(bq: number): string {
-  if (typeof bq !== "number" || !isFinite(bq)) return "—";
-  const abs = Math.abs(bq);
-  if (abs === 0) return "0";
-  if (abs >= 1e12) return (bq / 1e12).toPrecision(4) + " TBq";
-  if (abs >= 1e9) return (bq / 1e9).toPrecision(4) + " GBq";
-  if (abs >= 1e6) return (bq / 1e6).toPrecision(4) + " MBq";
-  if (abs >= 1e3) return (bq / 1e3).toPrecision(4) + " kBq";
-  if (abs >= 1) return bq.toPrecision(4) + " Bq";
-  return bq.toExponential(2) + " Bq";
+  return fmtSI(bq, "Bq", 4);
 }
 
 /** Auto-scale saturation yield. */
 export function fmtYield(val: number): string {
-  if (typeof val !== "number" || !isFinite(val)) return "—";
-  if (val === 0) return "0";
-  const abs = Math.abs(val);
-  if (abs >= 1e12) return (val / 1e12).toPrecision(3) + " TBq/µA";
-  if (abs >= 1e9) return (val / 1e9).toPrecision(3) + " GBq/µA";
-  if (abs >= 1e6) return (val / 1e6).toPrecision(3) + " MBq/µA";
-  if (abs >= 1e3) return (val / 1e3).toPrecision(3) + " kBq/µA";
-  if (abs >= 1) return val.toPrecision(3) + " Bq/µA";
-  return val.toExponential(2) + " Bq/µA";
+  return fmtSI(val, "Bq/µA", 3);
+}
+
+/** Auto-scale dose rate (µSv/h input) to the best human-readable unit. */
+export function fmtDoseRate(uSvPerH: number): string {
+  if (typeof uSvPerH !== "number" || !isFinite(uSvPerH)) return "—";
+  if (uSvPerH === 0) return "0";
+  // Input arrives in µSv/h; rebase to Sv/h so the SI prefix table picks the right rung.
+  return fmtSI(uSvPerH * 1e-6, "Sv/h", 3);
 }
 
 /** Find the best unit and divisor for a set of activity values. */
 export function bestActivityUnit(maxBq: number): { label: string; divisor: number } {
-  if (maxBq >= 1e12) return { label: "TBq", divisor: 1e12 };
-  if (maxBq >= 1e9) return { label: "GBq", divisor: 1e9 };
-  if (maxBq >= 1e6) return { label: "MBq", divisor: 1e6 };
-  if (maxBq >= 1e3) return { label: "kBq", divisor: 1e3 };
-  return { label: "Bq", divisor: 1 };
+  return bestSIUnit(maxBq, "Bq");
 }
 
 /** Pick best time unit for display. */
@@ -45,18 +63,6 @@ export function bestTimeUnit(maxS: number): { label: string; divisor: number } {
   if (maxS >= 3600 * 2) return { label: "h", divisor: 3600 };
   if (maxS >= 120) return { label: "min", divisor: 60 };
   return { label: "s", divisor: 1 };
-}
-
-/** Auto-scale dose rate (µSv/h input) to the best human-readable unit. */
-export function fmtDoseRate(uSvPerH: number): string {
-  if (typeof uSvPerH !== "number" || !isFinite(uSvPerH)) return "—";
-  const abs = Math.abs(uSvPerH);
-  if (abs === 0) return "0";
-  if (abs >= 1e6) return (uSvPerH / 1e6).toPrecision(3) + " Sv/h";
-  if (abs >= 1e3) return (uSvPerH / 1e3).toPrecision(3) + " mSv/h";
-  if (abs >= 1) return uSvPerH.toPrecision(3) + " µSv/h";
-  if (abs >= 1e-3) return (uSvPerH * 1e3).toPrecision(3) + " nSv/h";
-  return uSvPerH.toExponential(2) + " µSv/h";
 }
 
 /** Build NuDat 3.0 URL for an isotope. */


### PR DESCRIPTION
Three /tst-review findings from the v0.8.0 staging pass.

## Summary
- **Activity formatting**: `fmtActivity` / `fmtYield` / `fmtDoseRate` only had k/M/G/T tiers, so sub-Bq cells rendered as scientific notation (`7.63e-6 Bq`). Refactored around a single `fmtSI(value, baseUnit, precision)` helper backed by an SI-prefix table; extended down to p-tier. Cells now read `7.63 µBq` etc. `bestActivityUnit` now uses the same table so plot axes pick sub-Bq prefixes when warranted.
- **K/L/M-shell EC dedup in table**: Reaction column rendered four separate notations (`⁵¹Mn(KshellEC), ⁵¹Mn(LshellEC), ⁵¹Mn(MshellEC), ⁵¹Mn(β⁺)`). Added `kshellec`/`lshellec`/`mshellec` (and `_shell_` variants) to `DECAY_MODE_MAP` so `formatReaction` maps the inner token to `EC`; the cell now de-dupes by formatted-string identity → `⁵¹Mn(EC), ⁵¹Mn(β⁺)`. CSV/Parquet exports still keep the raw wire-form notations for downstream analysis.
- **Activity plot save-button alignment**: `SaveMenu` sat mid-toolbar (no `margin-left: auto`). Wrapped it + the conditional Clear button in `.right-actions` so the cluster hugs the right edge, matching every other plot's layout.

Also dropped three pre-existing dead `.chip` selectors in `ActivityTableEnhanced` (svelte-check warnings) left behind by PR #204.

## Test plan
- [ ] /tst staging: activity-table reaction column for ⁵¹Mn shows `⁵¹Mn(EC), ⁵¹Mn(β⁺)` (was four entries).
- [ ] /tst staging: activity-table cells like `7.63e-6 Bq` now render as `7.63 µBq`; dose-rate < 1 nSv/h shows `pSv/h`.
- [ ] /tst staging: activity-plot save icon is at the right edge of the toolbar, level with the other controls.
- [ ] Vitest: 41 frontend tests + 72 compute tests all pass (verified locally).
- [ ] `svelte-check`: 0 warnings introduced (1 pre-existing TS error in `BugReportModal.svelte:64` unchanged).