### PR TITLE
fix(enrichment): natural-fill partial vectors + guard Apply on invalid sums (#217)

### DIFF
--- a/frontend/src/lib/components/ElementPopup.svelte
+++ b/frontend/src/lib/components/ElementPopup.svelte
@@ -98,14 +98,30 @@
     rows = newRows;
   });
 
-  /** Effective enrichment: use set value or natural abundance for display. */
+  let setSum = $derived(rows.reduce((s, r) => s + (r.enrichment ?? 0), 0));
+  let unsetNatSum = $derived(
+    rows.filter((r) => r.enrichment === null).reduce((s, r) => s + r.naturalAbundance, 0),
+  );
+  let hasUnset = $derived(rows.some((r) => r.enrichment === null));
+
+  /**
+   * Effective composition shown to the user. For unset rows we distribute the
+   * `100 − setSum` remainder proportionally to natural abundance — same
+   * semantics the compute layer applies (see [[hyrr-architecture]] /
+   * normalizeIsotopeVector). This keeps the Effective column summing to 100%
+   * for partial vectors (#217) instead of double-counting natural + custom.
+   */
   function effective(row: IsotopeRow): number {
-    return row.enrichment ?? row.naturalAbundance;
+    if (row.enrichment !== null) return row.enrichment;
+    const remainder = Math.max(0, 100 - setSum);
+    if (unsetNatSum <= 0) return 0;
+    return (row.naturalAbundance / unsetNatSum) * remainder;
   }
 
   let total = $derived(rows.reduce((s, r) => s + effective(r), 0));
