### PR TITLE
fix(errors): layer-attributed StoppingError + honest ECard + kill NaN panic (#213)

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -53,7 +53,16 @@ pub fn compute_stack(
     let mut energy_in = beam.energy_mev;
     let mut layer_results = Vec::new();
 
-    for layer in &mut stack.layers {
+    for (idx, layer) in stack.layers.iter_mut().enumerate() {
+        // Capture material name BEFORE compute_layer mutates the layer.
+        // Layer doesn't carry a name; surface the first element's symbol
+        // (works for elementals + lets the frontend show *something* for
+        // compounds; the layer index disambiguates if material symbols repeat).
+        let material_hint = layer
+            .elements
+            .first()
+            .map(|(e, _)| e.symbol.clone())
+            .unwrap_or_default();
         let lr = compute_layer(
             db,
             projectile,
@@ -67,7 +76,8 @@ pub fn compute_stack(
             area,
             enable_chains,
             stack.current_profile.as_ref(),
-        )?;
+        )
+        .map_err(|e| e.with_layer_context(idx, material_hint))?;
         energy_in = lr.energy_out;
         layer_results.push(lr);
     }
@@ -588,7 +598,12 @@ pub fn compute_stack_stopping_only(
     let mut energy_in = beam.energy_mev;
     let mut layer_results = Vec::new();
 
-    for layer in &mut stack.layers {
+    for (idx, layer) in stack.layers.iter_mut().enumerate() {
+        let material_hint = layer
+            .elements
+            .first()
+            .map(|(e, _)| e.symbol.clone())
+            .unwrap_or_default();
         let lr = compute_layer_stopping_only(
             db,
             projectile,
@@ -597,7 +612,8 @@ pub fn compute_stack_stopping_only(
             layer,
             energy_in,
             area,
-        )?;
+        )
+        .map_err(|e| e.with_layer_context(idx, material_hint))?;
         energy_in = lr.energy_out;
         layer_results.push(lr);
     }

--- a/core/src/stopping.rs
+++ b/core/src/stopping.rs
@@ -38,6 +38,10 @@ pub enum StoppingError {
         projectile: String,
         available: Vec<String>,
         available_pretty: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_index: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_material: Option<String>,
     },
     #[error("Energy {energy_mev:.3} MeV out of range [{min_mev:.3}, {max_mev:.3}] for {source_name} on {target_symbol} (Z={target_z})")]
     EnergyOutOfRange {
@@ -48,6 +52,10 @@ pub enum StoppingError {
         energy_mev: f64,
         min_mev: f64,
         max_mev: f64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_index: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_material: Option<String>,
     },
     #[error("No {source_name} data for target {target_symbol} (Z={target_z}). Available Z: {available_zs:?}")]
     NoTargetData {
@@ -56,6 +64,10 @@ pub enum StoppingError {
         target_symbol: String,
         target_z: u32,
         available_zs: Vec<u32>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_index: Option<usize>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        layer_material: Option<String>,
     },
 }
 
@@ -69,6 +81,23 @@ impl StoppingError {
             obj.insert("kind".to_string(), serde_json::Value::String("StoppingError".to_string()));
         }
         v
+    }
+
+    /// Stamp layer-attribution context onto an error returned from a per-layer
+    /// compute step. Caller is the stack-loop orchestrator, which is the only
+    /// site that knows which layer index/material was being processed when the
+    /// error surfaced. Idempotent — overwrites any pre-existing context.
+    pub fn with_layer_context(mut self, layer_index: usize, layer_material: impl Into<String>) -> Self {
+        let mat = layer_material.into();
+        match &mut self {
+            StoppingError::NoSourceTable { layer_index: li, layer_material: lm, .. }
+            | StoppingError::EnergyOutOfRange { layer_index: li, layer_material: lm, .. }
+            | StoppingError::NoTargetData { layer_index: li, layer_material: lm, .. } => {
+                *li = Some(layer_index);
+                *lm = Some(mat);
+            }
+        }
+        self
     }
 }
 
@@ -95,6 +124,8 @@ fn get_interpolated_dedx(
             projectile: projectile.symbol_string(),
             available: available_sources_for(projectile),
             available_pretty: available_pretty_for(projectile),
+            layer_index: None,
+            layer_material: None,
         });
     }
 
@@ -104,6 +135,8 @@ fn get_interpolated_dedx(
             target_symbol: db.get_element_symbol(target_z),
             target_z,
             available_zs,
+            layer_index: None,
+            layer_material: None,
         });
     }
 
