### PR TITLE
feat(data): bump to data-2026.5.1 — catima, compound stopping, ASTAR fix (#215, #137, #63, #193)

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -18,6 +18,16 @@ pub trait DatabaseProtocol: Send + Sync {
     /// Returns (energies_MeV, dedx_MeV_cm2_g) sorted by energy.
     fn get_stopping_power(&self, source: &str, target_z: u32) -> (Vec<f64>, Vec<f64>);
 
+    /// Get compound stopping power from NIST tables (PSTAR_compound / ASTAR_compound).
+    /// Returns None if no compound table exists for this source+compound combo.
+    fn get_compound_stopping_power(
+        &self,
+        _source: &str,
+        _compound: &str,
+    ) -> Option<(Vec<f64>, Vec<f64>)> {
+        None // default: not available
+    }
+
     /// Get natural isotopic abundances.
     /// Returns dict[A] -> (fractional_abundance, atomic_mass_u).
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)>;
@@ -49,6 +59,8 @@ pub struct InMemoryDataStore {
     abundances: HashMap<u32, Vec<(u32, f64, f64)>>,
     decay_data: HashMap<String, DecayData>,
     stopping_data: HashMap<String, (Vec<f64>, Vec<f64>)>,
+    /// Compound stopping from NIST tables. Key: "source\0compound" (e.g. "PSTAR_compound\0WATER_LIQUID").
+    compound_stopping: HashMap<String, (Vec<f64>, Vec<f64>)>,
     dose_constants: HashMap<String, (f64, String)>,
     xs_cache: HashMap<String, Vec<CrossSectionData>>,
 }
@@ -62,6 +74,7 @@ impl InMemoryDataStore {
             abundances: HashMap::new(),
             decay_data: HashMap::new(),
             stopping_data: HashMap::new(),
+            compound_stopping: HashMap::new(),
             dose_constants: HashMap::new(),
             xs_cache: HashMap::new(),
         }
@@ -94,6 +107,17 @@ impl InMemoryDataStore {
         self.dose_constants.insert(key, (k, source.to_string()));
     }
 
+    pub fn add_compound_stopping_data(
+        &mut self,
+        source: &str,
+        compound: &str,
+        energies: Vec<f64>,
+        dedx: Vec<f64>,
+    ) {
+        let key = format!("{}\0{}", source, compound);
+        self.compound_stopping.insert(key, (energies, dedx));
+    }
+
     pub fn add_cross_sections(&mut self, projectile: &str, element_symbol: &str, xs_list: Vec<CrossSectionData>) {
         let key = format!("{}_{}", projectile, element_symbol);
         self.xs_cache.insert(key, xs_list);
@@ -113,6 +137,11 @@ impl DatabaseProtocol for InMemoryDataStore {
     fn get_stopping_power(&self, source: &str, target_z: u32) -> (Vec<f64>, Vec<f64>) {
         let key = format!("{}_{}", source, target_z);
         self.stopping_data.get(&key).cloned().unwrap_or_default()
+    }
+
+    fn get_compound_stopping_power(&self, source: &str, compound: &str) -> Option<(Vec<f64>, Vec<f64>)> {
+        let key = format!("{}\0{}", source, compound);
+        self.compound_stopping.get(&key).cloned()
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {
@@ -176,6 +205,9 @@ pub struct ParquetDataStore {
     // Lazily loaded on first use — each stopping/{source}.parquet loaded on demand.
     // Single Mutex covers both fields to avoid any lock-ordering issues.
     stopping: Mutex<(HashMap<String, (Vec<f64>, Vec<f64>)>, HashSet<String>)>,
+    /// Compound stopping from NIST tables (PSTAR_compounds, ASTAR_compounds).
+    /// Key: "source\0COMPOUND_NAME". Lazily loaded on first query.
+    compound_stopping: Mutex<(HashMap<String, (Vec<f64>, Vec<f64>)>, bool)>,
 }
 
 impl ParquetDataStore {
@@ -196,6 +228,7 @@ impl ParquetDataStore {
             dose_constants: HashMap::new(),
             xs_cache: HashMap::new(),
             stopping: Mutex::new((HashMap::new(), HashSet::new())),
+            compound_stopping: Mutex::new((HashMap::new(), false)),
         };
 
         store.load_elements()?;
@@ -244,6 +277,46 @@ impl ParquetDataStore {
             let energies: Vec<f64> = pairs.iter().map(|p| p.0).collect();
             let dedx: Vec<f64> = pairs.iter().map(|p| p.1).collect();
             guard.0.insert(key, (energies, dedx));
+        }
+    }
+
+    /// Lazily load NIST compound stopping tables from
+    /// `stopping/compounds/{PSTAR_compounds,ASTAR_compounds}.parquet`.
+    fn ensure_compound_stopping(&self) {
+        let mut guard = self.compound_stopping.lock().expect("compound_stopping mutex poisoned");
+        if guard.1 { return; }
+        guard.1 = true;
+
+        for filename in &["PSTAR_compounds.parquet", "ASTAR_compounds.parquet"] {
+            let path = self.data_dir.join("stopping").join("compounds").join(filename);
+            if !path.exists() { continue; }
+            let file = match std::fs::File::open(&path) {
+                Ok(f) => f,
+                Err(_) => continue,
+            };
+            let reader = match parquet::arrow::arrow_reader::ParquetRecordBatchReader::try_new(file, 65536) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            let mut raw: HashMap<String, Vec<(f64, f64)>> = HashMap::new();
+            for batch in reader {
+                let Ok(batch) = batch else { continue };
+                let n = batch.num_rows();
+                let source_col = get_string_or_default(&batch, "source");
+                let compound_col = get_string_or_default(&batch, "compound");
+                let e_col = get_f64(&batch, "energy_MeV");
+                let d_col = get_f64(&batch, "dedx");
+                for i in 0..n {
+                    let key = format!("{}\0{}", source_col[i], compound_col[i]);
+                    raw.entry(key).or_default().push((e_col[i], d_col[i]));
+                }
+            }
+            for (key, mut pairs) in raw {
+                pairs.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+                let energies: Vec<f64> = pairs.iter().map(|p| p.0).collect();
+                let dedx: Vec<f64> = pairs.iter().map(|p| p.1).collect();
+                guard.0.insert(key, (energies, dedx));
+            }
         }
     }
 
@@ -502,6 +575,12 @@ impl DatabaseProtocol for ParquetDataStore {
         self.ensure_stopping_source(source);
         let key = format!("{}_{}", source, target_z);
         self.stopping.lock().expect("stopping mutex poisoned").0.get(&key).cloned().unwrap_or_default()
+    }
+
+    fn get_compound_stopping_power(&self, source: &str, compound: &str) -> Option<(Vec<f64>, Vec<f64>)> {
+        self.ensure_compound_stopping();
+        let key = format!("{}\0{}", source, compound);
+        self.compound_stopping.lock().expect("compound_stopping mutex poisoned").0.get(&key).cloned()
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {

--- a/core/src/stopping.rs
+++ b/core/src/stopping.rs
@@ -336,14 +336,41 @@ pub fn get_stopping_sources(
     Ok(result)
 }
 
-/// Compound stopping power via Bragg additivity [MeV·cm²/g].
-/// composition: [(Z, mass_fraction)].
+/// Compound stopping power [MeV·cm²/g].
+///
+/// If `nist_compound` is provided, tries a direct NIST compound-table
+/// lookup first (avoids Bragg-additivity errors near the Bragg peak,
+/// issue #193). Falls back to Bragg additivity when no NIST table
+/// exists for the given compound + projectile.
 pub fn compound_dedx(
     db: &dyn DatabaseProtocol,
     projectile: &ProjectileType,
     composition: &[(u32, f64)],
     energies_mev: &[f64],
 ) -> Result<Vec<f64>, StoppingError> {
+    compound_dedx_with_nist(db, projectile, composition, energies_mev, None)
+}
+
+/// Like [`compound_dedx`] but accepts an optional NIST compound name
+/// for direct table lookup (e.g. "WATER_LIQUID", "KAPTON_POLYIMIDE_FILM").
+pub fn compound_dedx_with_nist(
+    db: &dyn DatabaseProtocol,
+    projectile: &ProjectileType,
+    composition: &[(u32, f64)],
+    energies_mev: &[f64],
+    nist_compound: Option<&str>,
+) -> Result<Vec<f64>, StoppingError> {
+    // Try NIST compound table first if a compound name was provided.
+    if let Some(compound) = nist_compound {
+        let source = compound_stopping_source(projectile);
+        if let Some((table_e, table_s)) = db.get_compound_stopping_power(source, compound) {
+            if table_e.len() >= 2 {
+                let interp = make_log_log_interpolator(&table_e, &table_s);
+                return Ok(interp(energies_mev));
+            }
+        }
+    }
+    // Fallback: Bragg additivity.
     let mut result = vec![0.0; energies_mev.len()];
     for &(z, mass_frac) in composition {
         let elemental = elemental_dedx(db, projectile, z, energies_mev)?;
@@ -352,6 +379,14 @@ pub fn compound_dedx(
         }
     }
     Ok(result)
+}
+
+/// NIST compound stopping source name for a projectile type.
+fn compound_stopping_source(projectile: &ProjectileType) -> &'static str {
+    let z = projectile.z();
+    if z == 1 { "PSTAR_compound" }
+    else if z == 2 { "ASTAR_compound" }
+    else { "" } // No NIST compound tables for heavy ions
 }
 
 /// Linear stopping power [MeV/cm].

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -287,6 +287,18 @@ async function transferDataToWasm(
     wasm.loadStoppingData(JSON.stringify(stoppingRows));
   }
 
+  // Compound stopping (NIST tables) — separate API since keyed by
+  // compound name, not target_Z. (#193)
+  if (tsStore.compoundStoppingData?.length) {
+    const compoundRows = tsStore.compoundStoppingData.map((row: any) => ({
+      source: String(row.source),
+      compound: String(row.compound),
+      energy_MeV: Number(row.energy_MeV),
+      dedx: Number(row.dedx),
+    }));
+    wasm.loadCompoundStoppingData(JSON.stringify(compoundRows));
+  }
+
   onProgress?.("WASM backend ready", 1.0);
 }
 

--- a/packages/compute/src/_energy-loss.ts
+++ b/packages/compute/src/_energy-loss.ts
@@ -7,10 +7,11 @@
  * expand-layers UI preview.
  */
 
-import { PROJECTILE_A, PROJECTILE_Z, type DatabaseProtocol } from "./types";
+import { PROJECTILE_A, PROJECTILE_Z, isHeavyIon, type DatabaseProtocol } from "./types";
 
 const SOURCE_PSTAR = "PSTAR";
 const SOURCE_ASTAR = "ASTAR";
+const SOURCE_CATIMA_PREFIX = "catima_";
 
 type InterpolatorFn = (energy: number) => number;
 
@@ -91,8 +92,13 @@ function elementalDedxScalar(
   } else if (projZ === 2) {
     source = SOURCE_ASTAR;
     lookupEnergy = energyMeV * (4 / projA);
+  } else if (isHeavyIon(projectile)) {
+    // Heavy ions: catima_<Symbol><A> table, no velocity scaling.
+    // Mirrors core/src/stopping.rs::source_for().
+    source = SOURCE_CATIMA_PREFIX + projectile.replace("-", "");
+    lookupEnergy = energyMeV;
   } else {
-    return 1.0; // heavy ions: rough fallback
+    return 1.0; // unknown projectile
   }
 
   const fn = getInterpolator(db, source, targetZ);

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -79,6 +79,9 @@ export class DataStore implements DatabaseProtocol {
   private spCache = new Map<string, { energiesMeV: Float64Array; dedx: Float64Array }>();
   /** Pre-indexed stopping data: "source_targetZ" -> sorted rows */
   private spIndex = new Map<string, ParquetRow[]>();
+  /** NIST compound stopping data (PSTAR/ASTAR compounds). Raw rows grouped
+   *  by "source\0compound" for transfer to WASM. (#193) */
+  compoundStoppingData: ParquetRow[] = [];
 
   private initialized = false;
 
@@ -118,16 +121,23 @@ export class DataStore implements DatabaseProtocol {
     }
 
     onProgress?.("Loading stopping power data...", 0.75);
-    // Load per-source light-ion stopping files (PSTAR, ASTAR, dSTAR, tSTAR).
-    // He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through
-    // ASTAR with velocity-scaling at lookup time (see _energy-loss.ts: Z=2
-    // uses ASTAR for both α and ³He; ³He uses E × 4/3 to match α at same
-    // MeV/u). The He3STAR.parquet file was a redundant precomputed cache
-    // that this compute path never queried; this list also never queried
-    // it. Removing matches the upstream layout.
-    const lightIonSources = ["PSTAR", "ASTAR", "dSTAR", "tSTAR"];
+    // Light-ion sources (PSTAR, ASTAR, dSTAR, tSTAR) plus heavy-ion
+    // catima pre-split tables (catima_C12, catima_O16, …). The catima
+    // files have the same (source, target_Z, energy_MeV, dedx) schema
+    // as the light-ion files — added in nucl-parquet data-2026.5.1.
+    //
+    // He3STAR removed in data-2026.5.0: ³He routes through ASTAR with
+    // velocity-scaling (E × 4/3). See _energy-loss.ts.
+    const stoppingSources = [
+      // Light ions
+      "PSTAR", "ASTAR", "dSTAR", "tSTAR",
+      // Heavy ions — pre-split catima tables (synced with
+      // BUNDLED_CATIMA_PROJECTILES in core/src/stopping.rs)
+      "catima_C12", "catima_O16", "catima_Ne20",
+      "catima_Si28", "catima_Ar40", "catima_Fe56",
+    ];
     const stoppingFiles = await Promise.all(
-      lightIonSources.map((src) =>
+      stoppingSources.map((src) =>
         readParquetRows(`${this.baseUrl}/stopping/${src}.parquet`).catch(() => [] as ParquetRow[]),
       ),
     );
@@ -141,6 +151,19 @@ export class DataStore implements DatabaseProtocol {
       let bucket = this.spIndex.get(key);
       if (!bucket) { bucket = []; this.spIndex.set(key, bucket); }
       bucket.push(row);
+    }
+
+    // Load NIST compound stopping tables (PSTAR/ASTAR compounds).
+    // Schema: { source, compound, energy_MeV, dedx } — keyed by compound
+    // name, not target_Z. (#193)
+    const compoundSources = ["compounds/PSTAR_compounds", "compounds/ASTAR_compounds"];
+    const compoundFiles = await Promise.all(
+      compoundSources.map((src) =>
+        readParquetRows(`${this.baseUrl}/stopping/${src}.parquet`).catch(() => [] as ParquetRow[]),
+      ),
+    );
+    for (const rows of compoundFiles) {
+      this.compoundStoppingData.push(...rows);
     }
 
     this.initialized = true;

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -114,13 +114,39 @@ impl WasmDataStore {
             // subsequent call with "recursive use of an object detected".
             // See #211 follow-up (#213).
             pairs.sort_by(|a, b| a.0.total_cmp(&b.0));
-            let parts: Vec<&str> = key.splitn(2, '_').collect();
-            if parts.len() == 2 {
-                let source = parts[0];
-                let target_z: u32 = parts[1].parse().unwrap_or(0);
+            // Split on the *last* underscore so catima sources with
+            // embedded underscores parse correctly: "catima_C12_6" →
+            // source="catima_C12", target_z=6. Matches the frontend's
+            // lastIndexOf("_") in backend.ts. (#215)
+            if let Some((source, z_str)) = key.rsplit_once('_') {
+                let target_z: u32 = z_str.parse().unwrap_or(0);
                 let energies: Vec<f64> = pairs.iter().map(|p| p.0).collect();
                 let dedx: Vec<f64> = pairs.iter().map(|p| p.1).collect();
                 self.inner.add_stopping_data(source, target_z, energies, dedx);
+            }
+        }
+        Ok(())
+    }
+
+    /// Load NIST compound stopping data from JSON:
+    /// `[{"source": "PSTAR_compound", "compound": "WATER_LIQUID", "energy_MeV": .., "dedx": ..}, ...]`
+    #[wasm_bindgen(js_name = loadCompoundStoppingData)]
+    pub fn load_compound_stopping_data(&mut self, json: &str) -> Result<(), JsValue> {
+        let entries: Vec<CompoundStoppingEntry> =
+            serde_json::from_str(json).map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+        let mut grouped: HashMap<String, Vec<(f64, f64)>> = HashMap::new();
+        for e in entries {
+            let key = format!("{}\0{}", e.source, e.compound);
+            grouped.entry(key).or_default().push((e.energy_mev, e.dedx));
+        }
+
+        for (key, mut pairs) in grouped {
+            pairs.sort_by(|a, b| a.0.total_cmp(&b.0));
+            if let Some((source, compound)) = key.split_once('\0') {
+                let energies: Vec<f64> = pairs.iter().map(|p| p.0).collect();
+                let dedx: Vec<f64> = pairs.iter().map(|p| p.1).collect();
+                self.inner.add_compound_stopping_data(source, compound, energies, dedx);
             }
         }
         Ok(())
@@ -448,6 +474,15 @@ struct StoppingEntry {
     source: String,
     #[serde(alias = "target_Z")]
     target_z: u32,
+    #[serde(alias = "energy_MeV")]
+    energy_mev: f64,
+    dedx: f64,
+}
+
+#[derive(Deserialize)]
+struct CompoundStoppingEntry {
+    source: String,
+    compound: String,
     #[serde(alias = "energy_MeV")]
     energy_mev: f64,
     dedx: f64,


### PR DESCRIPTION
## Summary

Bumps nucl-parquet submodule to `data-2026.5.1` and wires the new stopping power data through the full stack (TS → WASM → Rust).

- **Catima heavy-ion stopping** — load 6 pre-split catima tables (C-12, O-16, Ne-20, Si-28, Ar-40, Fe-56) in the TS DataStore so heavy-ion projectiles have real stopping data instead of a constant 1.0 fallback. Fixes the "no stopping table" error for ion projectiles.
- **WASM key-split fix** — `splitn(2, '_')` broke for catima source keys like `"catima_C12_6"` → switched to `rsplit_once('_')` (last underscore), matching the frontend's `lastIndexOf("_")`.
- **NIST compound stopping** — load PSTAR/ASTAR compound tables (48 NIST standard materials: water, tissue, bone, Kapton, PTFE, etc.). New `compound_dedx_with_nist()` tries direct NIST lookup before Bragg additivity, avoiding 5–10% errors near the Bragg peak.
- **Corrected ASTAR data** — the new ASTAR.parquet ships real NIST values (not Z²-scaled proton data). α-on-Al canary test passes within ±5% of NIST reference.

Fixes #215, fixes #137, fixes #63, refs #193

## Test plan

- [x] α-stopping canary test: `alpha_on_al_matches_nist_within_5pct` + `alpha_on_cu_matches_nist_within_5pct` — pass ±5%
- [x] Projectile matrix: all 4 tests pass (every supported projectile computes without panic)
- [x] Frontend: 545 tests pass
- [x] Frontend build: `vite build` succeeds
- [ ] CI: lint, test, e2e cross-platform
- [ ] Manual: load an O-16 beam on Cu target → stopping profile renders (was error before)
- [ ] Manual: load an α beam on Al → CSDA range ≈ 0.6 mm at 18 MeV (was ≈ 0.36 mm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)