### PR TITLE
feat(frontend): sticky beam bar + section nav + table UX (#236, #237, #238)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -400,6 +400,15 @@
         <BeamConfigBar />
       </div>
 
+      {#if hasLayers && result}
+        <nav class="section-nav" aria-label="Jump to section">
+          <button class="section-nav-btn" onclick={() => document.getElementById('sec-depth')?.scrollIntoView({ behavior: 'smooth' })}>Depth</button>
+          <button class="section-nav-btn" onclick={() => document.getElementById('sec-activity')?.scrollIntoView({ behavior: 'smooth' })}>Activity</button>
+          <button class="section-nav-btn" onclick={() => document.getElementById('sec-emission')?.scrollIntoView({ behavior: 'smooth' })}>Emissions</button>
+          <button class="section-nav-btn" onclick={() => document.getElementById('sec-table')?.scrollIntoView({ behavior: 'smooth' })}>Table</button>
+        </nav>
+      {/if}
+
       <LayerStackHorizontal onmaterialclick={openMaterialPopup} onelementclick={openElementPopup} />
 
       {#if computeError && !result}
@@ -417,6 +426,7 @@
       {/if}
 
       {#if hasLayers}
+        <div id="sec-depth"></div>
         <PlotDepthProfileLive />
 
         {#if result}
@@ -434,8 +444,11 @@
 
         {#if result}
           <IsotopeFilterBar {result} />
+          <div id="sec-activity"></div>
           <PlotActivityCurve {result} />
+          <div id="sec-emission"></div>
           <EmissionPlot {result} />
+          <div id="sec-table"></div>
           <ActivityTableEnhanced {result} onisotopeclick={openIsotopePopup} />
         {:else if resultError}
           <p class="compute-error-placeholder">
@@ -716,6 +729,37 @@
     display: flex;
     gap: 0.75rem;
     flex-wrap: wrap;
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: var(--c-bg);
+    padding: 0.4rem 0;
+    margin: -0.4rem 0 0;
+    border-bottom: 1px solid var(--c-border);
+  }
+
+  .section-nav {
+    display: flex;
+    gap: 3px;
+    align-items: center;
+    padding: 0.15rem 0;
+    flex-wrap: wrap;
+  }
+
+  .section-nav-btn {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 3px;
+    color: var(--c-text-muted);
+    padding: 0.1rem 0.4rem;
+    font-size: 0.6rem;
+    cursor: pointer;
+    transition: all 0.1s;
+  }
+
+  .section-nav-btn:hover {
+    color: var(--c-accent);
+    border-color: var(--c-accent);
   }
 
   .status-bar {

--- a/frontend/src/lib/components/ActivityTableEnhanced.svelte
+++ b/frontend/src/lib/components/ActivityTableEnhanced.svelte
@@ -446,10 +446,10 @@
         <tr>
           <th class="col-layer sortable" onclick={() => toggleSort("layer")}>L#</th>
           <th class="col-name sortable" onclick={() => toggleSort("name")}>Isotope</th>
+          <th class="col-reaction">Reaction</th>
           <th class="col-z">Z</th>
           <th class="col-a">A</th>
           <th class="col-hl sortable" onclick={() => toggleSort("half_life")}>t½</th>
-          <th class="col-reaction">Reaction</th>
           <th class="col-act sortable" onclick={() => toggleSort("activity_eob")} title="Activity at end of bombardment">EOB</th>
           <th class="col-act sortable" onclick={() => toggleSort("activity")} title="Activity at end of cooling">EOC</th>
           <th class="col-act sortable" onclick={() => toggleSort("direct")}>Direct</th>
@@ -473,9 +473,11 @@
             class:selected={isSelected(row.name)}
             onclick={() => toggleIsotope(row.name)}
           >
-            <td class="col-layer" title={row.layerList ? `layers ${row.layerList.map(i => i + 1).join(", ")}` : ""}>
+            <td class="col-layer" title={row.layerList && row.layerList.length > 1
+              ? `Produced in ${row.layerList.length} layers: ${row.layerList.map(i => `L${i + 1}`).join(", ")}. Activities summed across all layers.`
+              : ""}>
               {#if row.layerList && row.layerList.length > 1}
-                L{row.layerList[0] + 1}–{row.layerList[row.layerList.length - 1] + 1}×{row.layerList.length}
+                {row.layerList.map(i => `L${i + 1}`).join(", ")}
               {:else}
                 L{(row.layerList ? row.layerList[0] : row.layerIndex) + 1}
               {/if}
@@ -491,13 +493,15 @@
                 {@html nucHtml(row.name)}
               </button>
             </td>
-            <td class="col-z">{row.Z}</td>
-            <td class="col-a">{row.A}</td>
-            <td class="col-hl">{formatHalfLife(row.half_life_s)}</td>
-            <td class="col-reaction">
+            <td class="col-reaction" title={row.layerList && row.layerList.length > 1
+              ? `Routes across ${row.layerList.length} layers:\n${[...new Set([...row.reactions, ...row.decayNotations])].join("\n")}`
+              : ""}>
               {#each [...new Set([...row.reactions, ...row.decayNotations].map(formatReaction))] as rxn, i}{#if i > 0}, {/if}{rxn}{/each}
               {#if row.reactions.length === 0 && row.decayNotations.length === 0 && row.source === "daughter"}decay{/if}
             </td>
+            <td class="col-z">{row.Z}</td>
+            <td class="col-a">{row.A}</td>
+            <td class="col-hl">{formatHalfLife(row.half_life_s)}</td>
             <td class="col-act" class:clamped={eob.clamped}>{eob.text}</td>
             <td class="col-act" class:clamped={eoc.clamped}>{eoc.text}</td>
             <td class="col-act" class:clamped={direct.clamped}>{direct.text}</td>


### PR DESCRIPTION
## Summary

Three small UX features from the same mobile test session:

- **#236**: Sticky beam config bar (`position: sticky`) + section nav pills (Depth / Activity / Emissions / Table) with smooth scroll
- **#237**: Layer notation: "L1, L3" instead of cryptic "L1-3×2". Tooltip: "Produced in 2 layers: L1, L3. Activities summed across all layers."
- **#238**: Reaction column moved from position 6 to 3 (right after isotope name) so it's visible without horizontal scrolling on mobile. Grouped-row tooltip shows all production routes.

Closes #236, closes #237, closes #238

## Test plan

- [x] Build + 545 tests pass
- [ ] CI e2e
- [ ] Sticky bar stays on top when scrolling
- [ ] Nav pills scroll to correct sections
- [ ] Layer notation shows "L1, L3" in grouped mode
- [ ] Reaction column visible without scrolling on narrow viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)