### PR TITLE
fix(frontend): iOS mobile bugs — dose display, input overflow, unit UX (#233 #234 #235)

### DIFF
--- a/frontend/src/lib/components/BeamConfig.svelte
+++ b/frontend/src/lib/components/BeamConfig.svelte
@@ -34,12 +34,7 @@
     { id: "Fe-56", symbol: "\u2075\u2076Fe\u00b2\u2076\u207a", name: "\u2075\u2076Iron" },
   ];
 
-  const TIME_UNITS: { value: TimeUnit; label: string }[] = [
-    { value: "s", label: "s" },
-    { value: "min", label: "min" },
-    { value: "h", label: "h" },
-    { value: "d", label: "d" },
-  ];
+  const TIME_UNIT_LABELS: TimeUnit[] = ["s", "min", "h", "d"];
 
   let beam = $derived(getBeam());
   let config = $derived(getConfig());
@@ -77,22 +72,24 @@
   let irradValue = $derived(fromSeconds(config.irradiation_s, irradUnit));
   let coolValue = $derived(fromSeconds(config.cooling_s, coolUnit));
 
-  function onIrradChange(e: Event) {
-    const v = parseFloat((e.target as HTMLInputElement).value);
-    if (!isNaN(v) && v >= 0) setIrradiation(toSeconds(v, irradUnit));
+  function onIrradChange(v: number) {
+    if (v >= 0) setIrradiation(toSeconds(v, irradUnit));
   }
 
-  function onCoolChange(e: Event) {
-    const v = parseFloat((e.target as HTMLInputElement).value);
-    if (!isNaN(v) && v >= 0) setCooling(toSeconds(v, coolUnit));
+  function onCoolChange(v: number) {
+    if (v >= 0) setCooling(toSeconds(v, coolUnit));
   }
 
-  function onIrradUnitChange(e: Event) {
-    irradUnit = (e.target as HTMLSelectElement).value as TimeUnit;
+  function onIrradUnitChange(newUnit: string) {
+    const u = newUnit as TimeUnit;
+    setIrradiation(toSeconds(fromSeconds(config.irradiation_s, irradUnit), u));
+    irradUnit = u;
   }
 
-  function onCoolUnitChange(e: Event) {
-    coolUnit = (e.target as HTMLSelectElement).value as TimeUnit;
+  function onCoolUnitChange(newUnit: string) {
+    const u = newUnit as TimeUnit;
+    setCooling(toSeconds(fromSeconds(config.cooling_s, coolUnit), u));
+    coolUnit = u;
   }
 
   function handleCurrentUpload(e: Event) {
@@ -165,44 +162,28 @@
 
   <div class="separator"></div>
 
-  <div class="time-row">
-    <label for="bc-irrad">Irradiation</label>
-    <div class="time-controls">
-      <input
-        id="bc-irrad"
-        type="number"
-        value={irradValue}
-        min={0}
-        step={1}
-        onchange={onIrradChange}
-        class="time-input"
-      />
-      <select value={irradUnit} onchange={onIrradUnitChange} class="unit-select" aria-label="Irradiation unit">
-        {#each TIME_UNITS as u}
-          <option value={u.value}>{u.label}</option>
-        {/each}
-      </select>
-    </div>
-  </div>
+  <div class="field-grid">
+    <NumberInput
+      label="Irradiation"
+      unit={irradUnit}
+      units={TIME_UNIT_LABELS}
+      value={irradValue}
+      min={0}
+      step={1}
+      onchange={onIrradChange}
+      onunitchange={onIrradUnitChange}
+    />
 
-  <div class="time-row">
-    <label for="bc-cool">Cooling</label>
-    <div class="time-controls">
-      <input
-        id="bc-cool"
-        type="number"
-        value={coolValue}
-        min={0}
-        step={1}
-        onchange={onCoolChange}
-        class="time-input"
-      />
-      <select value={coolUnit} onchange={onCoolUnitChange} class="unit-select" aria-label="Cooling unit">
-        {#each TIME_UNITS as u}
-          <option value={u.value}>{u.label}</option>
-        {/each}
-      </select>
-    </div>
+    <NumberInput
+      label="Cooling"
+      unit={coolUnit}
+      units={TIME_UNIT_LABELS}
+      value={coolValue}
+      min={0}
+      step={1}
+      onchange={onCoolChange}
+      onunitchange={onCoolUnitChange}
+    />
   </div>
 
   <div class="current-profile">
@@ -283,54 +264,6 @@
   .separator {
     border-top: 1px solid var(--c-border);
     margin: 0.1rem 0;
-  }
-
-  .time-row {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .time-row label {
-    font-size: 0.8rem;
-    color: var(--c-text-label);
-  }
-
-  .time-controls {
-    display: flex;
-    gap: 0.4rem;
-  }
-
-  .time-input {
-    flex: 1;
-    background: var(--c-bg-default);
-    border: 1px solid var(--c-border);
-    border-radius: 4px;
-    color: var(--c-text);
-    padding: 0.35rem 0.5rem;
-    font-size: 0.85rem;
-    text-align: right;
-  }
-
-  .time-input:focus {
-    outline: none;
-    border-color: var(--c-accent);
-  }
-
-  .unit-select {
-    width: 60px;
-    background: var(--c-bg-default);
-    border: 1px solid var(--c-border);
-    border-radius: 4px;
-    color: var(--c-text);
-    padding: 0.35rem;
-    font-size: 0.85rem;
-    cursor: pointer;
-  }
-
-  .unit-select:focus {
-    outline: none;
-    border-color: var(--c-accent);
   }
 
   .current-profile {

--- a/frontend/src/lib/components/BeamConfig.svelte
+++ b/frontend/src/lib/components/BeamConfig.svelte
@@ -145,7 +145,7 @@
       value={displayedEnergy}
       min={isHI ? 3 : 1}
       max={isHI ? 1000 : 100}
-      step={isHI ? 1 : 0.5}
+
       onchange={onEnergyChange}
     />
 
@@ -155,7 +155,7 @@
       value={beam.current_mA * 1000}
       min={1}
       max={5000}
-      step={1}
+
       onchange={(v) => setCurrent(v / 1000)}
     />
   </div>
@@ -169,7 +169,7 @@
       units={TIME_UNIT_LABELS}
       value={irradValue}
       min={0}
-      step={1}
+
       onchange={onIrradChange}
       onunitchange={onIrradUnitChange}
     />
@@ -180,7 +180,7 @@
       units={TIME_UNIT_LABELS}
       value={coolValue}
       min={0}
-      step={1}
+
       onchange={onCoolChange}
       onunitchange={onCoolUnitChange}
     />

--- a/frontend/src/lib/components/LayerStackHorizontal.svelte
+++ b/frontend/src/lib/components/LayerStackHorizontal.svelte
@@ -244,6 +244,7 @@
     gap: 0.35rem;
     cursor: grab;
     transition: border-color 0.15s, opacity 0.15s;
+    overflow: hidden; /* prevent child inputs from escaping card bounds (#234) */
   }
 
   .layer-card:hover {

--- a/frontend/src/lib/components/LayerTable.svelte
+++ b/frontend/src/lib/components/LayerTable.svelte
@@ -19,7 +19,7 @@
     let total = 0;
     let hasAny = false;
     for (const iso of layerResult.isotopes) {
-      const d = getDoseConstant(iso.name, iso.activity_Bq);
+      const d = getDoseConstant(iso.name, iso.activity_Bq, iso.Z, iso.A, iso.state);
       if (d !== null) {
         total += d.doseRate;
         hasAny = true;

--- a/frontend/src/lib/components/NumberInput.svelte
+++ b/frontend/src/lib/components/NumberInput.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { parseValueUnit } from "../utils/unit-parse";
+
   interface Props {
     value: number;
     min?: number;
@@ -6,36 +8,91 @@
     step?: number;
     label: string;
     unit?: string;
+    units?: string[];
     onchange: (value: number) => void;
+    onunitchange?: (unit: string) => void;
   }
 
-  let { value, min = 0, max = 100, step = 1, label, unit = "", onchange }: Props = $props();
+  let {
+    value,
+    min = 0,
+    max = Infinity,
+    step = 1,
+    label,
+    unit = "",
+    units = [],
+    onchange,
+    onunitchange,
+  }: Props = $props();
 
-  function handleChange(e: Event) {
-    const target = e.target as HTMLInputElement;
-    const v = parseFloat(target.value);
-    if (!isNaN(v)) {
-      const clamped = Math.min(max, Math.max(min, v));
+  let editing = $state(false);
+  let text = $state("");
+
+  /** All recognized units for parsing: the current unit + any extra units list. */
+  let knownUnits = $derived(
+    unit
+      ? [...new Set([unit, ...units])]
+      : [...units],
+  );
+
+  function formatDisplay(v: number): string {
+    // Use reasonable precision: avoid floating-point noise
+    const s = parseFloat(v.toPrecision(10)).toString();
+    return s;
+  }
+
+  function onFocus(e: Event) {
+    editing = true;
+    text = formatDisplay(value);
+    requestAnimationFrame(() => (e.target as HTMLInputElement).select());
+  }
+
+  function onInput(e: Event) {
+    text = (e.target as HTMLInputElement).value;
+  }
+
+  function commit() {
+    editing = false;
+    const parsed = parseValueUnit(text, knownUnits);
+    if (parsed) {
+      const clamped = Math.min(max, Math.max(min, parsed.value));
       onchange(clamped);
+      if (parsed.unit && parsed.unit !== unit && onunitchange) {
+        onunitchange(parsed.unit);
+      }
+    }
+    // If parse fails, value stays unchanged (input resets to display)
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      commit();
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === "Escape") {
+      editing = false;
+      (e.target as HTMLInputElement).blur();
     }
   }
 </script>
 
 <div class="number-input">
   <label>
-    <span class="label-row">
-      <span class="label-text">{label}</span>
-      {#if unit}<span class="unit">{unit}</span>{/if}
-    </span>
-    <input
-      type="number"
-      {min}
-      {max}
-      {step}
-      {value}
-      onchange={handleChange}
-      class="text-input"
-    />
+    <span class="label-text">{label}</span>
+    <div class="input-wrapper">
+      <input
+        type="text"
+        inputmode="decimal"
+        value={editing ? text : formatDisplay(value)}
+        onfocus={onFocus}
+        oninput={onInput}
+        onblur={commit}
+        onkeydown={onKeydown}
+        class="text-input"
+      />
+      {#if unit && !editing}
+        <span class="unit-suffix">{unit}</span>
+      {/if}
+    </div>
   </label>
 </div>
 
@@ -53,19 +110,14 @@
     font-size: 0.8rem;
   }
 
-  .label-row {
-    display: flex;
-    align-items: baseline;
-    gap: 0.4rem;
-  }
-
   .label-text {
     color: var(--c-text-label);
   }
 
-  .unit {
-    color: var(--c-text-muted);
-    font-size: 0.75rem;
+  .input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
   }
 
   .text-input {
@@ -83,5 +135,29 @@
   .text-input:focus {
     outline: none;
     border-color: var(--c-accent);
+  }
+
+  .unit-suffix {
+    position: absolute;
+    right: 0.4rem;
+    color: var(--c-text-faint);
+    font-size: 0.7rem;
+    pointer-events: none;
+  }
+
+  /* When suffix is shown, add right padding so the number doesn't overlap it */
+  .input-wrapper:has(.unit-suffix) .text-input {
+    padding-right: 2.5rem;
+  }
+
+  @media (max-width: 640px) {
+    .text-input {
+      font-size: 16px; /* prevent iOS auto-zoom */
+      padding: 0.4rem 0.5rem;
+    }
+
+    .input-wrapper:has(.unit-suffix) .text-input {
+      padding-right: 3rem;
+    }
   }
 </style>

--- a/frontend/src/lib/components/NumberInput.svelte
+++ b/frontend/src/lib/components/NumberInput.svelte
@@ -5,7 +5,6 @@
     value: number;
     min?: number;
     max?: number;
-    step?: number;
     label: string;
     unit?: string;
     units?: string[];
@@ -17,7 +16,6 @@
     value,
     min = 0,
     max = Infinity,
-    step = 1,
     label,
     unit = "",
     units = [],

--- a/frontend/src/lib/components/ThicknessInput.svelte
+++ b/frontend/src/lib/components/ThicknessInput.svelte
@@ -232,6 +232,7 @@
     display: flex;
     align-items: center;
     gap: 0.3rem;
+    min-width: 0; /* allow shrink (#234) */
   }
 
   .input-with-feedback {
@@ -239,10 +240,12 @@
     align-items: center;
     gap: 0.25rem;
     flex: 1;
+    min-width: 0; /* allow shrink within parent flex (#234) */
   }
 
   .val-input {
     flex: 1;
+    min-width: 0; /* allow flex shrink below intrinsic width (#234) */
     background: var(--c-bg-default);
     border: 1px solid var(--c-border);
     border-radius: 4px;

--- a/frontend/src/lib/utils/dose-constants.test.ts
+++ b/frontend/src/lib/utils/dose-constants.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getDoseConstant } from "./dose-constants";
+
+/**
+ * Regression test for #233: LayerTable was calling getDoseConstant without
+ * Z/A/state, so only 8 hardcoded fallback isotopes got dose values.
+ *
+ * The function should still return fallback results when Z/A are omitted and
+ * the symbol is in the fallback table, but must NOT short-circuit to null for
+ * known fallback isotopes.
+ */
+describe("getDoseConstant", () => {
+  it("returns fallback dose for known isotopes when Z/A omitted", () => {
+    const result = getDoseConstant("Tc-99m", 1e6); // 1 MBq
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("fallback");
+    expect(result!.doseRate).toBeCloseTo(0.0141, 4); // k=0.0141 * 1 MBq
+  });
+
+  it("returns null for unknown isotopes when Z/A omitted (no parquet lookup)", () => {
+    // Without Z/A the parquet path is skipped and "Si-27" is not in FALLBACK
+    const result = getDoseConstant("Si-27", 1e6);
+    expect(result).toBeNull();
+  });
+
+  it("attempts parquet lookup when Z/A are provided", () => {
+    // Without a real DataStore loaded, this still returns null (no store),
+    // but the important thing is the call signature compiles and doesn't
+    // skip the parquet path. Integration tests cover the full lookup.
+    const result = getDoseConstant("Si-27", 1e6, 14, 27, "");
+    // With no DataStore available, falls through to fallback (which is also null for Si-27)
+    expect(result).toBeNull();
+  });
+
+  it("returns fallback for known isotopes even when Z/A are provided but no store", () => {
+    const result = getDoseConstant("Na-22", 1e6, 11, 22, "");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("fallback");
+    expect(result!.doseRate).toBeCloseTo(0.273, 3);
+  });
+});

--- a/frontend/src/lib/utils/unit-parse.test.ts
+++ b/frontend/src/lib/utils/unit-parse.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { parseValueUnit, formatValueUnit } from "./unit-parse";
+
+describe("parseValueUnit", () => {
+  const energyUnits = ["MeV", "MeV/u", "keV"];
+  const currentUnits = ["µA", "mA", "nA"];
+  const timeUnits = ["s", "min", "h", "d"];
+
+  it("parses number + unit with space", () => {
+    expect(parseValueUnit("18 MeV", energyUnits)).toEqual({ value: 18, unit: "MeV" });
+    expect(parseValueUnit("0.5 µA", currentUnits)).toEqual({ value: 0.5, unit: "µA" });
+    expect(parseValueUnit("20 min", timeUnits)).toEqual({ value: 20, unit: "min" });
+  });
+
+  it("parses number + unit without space", () => {
+    expect(parseValueUnit("18MeV", energyUnits)).toEqual({ value: 18, unit: "MeV" });
+    expect(parseValueUnit("10µA", currentUnits)).toEqual({ value: 10, unit: "µA" });
+    expect(parseValueUnit("3d", timeUnits)).toEqual({ value: 3, unit: "d" });
+  });
+
+  it("parses bare number (no unit)", () => {
+    expect(parseValueUnit("18", energyUnits)).toEqual({ value: 18, unit: null });
+    expect(parseValueUnit("  42  ", energyUnits)).toEqual({ value: 42, unit: null });
+  });
+
+  it("handles case-insensitive unit matching", () => {
+    expect(parseValueUnit("18 mev", energyUnits)).toEqual({ value: 18, unit: "MeV" });
+    expect(parseValueUnit("18 MEV", energyUnits)).toEqual({ value: 18, unit: "MeV" });
+  });
+
+  it("handles µ/μ normalization", () => {
+    // U+03BC (Greek mu) vs U+00B5 (micro sign)
+    expect(parseValueUnit("10\u03BCA", currentUnits)).toEqual({ value: 10, unit: "µA" });
+  });
+
+  it("handles floats and scientific notation", () => {
+    expect(parseValueUnit("1.5e3 MeV", energyUnits)).toEqual({ value: 1500, unit: "MeV" });
+    expect(parseValueUnit("0.001 mA", currentUnits)).toEqual({ value: 0.001, unit: "mA" });
+  });
+
+  it("returns null for empty or invalid input", () => {
+    expect(parseValueUnit("", energyUnits)).toBeNull();
+    expect(parseValueUnit("abc", energyUnits)).toBeNull();
+    expect(parseValueUnit("MeV", energyUnits)).toBeNull();
+  });
+
+  it("returns null for unrecognized unit", () => {
+    expect(parseValueUnit("18 GeV", energyUnits)).toBeNull();
+  });
+
+  it("handles MeV/u compound unit", () => {
+    expect(parseValueUnit("8 MeV/u", energyUnits)).toEqual({ value: 8, unit: "MeV/u" });
+    expect(parseValueUnit("8MeV/u", energyUnits)).toEqual({ value: 8, unit: "MeV/u" });
+  });
+});
+
+describe("formatValueUnit", () => {
+  it("formats with thin space", () => {
+    const result = formatValueUnit(18, "MeV");
+    expect(result).toBe("18\u2009MeV");
+  });
+});

--- a/frontend/src/lib/utils/unit-parse.test.ts
+++ b/frontend/src/lib/utils/unit-parse.test.ts
@@ -33,9 +33,11 @@ describe("parseValueUnit", () => {
     expect(parseValueUnit("10\u03BCA", currentUnits)).toEqual({ value: 10, unit: "µA" });
   });
 
-  it("handles floats and scientific notation", () => {
+  it("handles floats, leading-dot shorthand, and scientific notation", () => {
     expect(parseValueUnit("1.5e3 MeV", energyUnits)).toEqual({ value: 1500, unit: "MeV" });
     expect(parseValueUnit("0.001 mA", currentUnits)).toEqual({ value: 0.001, unit: "mA" });
+    expect(parseValueUnit(".5 MeV", energyUnits)).toEqual({ value: 0.5, unit: "MeV" });
+    expect(parseValueUnit(".5MeV", energyUnits)).toEqual({ value: 0.5, unit: "MeV" });
   });
 
   it("returns null for empty or invalid input", () => {

--- a/frontend/src/lib/utils/unit-parse.ts
+++ b/frontend/src/lib/utils/unit-parse.ts
@@ -1,0 +1,61 @@
+/**
+ * Parse "$VALUE $UNIT" strings — shared by beam param and time inputs (#235).
+ *
+ * Accepts: "18 MeV", "18MeV", "18", "0.5 µA", "20min", "3 d", etc.
+ * Returns null if the input is not parseable as a number.
+ */
+
+export interface ParsedValueUnit {
+  value: number;
+  unit: string | null; // null = no unit found in the input
+}
+
+/**
+ * Parse a string like "18 MeV" or "18MeV" into { value: 18, unit: "MeV" }.
+ *
+ * @param input  - the raw text
+ * @param knownUnits - list of valid unit strings (case-insensitive match)
+ * @returns parsed result or null if no valid number found
+ */
+export function parseValueUnit(
+  input: string,
+  knownUnits: string[],
+): ParsedValueUnit | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Try to match: optional sign, number (int or float or scientific), optional whitespace, optional unit
+  const m = trimmed.match(
+    /^([+-]?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*(.*)$/i,
+  );
+  if (!m) return null;
+
+  const value = parseFloat(m[1]);
+  if (isNaN(value)) return null;
+
+  const unitPart = m[2].trim();
+  if (!unitPart) return { value, unit: null };
+
+  // Match against known units (case-insensitive, but preserve original casing from knownUnits)
+  const match = knownUnits.find(
+    (u) => u.toLowerCase() === unitPart.toLowerCase(),
+  );
+  // Also handle µ/μ normalization for µA
+  if (!match) {
+    const normalized = unitPart.replace(/μ/g, "µ");
+    const matchNorm = knownUnits.find(
+      (u) => u.toLowerCase().replace(/μ/g, "µ") === normalized.toLowerCase(),
+    );
+    return matchNorm ? { value, unit: matchNorm } : null;
+  }
+
+  return { value, unit: match };
+}
+
+/**
+ * Format a value + unit into a display string.
+ * Uses a thin space (U+2009) between number and unit for clean display.
+ */
+export function formatValueUnit(value: number, unit: string): string {
+  return `${value}\u2009${unit}`;
+}

--- a/frontend/src/lib/utils/unit-parse.ts
+++ b/frontend/src/lib/utils/unit-parse.ts
@@ -24,9 +24,9 @@ export function parseValueUnit(
   const trimmed = input.trim();
   if (!trimmed) return null;
 
-  // Try to match: optional sign, number (int or float or scientific), optional whitespace, optional unit
+  // Try to match: optional sign, number (int/float/.N shorthand/scientific), optional whitespace, optional unit
   const m = trimmed.match(
-    /^([+-]?\d+(?:\.\d+)?(?:e[+-]?\d+)?)\s*(.*)$/i,
+    /^([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?)\s*(.*)$/i,
   );
   if (!m) return null;
 


### PR DESCRIPTION
## Summary

Batch fix for three iOS Safari field-test issues from 2026-05-17:

- **#233 — Dose not showing per layer**: `LayerTable` called `getDoseConstant(name, activity)` with only 2 args, skipping the parquet DB lookup (requires Z/A). Only 8 hardcoded fallback isotopes got values; everything else showed "—". Now passes `iso.Z`, `iso.A`, `iso.state` — matching `ActivityTableEnhanced`.

- **#234 — Layer thickness input overflows on iOS**: On mobile (≤640px), `.val-input` gets `font-size: 16px` (prevents Safari auto-zoom) but without `min-width: 0` the flex item can't shrink below intrinsic width, overflowing the 180px card. Added `min-width: 0` to all flex children + `overflow: hidden` on the card.

- **#235 — Beam input units unification**: Replaced `type="number"` inputs + separate `<select>` dropdowns with unified smart text inputs. All beam parameters (Energy, Current, Irradiation, Cooling) now show an inline grey unit suffix and accept `$VAL$UNIT` input (e.g. "18MeV", "20 min") with auto-parsing. New `unit-parse.ts` utility.

## Test plan

- [ ] Verify dose column shows values (not "—") in LayerTable for the [test config](https://exoma-ch.github.io/hyrr/#config=1:q1ZKUrKqVipQsgJiHaVUJStDCx2lZCUrAz0Dw1odpRwlq-hqpVygdEgmUL4ELGFgZGqAAkxrdSCKPFIhioxhAo45cF1GqHoMTGBqnEuRTMbUaFQbq6OUCXQY0ACw0wwNagE)
- [ ] On mobile viewport (390px): layer card inputs stay within card bounds
- [ ] Energy/Current inputs show grey unit suffix, accept "18MeV" style input
- [ ] Irradiation/Cooling inputs show unit suffix, accept "20min" / "3 d" style input
- [ ] Unit auto-detection: typing "20min" in a field showing "d" switches to "min"
- [ ] All 559 tests pass, svelte-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)