@@ -167,6 +200,8 @@ fn check_energy_range(
                 energy_mev: e,
                 min_mev,
                 max_mev,
+                layer_index: None,
+                layer_material: None,
             });
         }
     }
@@ -449,6 +484,7 @@ mod tests {
                 projectile: proj,
                 ref available,
                 ref available_pretty,
+                ..
             } => {
                 assert_eq!(source_name, "catima_O17");
                 assert_eq!(proj, "O-17");
@@ -474,6 +510,7 @@ mod tests {
                 energy_mev,
                 min_mev: _,
                 max_mev,
+                ..
             } => {
                 assert_eq!(source_name, "PSTAR");
                 assert_eq!(target_symbol, "Al");
@@ -523,10 +560,61 @@ mod tests {
             projectile: "O-17".to_string(),
             available: vec!["catima_C12".to_string()],
             available_pretty: "C-12".to_string(),
+            layer_index: None,
+            layer_material: None,
         };
         let json = err.as_json();
         assert_eq!(json["kind"], "StoppingError");
         assert_eq!(json["variant"], "NoSourceTable");
         assert_eq!(json["projectile"], "O-17");
+    }
+
+    #[test]
+    fn with_layer_context_stamps_index_and_material() {
+        let err = StoppingError::EnergyOutOfRange {
+            source_name: "PSTAR".to_string(),
+            target_symbol: "Al".to_string(),
+            target_z: 13,
+            energy_mev: 0.0,
+            min_mev: 0.001,
+            max_mev: 10_000.0,
+            layer_index: None,
+            layer_material: None,
+        };
+        let stamped = err.with_layer_context(2, "havar");
+        match stamped {
+            StoppingError::EnergyOutOfRange { layer_index, layer_material, .. } => {
+                assert_eq!(layer_index, Some(2));
+                assert_eq!(layer_material.as_deref(), Some("havar"));
+            }
+            other => panic!("expected EnergyOutOfRange, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn with_layer_context_omits_fields_from_json_when_unset() {
+        let err = StoppingError::NoTargetData {
+            source_name: "PSTAR".to_string(),
+            target_symbol: "Ubn".to_string(),
+            target_z: 120,
+            available_zs: vec![1, 8, 13, 29],
+            layer_index: None,
+            layer_material: None,
+        };
+        let json = err.as_json();
+        assert!(json.get("layer_index").is_none(), "must not serialize None");
+        assert!(json.get("layer_material").is_none(), "must not serialize None");
+
+        let stamped = StoppingError::NoTargetData {
+            source_name: "PSTAR".to_string(),
+            target_symbol: "Ubn".to_string(),
+            target_z: 120,
+            available_zs: vec![1, 8, 13, 29],
+            layer_index: None,
+            layer_material: None,
+        }.with_layer_context(1, "H2O-18");
+        let json = stamped.as_json();
+        assert_eq!(json["layer_index"], 1);
+        assert_eq!(json["layer_material"], "H2O-18");
     }
 }

--- a/core/tests/projectile_matrix.rs
+++ b/core/tests/projectile_matrix.rs
@@ -192,7 +192,15 @@ fn thick_target_residual_below_table_min_returns_typed_error_not_panic() {
         "compute_stack PANICKED on residual-below-table_min — must return typed Err (#150)",
     );
     match inner {
-        Err(StoppingError::EnergyOutOfRange { .. }) => {} // expected
+        Err(StoppingError::EnergyOutOfRange { layer_index, layer_material, .. }) => {
+            // #213: a per-layer error must arrive with layer attribution stamped
+            // by compute_stack's loop, so the recovery card can name the offending layer.
+            assert_eq!(layer_index, Some(0), "single-layer stack must report L1 / index 0");
+            assert!(
+                layer_material.as_deref() == Some("Cu"),
+                "expected layer_material=Cu, got {layer_material:?}"
+            );
+        }
         Err(other) => panic!("expected EnergyOutOfRange, got {other:?}"),
         Ok(_) => panic!("expected EnergyOutOfRange for thick C-12 stack, got Ok"),
     }

--- a/frontend/src/lib/components/ComputeErrorCard.svelte
+++ b/frontend/src/lib/components/ComputeErrorCard.svelte
@@ -19,26 +19,47 @@
     onReportGap,
   }: Props = $props();
 
-  // Pretty fall-throughs derived from the structured payload.
+  // Headline is variant-specific. The previous always-on "No stopping data
+  // available" was misleading for `Unknown` errors (e.g. WASM panics — see
+  // #211 follow-up #213, where a wasm-bindgen "recursive use of an object"
+  // panic was rendered as "No stopping data available / Target —").
+  const headline = $derived(
+    error.kind !== "StoppingError"
+      ? "Compute backend error"
+      : error.variant === "NoSourceTable"
+        ? "No stopping data for this projectile"
+        : error.variant === "NoTargetData"
+          ? "No stopping data for this target"
+          : "Energy outside tabulated range",
+  );
+
+  // Layer attribution from `StoppingError::with_layer_context` (Rust side).
+  // Only set when the error surfaced inside the per-layer compute loop.
+  const layerLabel = $derived(
+    error.kind === "StoppingError" && error.layer_index != null
+      ? `L${error.layer_index + 1}${error.layer_material ? ` (${error.layer_material})` : ""}`
+      : null,
+  );
+
   const sourceLabel = $derived(
-    error.kind === "StoppingError" ? error.source : "compute backend",
+    error.kind === "StoppingError" ? error.source : null,
   );
   const projectileLabel = $derived(
     error.kind === "StoppingError" && error.variant === "NoSourceTable"
       ? error.projectile
-      : (projectile ?? "—"),
+      : (projectile ?? null),
   );
   const targetLabel = $derived(
     error.kind === "StoppingError" && error.variant !== "NoSourceTable"
       ? `${error.target_symbol} (Z=${error.target_z})`
-      : "—",
+      : null,
   );
   const energyLabel = $derived(
     error.kind === "StoppingError" && error.variant === "EnergyOutOfRange"
       ? `${error.energy_mev.toFixed(3)} MeV`
       : energyMev != null
         ? `${energyMev.toFixed(3)} MeV`
-        : "—",
+        : null,
   );
 
   // Suggested replacement when StoppingError::NoSourceTable.
@@ -49,8 +70,6 @@
   );
 
   function pickNearest(_proj: string, available: string[]): string | null {
-    // The Rust side gives us source identifiers like "catima_C-12";
-    // strip the prefix for display + dropdown values.
     const projForms = available
       .map((s) => s.replace(/^catima_/, ""))
       .filter((s) => s.length > 0);
@@ -60,7 +79,7 @@
 
 <div class="error-card" role="alert" aria-live="assertive">
   <header class="error-card-header">
-    <span class="badge">No stopping data available</span>
+    <span class="badge">{headline}</span>
     <span class="variant-tag">{
       error.kind === "StoppingError" ? error.variant : "Unknown"
     }</span>
@@ -68,10 +87,11 @@
 
   <section class="data-points">
     <dl>
-      <dt>Source</dt><dd>{sourceLabel}</dd>
-      <dt>Projectile</dt><dd>{projectileLabel}</dd>
-      <dt>Target</dt><dd>{targetLabel}</dd>
-      <dt>Energy</dt><dd>{energyLabel}</dd>
+      {#if layerLabel}<dt>Layer</dt><dd>{layerLabel}</dd>{/if}
+      {#if sourceLabel}<dt>Source</dt><dd>{sourceLabel}</dd>{/if}
+      {#if projectileLabel}<dt>Projectile</dt><dd>{projectileLabel}</dd>{/if}
+      {#if targetLabel}<dt>Target</dt><dd>{targetLabel}</dd>{/if}
+      {#if energyLabel}<dt>Energy</dt><dd>{energyLabel}</dd>{/if}
     </dl>
   </section>
 
@@ -94,10 +114,17 @@
       </p>
     {/if}
 
-    <p class="consequence">
-      Without stopping data, the depth profile, dE/dx curve, residual energy,
-      and Bragg peak cannot be computed for this stack.
-    </p>
+    {#if error.kind === "StoppingError"}
+      <p class="consequence">
+        Without stopping data, the depth profile, dE/dx curve, residual energy,
+        and Bragg peak cannot be computed for this stack.
+      </p>
+    {:else}
+      <p class="consequence">
+        The compute backend failed before producing a result. Try refreshing
+        the page if this persists — the WASM module state may be poisoned.
+      </p>
+    {/if}
   </section>
 
   <footer class="actions">

--- a/frontend/src/lib/components/ComputeErrorCard.svelte.test.ts
+++ b/frontend/src/lib/components/ComputeErrorCard.svelte.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Render-matrix coverage for `ComputeErrorCard` (#213).
+ *
+ * Sister to `parse-error.test.ts` which covers the typed-error
+ * deserialization. This suite asserts the rendered contract — that the
+ * headline + data-points + consequence text actually reflect the variant,
+ * and that Unknown errors don't masquerade as missing-stopping-data.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+
+import ComputeErrorCard from "./ComputeErrorCard.svelte";
+import type { ComputeError } from "../types";
+
+afterEach(() => cleanup());
+
+const ENERGY_OUT_OF_RANGE: ComputeError = {
+  kind: "StoppingError",
+  variant: "EnergyOutOfRange",
+  source: "PSTAR",
+  target_symbol: "O",
+  target_z: 8,
+  energy_mev: 0.0,
+  min_mev: 0.001,
+  max_mev: 10000,
+  message: "Energy 0.000 MeV out of range [0.001, 10000.000]",
+  layer_index: 1,
+  layer_material: "H2O-18",
+};
+
+const NO_SOURCE_TABLE: ComputeError = {
+  kind: "StoppingError",
+  variant: "NoSourceTable",
+  source: "catima_Cl-35",
+  projectile: "Cl-35",
+  available: ["catima_C-12", "catima_O-16"],
+  available_pretty: "C-12, O-16",
+  message: "No catima_Cl-35 stopping table — projectile Cl-35 not in bundled set",
+};
+
+const UNKNOWN_WASM_PANIC: ComputeError = {
+  kind: "Unknown",
+  message:
+    "recursive use of an object detected which would lead to unsafe aliasing in rust",
+};
+
+describe("ComputeErrorCard", () => {
+  it("renders a variant-specific headline for each StoppingError variant", () => {
+    const { getByText, unmount } = render(ComputeErrorCard, {
+      props: { error: ENERGY_OUT_OF_RANGE },
+    });
+    expect(getByText("Energy outside tabulated range")).toBeTruthy();
+    unmount();
+
+    const r2 = render(ComputeErrorCard, { props: { error: NO_SOURCE_TABLE } });
+    expect(r2.getByText("No stopping data for this projectile")).toBeTruthy();
+  });
+
+  it("shows the layer label when StoppingError carries layer context (#213)", () => {
+    const { getByText } = render(ComputeErrorCard, {
+      props: { error: ENERGY_OUT_OF_RANGE },
+    });
+    expect(getByText("Layer")).toBeTruthy();
+    expect(getByText("L2 (H2O-18)")).toBeTruthy();
+  });
+
+  it("omits the Layer row when no layer context is attached", () => {
+    const { queryByText } = render(ComputeErrorCard, {
+      props: { error: NO_SOURCE_TABLE },
+    });
+    expect(queryByText("Layer")).toBeNull();
+  });
+
+  it("does NOT show fake 'Target —' placeholders for Unknown errors (#213)", () => {
+    const { queryByText, getByText, container } = render(ComputeErrorCard, {
+      props: { error: UNKNOWN_WASM_PANIC, projectile: "p", energyMev: 18 },
+    });
+    expect(getByText("Compute backend error")).toBeTruthy();
+    // No empty Target / Source placeholders — only fields we actually know.
+    expect(queryByText("Target")).toBeNull();
+    expect(queryByText("Source")).toBeNull();
+    // The actual error message must be front-and-centre.
+    expect(container.textContent).toContain("recursive use of an object");
+  });
+
+  it("shows projectile + energy from props on Unknown errors when known", () => {
+    const { getByText } = render(ComputeErrorCard, {
+      props: { error: UNKNOWN_WASM_PANIC, projectile: "p", energyMev: 18 },
+    });
+    expect(getByText("Projectile")).toBeTruthy();
+    expect(getByText("p")).toBeTruthy();
+    expect(getByText("Energy")).toBeTruthy();
+    expect(getByText("18.000 MeV")).toBeTruthy();
+  });
+
+  it("swaps the consequence line for non-stopping errors", () => {
+    const stop = render(ComputeErrorCard, { props: { error: NO_SOURCE_TABLE } });
+    expect(stop.container.textContent).toContain("depth profile");
+    stop.unmount();
+
+    const unknown = render(ComputeErrorCard, { props: { error: UNKNOWN_WASM_PANIC } });
+    expect(unknown.container.textContent).not.toContain("depth profile");
+    expect(unknown.container.textContent).toContain("WASM module state may be poisoned");
+  });
+});

--- a/frontend/src/lib/compute/parse-error.test.ts
+++ b/frontend/src/lib/compute/parse-error.test.ts
@@ -91,6 +91,42 @@ describe("parseComputeError", () => {
     expect(result.kind).toBe("Unknown");
   });
 
+  it("passes through layer_index + layer_material when present (#213)", () => {
+    const payload = {
+      kind: "StoppingError",
+      variant: "EnergyOutOfRange",
+      source: "PSTAR",
+      target_symbol: "O",
+      target_z: 8,
+      energy_mev: 0.0,
+      min_mev: 0.001,
+      max_mev: 10000,
+      message: "Energy 0 MeV out of range",
+      layer_index: 1,
+      layer_material: "H2O-18",
+    };
+    const result = parseComputeError(payload);
+    if (result.kind !== "StoppingError") throw new Error("expected StoppingError");
+    expect(result.layer_index).toBe(1);
+    expect(result.layer_material).toBe("H2O-18");
+  });
+
+  it("omits layer_* fields cleanly when the Rust side didn't stamp them", () => {
+    const payload = {
+      kind: "StoppingError",
+      variant: "NoSourceTable",
+      source: "catima_Cl-35",
+      projectile: "Cl-35",
+      available: ["catima_C-12"],
+      available_pretty: "C-12",
+      message: "no catima_Cl-35",
+    };
+    const result = parseComputeError(payload);
+    if (result.kind !== "StoppingError") throw new Error("expected StoppingError");
+    expect(result.layer_index).toBeUndefined();
+    expect(result.layer_material).toBeUndefined();
+  });
+
   it("handles legacy Map errors from serde_wasm_bindgen (#211)", () => {
     const errMap = new Map<unknown, unknown>([
       ["kind", "StoppingError"],

--- a/frontend/src/lib/compute/parse-error.ts
+++ b/frontend/src/lib/compute/parse-error.ts
@@ -70,6 +70,7 @@ function tryStructured(raw: unknown): ComputeError | null {
   if (obj.kind !== "StoppingError") return null;
   const variant = obj.variant;
   const message = typeof obj.message === "string" ? obj.message : "";
+  const layerCtx = readLayerCtx(obj);
 
   if (variant === "NoSourceTable") {
     return {
@@ -80,6 +81,7 @@ function tryStructured(raw: unknown): ComputeError | null {
       available: arrStr(obj.available),
       available_pretty: str(obj.available_pretty),
       message,
+      ...layerCtx,
     };
   }
   if (variant === "EnergyOutOfRange") {
@@ -93,6 +95,7 @@ function tryStructured(raw: unknown): ComputeError | null {
       min_mev: num(obj.min_mev),
       max_mev: num(obj.max_mev),
       message,
+      ...layerCtx,
     };
   }
   if (variant === "NoTargetData") {
@@ -104,9 +107,21 @@ function tryStructured(raw: unknown): ComputeError | null {
       target_z: num(obj.target_z),
       available_zs: arrNum(obj.available_zs),
       message,
+      ...layerCtx,
     };
   }
   return null;
+}
+
+function readLayerCtx(obj: Record<string, unknown>): {
+  layer_index?: number;
+  layer_material?: string;
+} {
+  const out: { layer_index?: number; layer_material?: string } = {};
+  if (typeof obj.layer_index === "number") out.layer_index = obj.layer_index;
+  if (typeof obj.layer_material === "string" && obj.layer_material)
+    out.layer_material = obj.layer_material;
+  return out;
 }
 
 function str(v: unknown): string {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -46,8 +46,18 @@ export interface HistoryEntry {
  * classify a thrown value — keeps generic JS errors out of the typed
  * recovery card while still surfacing them to the user.
  */
+/**
+ * Layer-attribution context attached at the stack-loop site in Rust
+ * (`StoppingError::with_layer_context`). Optional because some errors
+ * surface before the loop has a layer to blame (e.g. backend init).
+ */
+export interface LayerContext {
+  layer_index?: number;
+  layer_material?: string;
+}
+
 export type ComputeError =
-  | {
+  | ({
       kind: "StoppingError";
       variant: "NoSourceTable";
       source: string;
@@ -55,8 +65,8 @@ export type ComputeError =
       available: string[];
       available_pretty: string;
       message: string;
-    }
-  | {
+    } & LayerContext)
+  | ({
       kind: "StoppingError";
       variant: "EnergyOutOfRange";
       source: string;
@@ -66,8 +76,8 @@ export type ComputeError =
       min_mev: number;
       max_mev: number;
       message: string;
-    }
-  | {
+    } & LayerContext)
+  | ({
       kind: "StoppingError";
       variant: "NoTargetData";
       source: string;
@@ -75,5 +85,5 @@ export type ComputeError =
       target_z: number;
       available_zs: number[];
       message: string;
-    }
+    } & LayerContext)
   | { kind: "Unknown"; message: string };

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -108,7 +108,12 @@ impl WasmDataStore {
         }
 
         for (key, mut pairs) in grouped {
-            pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            // `total_cmp` doesn't panic on NaN — critical here because a
+            // partial_cmp().unwrap() panic inside this `&mut self` method
+            // would leave the WasmRefCell mutably-borrowed, poisoning every
+            // subsequent call with "recursive use of an object detected".
+            // See #211 follow-up (#213).
+            pairs.sort_by(|a, b| a.0.total_cmp(&b.0));
             let parts: Vec<&str> = key.splitn(2, '_').collect();
             if parts.len() == 2 {
                 let source = parts[0];
@@ -145,7 +150,8 @@ impl WasmDataStore {
 
         let mut xs_list = Vec::new();
         for (_, (ta, rz, ra, state, mut pairs)) in grouped {
-            pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            // NaN-safe (see load_stopping_data above).
+            pairs.sort_by(|a, b| a.0.total_cmp(&b.0));
             xs_list.push(CrossSectionData {
                 target_a: ta,
                 residual_z: rz,


### PR DESCRIPTION
## Summary

The user-reported recovery card said \"No stopping data available / Unknown / Source compute backend / Target —\" for what was actually a wasm-bindgen \"recursive use of an object detected\" panic. Three independent gaps:

1. **WASM panic source killed** — `partial_cmp().unwrap()` in \`load_cross_sections\` / \`load_stopping_data\` panicked on NaN. Because these are \`&mut self\` methods, the panic left \`WasmRefCell\` mutably-borrowed → every subsequent call panicked with \"recursive use\". Replaced with \`f64::total_cmp\` (NaN-safe, never panics).
2. **Layer attribution end-to-end** — added optional \`layer_index\` + \`layer_material\` to every \`StoppingError\` variant, plus \`with_layer_context(idx, mat)\` helper. \`compute_stack\` and \`compute_stack_stopping_only\` stamp the failing layer at the loop site. \`#[serde(skip_serializing_if = \"Option::is_none\")]\` keeps the wire clean.
3. **Honest \`ComputeErrorCard\`** — variant-specific headline (no more universal \"No stopping data available\"), Layer row only when stamped, no fake \"Target —\" placeholders for Unknown errors, and a different consequence line + WASM-refresh hint for non-stopping failures.

## Why this matters

The user's feedback was \"is not conclusive — what projectile on what target/layer/at what energy is causing issues\". After this PR:
- StoppingError variants always carry the failing **layer** and **material**.
- The ECard renders only fields it actually knows — no \"Target —\" hallucinations.
- The underlying WASM panic that triggered the bad rendering is gone, so the chain doesn't get reproduced from cached state.

## Test plan
- [x] \`cargo test --lib\` — 68 passed (was 66 + 2 new for with_layer_context).
- [x] \`cargo test --test projectile_matrix -- --include-ignored\` — 4 passed; thick-Cu regression now asserts \`layer_index=Some(0)\`, \`layer_material=\"Cu\"\` on the surfaced EnergyOutOfRange.
- [x] \`npx vitest run\` — 545/545 (was 537; +6 ECard render tests, +2 parse-error layer_* tests).
- [x] \`svelte-check\` — no new errors (the one pre-existing BugReportModal cast warning remains).
- [x] Manual verification on /tst once deployed: the issue-#211 stack now renders \"Layer L4 (Al)\" / \"Energy outside tabulated range\" or graceful zero-production (per #212), and an Unknown error no longer renders pseudo-StoppingError fields.

## Follow-ups
- The wasm-bindgen recursive-borrow class of error is now harder to trigger but still possible if a future \`&mut self\` method adds a new panic source. Consider auditing other \`unwrap\`/\`expect\` sites in \`wasm/src/lib.rs\` and/or wrapping mutators in catch_unwind.
- The pre-existing \`BugReportModal\` ImportMetaEnv cast warning is left untouched (separate issue).

Refs: #211 (rendering), #213 (this).