### PR TITLE
fix(ci): drop macOS .app bundle from attest subject list

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -121,6 +121,26 @@ jobs:
           updaterJsonPreferNsis: true
           args: ${{ matrix.args }}
 
+      # Drop macOS .app bundle paths from the attest subject list. .app is a
+      # *directory* — actions/attest-build-provenance recurses into it and
+      # registers every contained file (Frameworks/, Resources/, _CodeSignature/,
+      # MainBin), easily blowing past the action's 1024-subject cap. The
+      # accompanying .dmg + .tar.gz + .sig already cover the .app contents
+      # transitively, so we lose nothing by dropping it.
+      - name: Filter artifact paths for attestation
+        id: filter_artifacts
+        if: ${{ steps.tauri_build.outputs.artifactPaths != '' }}
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri_build.outputs.artifactPaths }}
+        run: |
+          filtered=$(printf '%s' "$ARTIFACT_PATHS" | jq -c 'map(select(endswith(".app") | not))')
+          {
+            echo "paths<<EOF"
+            echo "$filtered"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       # Build provenance attestation (Sigstore-keyless via GitHub OIDC).
       # Separate trust layer from the minisign updater signature: the
       # attestation proves "this binary came from this exact workflow run
@@ -131,4 +151,4 @@ jobs:
         if: ${{ steps.tauri_build.outputs.artifactPaths != '' }}
         uses: actions/attest-build-provenance@v4
         with:
-          subject-path: ${{ steps.tauri_build.outputs.artifactPaths }}
+          subject-path: ${{ steps.filter_artifacts.outputs.paths }}


### PR DESCRIPTION
## Problem
After the TAURI_SIGNING_PRIVATE_KEY secret was rotated, the desktop-build matrix on \`a794d0c\` got further but both macOS targets failed in \`Attest build provenance\`:

\`\`\`
Error: Too many subjects specified (>1024). The maximum number of subjects is 1024.
\`\`\`

(Windows + Linux passed cleanly.)

## Root cause
\`actions/attest-build-provenance@v4\` recursively walks any **directory** passed in \`subject-path\`. The \`tauri-action\` \`artifactPaths\` output includes the macOS \`.app\` bundle, and a Tauri \`.app\` is a directory — Frameworks/, Resources/, _CodeSignature/, the main binary — that easily blows past the action's hardcoded 1024-subject cap.

## Fix
Added a small filter step between \`tauri_build\` and \`attest-build-provenance\` that drops entries ending in \`.app\` from the JSON array. The \`.dmg\` and \`.tar.gz\` + \`.sig\` pair are still attested and contain the \`.app\` contents transitively, so we lose nothing.

## Test plan
- [x] Diagnosed against tauri-build run [25768982862](https://github.com/exoma-ch/hyrr/actions/runs/25768982862) — Windows + Linux passed there, macOS failed in attest step only (build itself succeeded).
- [ ] Re-dispatch \`tauri-build.yml --ref main\` after this lands; all four targets should publish + attest.

## Refs
- Workflow run that surfaced the bug: 25768982862
- TAURI_SIGNING_PRIVATE_KEY secret rotation (separate issue, already fixed)