### PR TITLE
fix(compute): graceful zero-production for beam-stopped-upstream layers (#211)

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -93,6 +93,26 @@ fn compute_layer(
     enable_chains: bool,
     current_profile: Option<&CurrentProfile>,
 ) -> Result<LayerResult, StoppingError> {
+    // Beam already stopped upstream — emit a zero-production layer instead of
+    // querying dE/dx at 0 MeV (which trips EnergyOutOfRange under the table_min
+    // floor). Mirrors the depth-preview behavior so the user sees the stack as
+    // configured, with the deposited-here layers cleanly empty. See #211.
+    if energy_in <= 0.0 {
+        layer.computed_energy_in = 0.0;
+        layer.computed_energy_out = 0.0;
+        layer.computed_thickness = layer.thickness_cm.unwrap_or(0.0);
+        return Ok(LayerResult {
+            energy_in: 0.0,
+            energy_out: 0.0,
+            delta_e_mev: 0.0,
+            heat_kw: 0.0,
+            depth_profile: Vec::new(),
+            isotope_results: HashMap::new(),
+            stopping_power_sources: HashMap::new(),
+            depth_production_rates: HashMap::new(),
+        });
+    }
+
     let composition = layer_composition(layer);
     let density = layer.density_g_cm3;
 
@@ -602,6 +622,23 @@ fn compute_layer_stopping_only(
     energy_in: f64,
     area: f64,
 ) -> Result<LayerResult, StoppingError> {
+    // Beam already stopped upstream — see [`compute_layer`] for rationale (#211).
+    if energy_in <= 0.0 {
+        layer.computed_energy_in = 0.0;
+        layer.computed_energy_out = 0.0;
+        layer.computed_thickness = layer.thickness_cm.unwrap_or(0.0);
+        return Ok(LayerResult {
+            energy_in: 0.0,
+            energy_out: 0.0,
+            delta_e_mev: 0.0,
+            heat_kw: 0.0,
+            depth_profile: Vec::new(),
+            isotope_results: HashMap::new(),
+            stopping_power_sources: HashMap::new(),
+            depth_production_rates: HashMap::new(),
+        });
+    }
+
     let composition = layer_composition(layer);
     let density = layer.density_g_cm3;
 

--- a/core/tests/projectile_matrix.rs
+++ b/core/tests/projectile_matrix.rs
@@ -197,3 +197,62 @@ fn thick_target_residual_below_table_min_returns_typed_error_not_panic() {
         Ok(_) => panic!("expected EnergyOutOfRange for thick C-12 stack, got Ok"),
     }
 }
+
+/// Regression for #211. A stack of `[Ti(thin), Al(o=1MeV degrader), Ti, Al]`
+/// at 18 MeV protons stops the beam in the third (Ti) layer. The fourth
+/// layer (Al, t=0.01 cm) then enters compute_layer with `energy_in = 0`,
+/// which used to query dE/dx at 0 MeV and surface as a fatal
+/// `EnergyOutOfRange`. Beam already stopped is not a *compute* error — the
+/// downstream layers must come back as empty-but-valid LayerResults.
+#[test]
+#[ignore = "requires bundled nucl-parquet data; run with --include-ignored after submodule init"]
+fn beam_stopped_upstream_yields_empty_downstream_layers_not_error() {
+    let Some(mut db) = make_db("tendl-2025") else {
+        eprintln!("skipping: no nucl-parquet data dir found");
+        return;
+    };
+    let _ = db.load_xs("p", 22); // Ti
+    let _ = db.load_xs("p", 13); // Al
+
+    let ti = resolve_material(&db, "Ti", None);
+    let al = resolve_material(&db, "Al", None);
+
+    let mk = |elems: &Vec<(Element, f64)>, dens: f64, t: Option<f64>, eo: Option<f64>| -> Layer {
+        Layer {
+            density_g_cm3: dens,
+            elements: elems.clone(),
+            thickness_cm: t,
+            areal_density_g_cm2: None,
+            energy_out_mev: eo,
+            is_monitor: false,
+            computed_energy_in: 0.0,
+            computed_energy_out: 0.0,
+            computed_thickness: 0.0,
+        }
+    };
+
+    let mut stack = TargetStack {
+        beam: Beam::new(ProjectileType::Proton, 18.0, 0.01),
+        layers: vec![
+            mk(&ti.elements, ti.density, Some(0.0025), None),
+            mk(&al.elements, al.density, None, Some(1.0)),
+            mk(&ti.elements, ti.density, Some(0.04), None),
+            mk(&al.elements, al.density, Some(0.01), None),
+        ],
+        irradiation_time_s: 3600.0,
+        cooling_time_s: 28800.0,
+        area_cm2: 1.0,
+        current_profile: None,
+    };
+
+    let result = compute_stack(&db, &mut stack, true)
+        .expect("beam-stopped-upstream must return Ok, not a fatal StoppingError");
+
+    assert_eq!(result.layer_results.len(), 4);
+    // Last layer received energy_in = 0 → must be a valid empty layer.
+    let last = result.layer_results.last().unwrap();
+    assert_eq!(last.energy_in, 0.0);
+    assert_eq!(last.energy_out, 0.0);
+    assert!(last.isotope_results.is_empty(), "stopped layer must produce nothing");
+    assert!(last.depth_profile.is_empty(), "stopped layer has no depth profile");
+}

--- a/frontend/src/lib/components/bug-report-body.test.ts
+++ b/frontend/src/lib/components/bug-report-body.test.ts
@@ -72,4 +72,26 @@ describe("buildBugReportBody (#143)", () => {
     );
     expect(body).toMatch(/\*\*Compute error:\*\*.*StoppingError|object Object/);
   });
+
+  it("renders a Map error as JSON instead of '[object Map]' (#211)", () => {
+    const errMap = new Map<unknown, unknown>([
+      ["kind", "StoppingError"],
+      ["variant", "EnergyOutOfRange"],
+      ["message", "Energy 0 MeV outside PSTAR range"],
+    ]);
+    const body = buildBugReportBody(baseInput({ computeError: errMap }));
+    expect(body).not.toContain("[object Map]");
+    expect(body).toContain("Energy 0 MeV outside PSTAR range");
+  });
+
+  it("renders a structured object error using its message field", () => {
+    const errObj = {
+      kind: "StoppingError",
+      variant: "EnergyOutOfRange",
+      message: "Energy 0 MeV outside PSTAR range",
+    };
+    const body = buildBugReportBody(baseInput({ computeError: errObj }));
+    expect(body).not.toContain("[object Object]");
+    expect(body).toContain("Energy 0 MeV outside PSTAR range");
+  });
 });

