### PR TITLE
fix(ci): trigger staging deploy on wasm/core changes too

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -8,8 +8,17 @@ name: Deploy frontend (staging slot)
 on:
   push:
     branches: [main]
+    # WASM is built from wasm/** linking core/**, then bundled into
+    # frontend/dist — so a core or wasm change is functionally a
+    # frontend change for the deployed /tst bundle. Without these
+    # paths a wasm-only PR (e.g. depth-grid bump) merges to main but
+    # never reaches staging. Cargo.lock is here because dependency
+    # bumps can affect WASM size/behavior even without source changes.
     paths:
       - "frontend/**"
+      - "wasm/**"
+      - "core/**"
+      - "Cargo.lock"
       - ".github/workflows/deploy-frontend.yml"
   workflow_dispatch:
 


### PR DESCRIPTION
## Problem
\`deploy-frontend.yml\` only triggered on \`frontend/**\` and \`.github/workflows/deploy-frontend.yml\`. But the deployed bundle includes WASM built from \`wasm/**\` (linking \`core/**\`), so a wasm-only PR is functionally a frontend change for /tst — it just doesn't look like one to the path filter.

This bit us on PR #206 (the depth-grid bump): merged to main as \`59fe66f\` but /tst stayed on \`a794d0c\` until I manually \`workflow_dispatch\`ed the deploy. Verified by reading Plotly trace lengths from the deployed page — they only updated after the manual dispatch.

## Fix
Added \`wasm/**\`, \`core/**\`, and \`Cargo.lock\` to the path filter:

\`\`\`yaml
paths:
  - "frontend/**"
  - "wasm/**"
  - "core/**"
  - "Cargo.lock"
  - ".github/workflows/deploy-frontend.yml"
\`\`\`

\`Cargo.lock\` is in because dependency bumps can affect WASM size/behavior even without source-file changes.

## Test plan
- [ ] Land. Verify next wasm-touching merge auto-triggers staging deploy without manual dispatch.