### PR TITLE
perf(plots): denser depth-profile grids for smoother σ/production plots

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -169,9 +169,12 @@ fn compute_layer(
     // Pre-compute the layer's energy grid + stopping power once — shared across all
     // target isotopes (neither depends on the target). Used for integrated production
     // (inside compute_production_rate) and for the depth profile + per-isotope depth
-    // rates. Same linspace size (100) keeps both paths bit-identical.
+    // rates. Same linspace size keeps both paths bit-identical. Linear-in-E sampling
+    // produces uneven depth steps (sparse near beam entry, tight at Bragg peak); 300
+    // pts keeps the visible stair-step well below pixel-scale at typical plot widths.
+    // Proper fix tracked separately — uniform-in-depth grid via dE/dx back-solve.
     let layer_e_low = energy_out.max(0.01);
-    let layer_energies = linspace(layer_e_low, energy_in, 100);
+    let layer_energies = linspace(layer_e_low, energy_in, 300);
     let layer_dedx = dedx_fn(&layer_energies);
 
     // Generate depth profile once (index 0 = beam entry, highest E).
@@ -629,7 +632,7 @@ fn compute_layer_stopping_only(
     // Same energy grid + dE/dx the full path uses, so heat values are
     // bit-identical to the activation path's output.
     let layer_e_low = energy_out.max(0.01);
-    let layer_energies = linspace(layer_e_low, energy_in, 100);
+    let layer_energies = linspace(layer_e_low, energy_in, 300);
     let layer_dedx = dedx_mev_per_cm(db, projectile, &composition, density, &layer_energies)?;
 
     let depth_raw =

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -279,7 +279,11 @@ impl WasmDataStore {
                     }
                 };
 
-                let n_pts = 50;
+                // Linear-in-E sampling → uneven depth steps (sparse near beam
+                // entry, tight at Bragg peak). 200 pts keeps the visible
+                // stair-step below pixel-scale at typical plot widths. Proper
+                // fix (uniform-in-depth grid) tracked separately.
+                let n_pts = 200;
                 let e_min = e_out.max(0.01);
                 let energies: Vec<f64> = (0..n_pts)
                     .map(|i| e_min + (energy_in - e_min) * (i as f64) / ((n_pts - 1) as f64))


### PR DESCRIPTION
## Summary
Production-vs-depth and σ(E(x))-vs-depth plots on /tst showed visible stair-stepping near beam entry. Root cause is on our side: linear-in-energy sampling means dE/dx-driven depth steps cluster at the Bragg peak and starve the high-energy front. Underlying TENDL data is fine — it's our grid.

| Plot | File | Was | Now |
|------|------|-----|-----|
| Theory σ(E(x))-vs-depth (preview) | `wasm/src/lib.rs:282` | `n_pts = 50` | `200` |
| Real production-rate-vs-depth (sim result) | `core/src/compute.rs:174,632` | `linspace(..., 100)` | `linspace(..., 300)` |

This is a **stop-gap**. The proper fix is a uniform-in-depth grid (back-solve energy from a uniform depth axis via dE/dx integration), which eliminates the stair-step regardless of point count. Filed as follow-up issue.

## Conservation invariant
`depth_rate_integrates_to_production_rate` (core/src/production.rs:159) is the drift guard for the depth-rate vs integrated-rate equivalence. Re-ran the full core test suite with the new grid — all 65 tests pass, including this one.

## Test plan
- [ ] /tst staging: σ-vs-depth and production-vs-depth plots look smooth across the full depth axis (no visible stair-step at the high-E end).
- [ ] No regression in WASM preview latency (was ~30 ms, expect ~120 ms — still sub-frame).
- [ ] Cross-checks for full sim runtime unaffected (Bateman dominates).