--- a/frontend/src/lib/components/bug-report-body.ts
+++ b/frontend/src/lib/components/bug-report-body.ts
@@ -28,6 +28,31 @@ export interface BugReportBodyInput {
   now?: Date;
 }
 
+/**
+ * Stringify a raw compute error for the bug-report body. The WASM backend
+ * historically returned `serde_wasm_bindgen` Map values (pre-#211) and Tauri
+ * returns JSON strings — both should render as legible JSON, never the bare
+ * `[object Map]` / `[object Object]` placeholders that #211 was filed about.
+ */
+function formatComputeError(err: unknown): string {
+  if (err == null) return "";
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return String(err);
+  if (err instanceof Map) {
+    return JSON.stringify(Object.fromEntries(err as Map<unknown, unknown>));
+  }
+  if (typeof err === "object") {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === "string" && message) return message;
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return Object.prototype.toString.call(err);
+    }
+  }
+  return String(err);
+}
+
 export function buildBugReportBody(input: BugReportBodyInput): string {
   const sections: string[] = [];
 
@@ -62,7 +87,7 @@ export function buildBugReportBody(input: BugReportBodyInput): string {
   }
 
   if (input.computeError != null) {
-    sections.push(`**Compute error:** ${String(input.computeError)}`);
+    sections.push(`**Compute error:** ${formatComputeError(input.computeError)}`);
   }
 
   sections.push(`**Version:** ${input.appVersion}`);

--- a/frontend/src/lib/compute/parse-error.test.ts
+++ b/frontend/src/lib/compute/parse-error.test.ts
@@ -90,4 +90,24 @@ describe("parseComputeError", () => {
     const result = parseComputeError({ foo: "bar" });
     expect(result.kind).toBe("Unknown");
   });
+
+  it("handles legacy Map errors from serde_wasm_bindgen (#211)", () => {
+    const errMap = new Map<unknown, unknown>([
+      ["kind", "StoppingError"],
+      ["variant", "EnergyOutOfRange"],
+      ["source", "PSTAR"],
+      ["target_symbol", "Al"],
+      ["target_z", 13],
+      ["energy_mev", 0.0],
+      ["min_mev", 0.001],
+      ["max_mev", 10000],
+      ["message", "Energy 0 MeV outside PSTAR range for Al"],
+    ]);
+    const result = parseComputeError(errMap);
+    expect(result.kind).toBe("StoppingError");
+    if (result.kind === "StoppingError") {
+      expect(result.variant).toBe("EnergyOutOfRange");
+      expect(result.message).toContain("PSTAR range");
+    }
+  });
 });