-  let setTotal = $derived(rows.reduce((s, r) => s + (r.enrichment ?? 0), 0));
-  let hasUnset = $derived(rows.some((r) => r.enrichment === null));
+
+  /** Valid if the displayed composition sums to 100% and no row overshoots. */
+  let isValid = $derived(setSum <= 100.1 && Math.abs(total - 100) < 0.1);
 
   /**
    * Normalize: set rows fill the remainder to 100% by scaling unset rows
@@ -155,26 +171,30 @@
   }
 
   function apply() {
-    // If all unset (natural), return undefined
+    if (!isValid) return;
+
+    // All unset → natural composition.
     if (rows.every((r) => r.enrichment === null)) {
       onchange(undefined);
       onclose();
       return;
     }
-    // Resolve all values
-    const resolved = rows.map((r) => ({ ...r, enrichment: effective(r) }));
-    const isNatural = resolved.every((r) => Math.abs(r.enrichment - r.naturalAbundance) < 0.01);
-    if (isNatural) {
-      onchange(undefined);
-    } else {
-      const result: Record<number, number> = {};
-      for (const row of resolved) {
-        if (row.enrichment > 0) {
-          result[row.A] = row.enrichment / 100;
-        }
+
+    // Emit only the explicitly-set rows. The compute layer natural-fills the
+    // remainder (see normalizeIsotopeVector in @hyrr/compute materials.ts).
+    // For a fully-specified vector this is just the normalize() result.
+    const result: Record<number, number> = {};
+    for (const row of rows) {
+      if (row.enrichment !== null && row.enrichment > 0) {
+        result[row.A] = row.enrichment / 100;
       }
-      onchange(result);
     }
+
+    // Effective view matches natural within tolerance → no override needed.
+    const isNatural = rows.every(
+      (r) => Math.abs(effective(r) - r.naturalAbundance) < 0.01,
+    );
+    onchange(isNatural ? undefined : result);
     onclose();
   }
 </script>
@@ -229,21 +249,27 @@
     </table>
 
     <div class="summary-row">
-      <span class="total" class:warn={Math.abs(total - 100) > 0.1}>
+      <span class="total" class:warn={!isValid}>
         Total: {total.toFixed(2)}%
-        {#if hasUnset}
-          <span class="total-hint">(unset rows use natural)</span>
+        {#if hasUnset && isValid}
+          <span class="total-hint">(unset rows fill from natural)</span>
         {/if}
       </span>
       <div class="actions">
-        <button class="btn" onclick={normalize} title="Fill unset rows from natural ratios to reach 100%">Normalize</button>
+        <button class="btn" class:hint={!isValid} onclick={normalize} title="Fill unset rows from natural ratios to reach 100%">Normalize</button>
         <button class="btn" onclick={resetToNatural}>Natural</button>
       </div>
     </div>
 
     <div class="bottom-actions">
       <button class="btn cancel" onclick={onclose}>Cancel</button>
-      <button class="btn apply" onclick={apply}>Apply</button>
+      <button
+        class="btn apply"
+        class:invalid={!isValid}
+        disabled={!isValid}
+        title={isValid ? "" : "Sum must equal 100% — click Normalize first"}
+        onclick={apply}
+      >Apply</button>
     </div>
   </div>
 </Modal>
@@ -429,5 +455,21 @@
 
   .btn.apply:hover {
     background: var(--c-green-emphasis);
+  }
+
+  .btn.apply.invalid {
+    background: var(--c-red);
+    border-color: var(--c-red);
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .btn.apply.invalid:hover {
+    background: var(--c-red);
+  }
+
+  .btn.hint {
+    border-color: var(--c-gold);
+    color: var(--c-gold);
   }
 </style>

--- a/frontend/src/lib/components/LayerGroup.svelte
+++ b/frontend/src/lib/components/LayerGroup.svelte
@@ -108,7 +108,7 @@
                 class="el-badge"
                 class:enriched={!!layer.enrichment?.[el]}
                 onclick={(e) => { e.stopPropagation(); onelementclick?.(groupIndex, i, el); }}
-              >{el}{#if layer.enrichment?.[el]}<span class="enr-dot"></span>{/if}</button>
+              >{el}</button>
             {/each}
           </div>
         {/if}
@@ -270,16 +270,6 @@
 
   .el-badge:hover { border-color: var(--c-accent); color: var(--c-accent); }
   .el-badge.enriched { border-color: var(--c-gold); color: var(--c-gold); background: var(--c-gold-tint-subtle); }
-
-  .enr-dot {
-    display: inline-block;
-    width: 3px;
-    height: 3px;
-    background: var(--c-gold);
-    border-radius: 50%;
-    margin-left: 0.1rem;
-    vertical-align: middle;
-  }
 
   .add-layer-btn {
     flex-shrink: 0;

--- a/frontend/src/lib/components/LayerStackHorizontal.svelte
+++ b/frontend/src/lib/components/LayerStackHorizontal.svelte
@@ -179,7 +179,7 @@
                   class:enriched={!!item.enrichment?.[el]}
                   onclick={(e) => { e.stopPropagation(); onelementclick?.(undefined, i, el); }}
                   title="{el}{item.enrichment?.[el] ? ' (enriched)' : ''}"
-                >{el}{#if item.enrichment?.[el]}<span class="enr-dot"></span>{/if}</button>
+                >{el}</button>
               {/each}
             </div>
           {/if}
@@ -416,16 +416,6 @@
     border-color: var(--c-gold);
     color: var(--c-gold);
     background: var(--c-gold-tint-subtle);
-  }
-
-  .enr-dot {
-    display: inline-block;
-    width: 4px;
-    height: 4px;
-    background: var(--c-gold);
-    border-radius: 50%;
-    margin-left: 0.15rem;
-    vertical-align: middle;
   }
 
   @media (max-width: 640px) {

--- a/packages/compute/src/materials.test.ts
+++ b/packages/compute/src/materials.test.ts
@@ -121,6 +121,30 @@ describe("resolveElement", () => {
     expect(el.isotopes.get(63)).toBe(0.99);
   });
 
+  it("natural-fills a partial enrichment vector (#217)", () => {
+    // Preset shape: `{ Mo: { 100: 0.995 } }` — only Mo-100 is named.
+    // The remaining 0.5% should be distributed across other Mo isotopes
+    // proportionally to their natural abundance, so the resolved vector
+    // sums to 1 and downstream mass-density math stays correct.
+    const el = resolveElement(db, "Mo", new Map([[100, 0.995]]));
+    let sum = 0;
+    for (const v of el.isotopes.values()) sum += v;
+    expect(sum).toBeCloseTo(1.0, 9);
+    expect(el.isotopes.get(100)).toBe(0.995);
+    // Mo-92 natural = 0.1477 of the non-Mo-100 share (which sums to
+    // 1 − 0.0967 = 0.9033). Remainder = 0.005; share = 0.1477 / 0.9033.
+    const expected92 = (0.1477 / (1 - 0.0967)) * 0.005;
+    expect(el.isotopes.get(92)).toBeCloseTo(expected92, 9);
+  });
+
+  it("renormalizes an over-specified vector (sum > 1)", () => {
+    const el = resolveElement(db, "Cu", new Map([[63, 0.8], [65, 0.4]]));
+    let sum = 0;
+    for (const v of el.isotopes.values()) sum += v;
+    expect(sum).toBeCloseTo(1.0, 9);
+    expect(el.isotopes.get(63)).toBeCloseTo(0.8 / 1.2, 9);
+  });
+
   it("throws for unknown element", () => {
     expect(() => resolveElement(db, "Xx")).toThrow("Unknown element symbol");
   });

--- a/packages/compute/src/materials.ts
+++ b/packages/compute/src/materials.ts
@@ -73,6 +73,85 @@ export function massToAtomFractions(
   return result;
 }
 
+/**
+ * Normalize a (possibly partial) isotope-fraction vector to sum to 1.
+ *
+ * - sum ≈ 1: pass through.
+ * - sum < 1: distribute the (1 − sum) remainder across isotopes NOT in
+ *   `override`, proportionally to their natural abundance. If every natural
+ *   isotope is already specified, scale the override values up to sum = 1.
+ * - sum > 1: scale down to sum = 1 (defensive — a UI invariant should keep
+ *   this from happening in practice).
+ */
+export function normalizeIsotopeVector(
+  override: Map<number, number>,
+  naturalAbundances: Map<number, { abundance: number; atomicMass: number }>,
+): Map<number, number> {
+  const result = new Map(override);
+  let sum = 0;
+  for (const v of result.values()) sum += v;
+
+  if (Math.abs(sum - 1) < 1e-9) return result;
+
+  if (sum > 1) {
+    for (const [a, v] of result) result.set(a, v / sum);
+    return result;
+  }
+
+  const remainder = 1 - sum;
+  let natSum = 0;
+  for (const [A, { abundance }] of naturalAbundances) {
+    if (!result.has(A)) natSum += abundance;
+  }
+
+  if (natSum > 0) {
+    for (const [A, { abundance }] of naturalAbundances) {
+      if (!result.has(A)) {
+        result.set(A, (abundance / natSum) * remainder);
+      }
+    }
+  } else if (sum > 0) {
+    for (const [a, v] of result) result.set(a, v / sum);
+  }
+  return result;
+}
+
+/**
+ * Record-flavored variant of `normalizeIsotopeVector` used by the mixture
+ * resolver. `natural` is the full natural-abundance vector (sum ≈ 1).
+ */
+export function normalizeOverrideRecord(
+  override: Record<number, number>,
+  natural: Record<number, number>,
+): Record<number, number> {
+  const result: Record<number, number> = { ...override };
+  let sum = 0;
+  for (const v of Object.values(result)) sum += v;
+
+  if (Math.abs(sum - 1) < 1e-9) return result;
+
+  if (sum > 1) {
+    for (const a of Object.keys(result)) result[Number(a)] = result[Number(a)] / sum;
+    return result;
+  }
+
+  const remainder = 1 - sum;
+  let natSum = 0;
+  for (const [a, ab] of Object.entries(natural)) {
+    if (!(Number(a) in result)) natSum += ab;
+  }
+
+  if (natSum > 0) {
+    for (const [a, ab] of Object.entries(natural)) {
+      const A = Number(a);
+      if (!(A in result)) result[A] = (ab / natSum) * remainder;
+    }
+  } else if (sum > 0) {
+    for (const a of Object.keys(result)) result[Number(a)] = result[Number(a)] / sum;
+  }
+  return result;
+}
+
 /** Resolve an element with natural or enriched isotopic composition. */
 export function resolveElement(
   db: DatabaseProtocol,
@@ -82,11 +161,12 @@ export function resolveElement(
   const Z = SYMBOL_TO_Z[symbol];
   if (Z === undefined) throw new Error(`Unknown element symbol: ${symbol}`);
 
+  const abundances = db.getNaturalAbundances(Z);
+
   if (enrichment) {
-    return { symbol, Z, isotopes: enrichment };
+    return { symbol, Z, isotopes: normalizeIsotopeVector(enrichment, abundances) };
   }
 
-  const abundances = db.getNaturalAbundances(Z);
   const isotopes = new Map<number, number>();
   for (const [A, { abundance }] of abundances) {
     isotopes.set(A, abundance);
@@ -402,9 +482,11 @@ export function resolveMixtureToElements(
       if (atomsHere === 0) continue;
       // Resolve the isotope vector for this (row, element):
       //   row.enrichment[el] → opts.layerEnrichment[el] → naturalAbundance(el)
-      const vector = rows[i].enrichment?.[el]
-        ?? opts.layerEnrichment?.[el]
-        ?? opts.naturalAbundance(el);
+      const override = rows[i].enrichment?.[el] ?? opts.layerEnrichment?.[el];
+      const natural = opts.naturalAbundance(el);
+      const vector = override
+        ? normalizeOverrideRecord(override, natural)
+        : natural;
       const share = atomsHere / totalAtoms;
       for (const [a, frac] of Object.entries(vector)) {
         const A = Number(a);


### PR DESCRIPTION
Closes #217.

## Summary
- Feeling Lucky presets like `{Mo: {100: 0.995}}` were partial vectors. The compute layer used them as-is (Mo at 99.5% mass density) and the ElementPopup's 'Effective' column double-counted set values + raw natural for the unset rows, giving sums ~190%.
- Compute: `resolveElement` and the mixture-resolver row path now normalize partial overrides via a shared helper. `sum < 1` distributes the remainder across unspecified isotopes proportionally to natural abundance; `sum > 1` renormalizes defensively.
- UI: ElementPopup's 'Effective' for unset rows shows the same natural-scaled fill, so the Total reads 100% for partial vectors. When the user edits the sum out of range, Apply turns red and disables with a 'Sum must equal 100% — click Normalize first' tooltip; Normalize highlights gold. Apply emits only explicitly-set rows so the compute layer's fill stays the SSoT.

## Test plan
- [x] `vitest run packages` — 74/74 pass (2 new tests cover partial + over-specified vectors)
- [x] `vitest run` (frontend) — 545/545 pass
- [x] `svelte-check` — no new errors (preexisting BugReportModal warning unrelated)
- [ ] Manual: load Tc-99m (Mo-100) preset, open Mo enrichment popup, confirm Effective sums to 100% and Apply is green
- [ ] Manual: set Mo-100 to 110%, confirm Apply turns red + tooltip + Normalize highlights gold
- [ ] Manual: run a simulation pre/post change with the same preset and confirm isotope yields shift sensibly (Mo mass density now matches 1.0× target)