--- a/frontend/src/lib/compute/parse-error.ts
+++ b/frontend/src/lib/compute/parse-error.ts
@@ -13,6 +13,17 @@
 import type { ComputeError } from "../types";
 
 export function parseComputeError(raw: unknown): ComputeError {
+  // Older WASM builds returned `serde_wasm_bindgen` `Map`s instead of plain
+  // objects — fixed in #211 by configuring `.serialize_maps_as_objects(true)`,
+  // but kept here so a cached old build / Tauri returning a Map still parses
+  // cleanly.
+  if (raw instanceof Map) {
+    const obj: Record<string, unknown> = {};
+    for (const [k, v] of raw as Map<unknown, unknown>) {
+      if (typeof k === "string") obj[k] = v;
+    }
+    raw = obj;
+  }
   const structured = tryStructured(raw);
   if (structured) return structured;
 

--- a/frontend/src/lib/utils/threshold-format.test.ts
+++ b/frontend/src/lib/utils/threshold-format.test.ts
@@ -111,9 +111,14 @@ describe("formatWithThreshold — exceptional values", () => {
     }
   });
 
-  it("treats exact zero as below threshold (collapses / indicates)", () => {
-    expect(formatWithThresholdEx(0, "activity", "indicator", T).clamped).toBe(true);
-    expect(formatWithThresholdEx(0, "activity", "zero", T).text).toBe("0");
+  it("renders true zero as '0' in every mode and never marks it clamped (#205)", () => {
+    // Mode-dependent rendering is reserved for *sub-threshold non-zero* values
+    // — exact zero is unambiguous and must not be hidden behind a `<X` chip.
+    for (const m of ["all", "indicator", "zero"] as const) {
+      const r = formatWithThresholdEx(0, "activity", m, T);
+      expect(r.text).toBe("0");
+      expect(r.clamped).toBe(false);
+    }
   });
 });
 

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -209,6 +209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +320,7 @@ name = "hyrr-core"
 version = "0.1.0"
 dependencies = [
  "fs2",
+ "home",
  "regex",
  "reqwest",
  "serde",

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -604,11 +604,17 @@ struct MaterialElementJson {
 /// `parseComputeError` helper can deserialize. Keeps the variant tag, payload
 /// fields, and a `message` string for display fallback.
 fn stopping_error_to_jsvalue(err: StoppingError) -> JsValue {
+    use serde::Serialize;
     let mut value = err.as_json();
     if let Some(obj) = value.as_object_mut() {
         obj.insert("message".to_string(), serde_json::Value::String(err.to_string()));
     }
-    match serde_wasm_bindgen::to_value(&value) {
+    // `serde_wasm_bindgen::to_value` defaults to converting JSON objects into
+    // JS `Map`s, which the frontend's `parseComputeError` can't introspect via
+    // `obj.kind`. Force plain-object serialization so the structured error is
+    // legible end-to-end (#211).
+    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    match value.serialize(&serializer) {
         Ok(js) => js,
         Err(_) => JsValue::from_str(&err.to_string()),
     }


### PR DESCRIPTION
## Summary

Fixes #211. Stack `Ti / Al(o=1 MeV) / Ti / Al` at 18 MeV p let the beam
stop inside layer 3 (Ti, 0.04 cm) and layer 4 (Al, 0.01 cm) then entered
`compute_layer` with `energy_in = 0`, tripping `EnergyOutOfRange` at the
PSTAR table floor. The user saw a UI with no result and the literal
string `[object Map]` in the bug-report body.

Three independent bugs, all addressed:

1. **core/src/compute.rs** — `compute_layer` and `compute_layer_stopping_only`
   short-circuit when `energy_in <= 0` and return a zero-production
   `LayerResult` (no isotopes, empty depth profile) so the rest of the
   stack still renders. The beam-stopped condition is physics, not a
   compute error.
2. **wasm/src/lib.rs** — `serde_wasm_bindgen::to_value` was defaulting
   to JS `Map` for the structured `StoppingError` payload, so
   `parseComputeError` could not read `.kind` and fell through to
   `Unknown`. Force `Serializer::new().serialize_maps_as_objects(true)`.
3. **frontend/src/lib/components/bug-report-body.ts** — `String(map)`
   returned `"[object Map]"`. New `formatComputeError` helper handles
   `Error`, `Map`, and `{message}` shapes; `parseComputeError` also
   accepts legacy `Map`s for cached old WASM builds.

Pre-existing failing `threshold-format` test (asserted old behavior
where exact 0 collapsed to `<X`) updated to match the #205 contract:
true zero is always `"0"`, never clamped.

## Test plan
- [x] `cargo test --test projectile_matrix -- --include-ignored` — new
      regression `beam_stopped_upstream_yields_empty_downstream_layers_not_error`
      reproduces the issue-#211 stack end-to-end. Passes.
- [x] `cargo test --lib` — 66 passed.
- [x] `npx vitest run` — 537/537 passed (was 536/537 on main).
- [x] Verify on `/tst` after deploy that the issue-#211 share URL
      renders a stack with the trailing Al layer at zero energy and no
      `[object Map]` recovery card.

Refs: #211