### PR TITLE
fix(frontend): β⁺ endpoint energy + γ relative intensity labeling (#240, #242)

### DIFF
--- a/frontend/src/lib/components/EmissionsTable.svelte
+++ b/frontend/src/lib/components/EmissionsTable.svelte
@@ -81,7 +81,7 @@
     if (activeTab === "gamma") {
       return gammaLines.map((l) => ({
         energyKeV: l.energyKeV,
-        intensity: l.totalIntensity,
+        intensity: l.intensity,
       }));
     }
     return decayEmissions
@@ -203,8 +203,8 @@
               <th class="et-energy sortable" onclick={() => toggleSort("energy")}>
                 Energy (keV){sortIndicator("energy")}
               </th>
-              <th class="et-intensity sortable" onclick={() => toggleSort("intensity")}>
-                Intensity (%){sortIndicator("intensity")}
+              <th class="et-intensity sortable" onclick={() => toggleSort("intensity")} title={activeTab === "gamma" ? "Relative intensity (strongest transition from each level = 100%). Absolute per-decay values pending upstream data." : "Branching ratio per decay (%)"}>
+                {activeTab === "gamma" ? "Rel. I (%)" : "I (%)"}{sortIndicator("intensity")}
               </th>
               {#if activeTab === "EC"}
                 <th class="et-note">Shell</th>

--- a/packages/compute/src/data-store.test.ts
+++ b/packages/compute/src/data-store.test.ts
@@ -58,9 +58,20 @@ function indexDecays(rows: any[]) {
     const key = `${row.Z}_${row.A}`;
     let bucket = idx.get(key);
     if (!bucket) { bucket = []; idx.set(key, bucket); }
+    // Apply physics corrections (mirrors DataStore.init)
+    const qKeV = Number(row.q_value_kev ?? 0);
+    const A = Number(row.A);
+    let energyKeV: number;
+    if (channel === "beta+") {
+      energyKeV = Math.max(0, qKeV - 1022);
+    } else if (channel === "alpha") {
+      energyKeV = A > 4 ? qKeV * (A - 4) / A : qKeV;
+    } else {
+      energyKeV = qKeV;
+    }
     bucket.push({
       channel,
-      energyKeV: Number(row.q_value_kev ?? 0),
+      energyKeV,
       intensity: Number(row.branching ?? 0),
     });
   }
@@ -142,4 +153,32 @@ describe("Decay emission matrix (#201)", () => {
       }
     });
   }
+
+  // β⁺ energy correction: endpoint = Q - 1022 keV (#240)
+  it.skipIf(!HAS_DECAY)("F-18 β⁺ endpoint ≈ 634 keV (Q=1656 − 1022)", async () => {
+    if (!decayIdx) {
+      const rows = await loadParquet(DECAY_FILE);
+      decayIdx = indexDecays(rows);
+    }
+    const f18 = decayIdx.get("9_18") ?? [];
+    const bp = f18.find((l: any) => l.channel === "beta+");
+    expect(bp).toBeDefined();
+    // Q = 1655.9 keV → endpoint = 633.9 keV
+    expect(bp.energyKeV).toBeGreaterThan(600);
+    expect(bp.energyKeV).toBeLessThan(670);
+  });
+
+  // α energy correction: kinetic E = Q × (A-4)/A (#240)
+  it.skipIf(!HAS_DECAY)("Ra-226 α energy ≈ 4784 keV (Q × 222/226)", async () => {
+    if (!decayIdx) {
+      const rows = await loadParquet(DECAY_FILE);
+      decayIdx = indexDecays(rows);
+    }
+    const ra226 = decayIdx.get("88_226") ?? [];
+    const alpha = ra226.find((l: any) => l.channel === "alpha" && l.intensity > 0.5);
+    expect(alpha).toBeDefined();
+    // Dominant α: Q ≈ 4870 keV → kinetic ≈ 4870 × 222/226 ≈ 4784 keV
+    expect(alpha.energyKeV).toBeGreaterThan(4700);
+    expect(alpha.energyKeV).toBeLessThan(4900);
+  });
 });

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -189,9 +189,23 @@ export class DataStore implements DatabaseProtocol {
         const key = `${row.Z}_${row.A}`;
         let bucket = this.decayEmissionIndex.get(key);
         if (!bucket) { bucket = []; this.decayEmissionIndex.set(key, bucket); }
+        // Convert Q-value to actual particle energy:
+        // β⁺: endpoint = Q − 2mₑc² (1022 keV)
+        // α:  kinetic E = Q × (A−4)/A (recoil correction)
+        // β⁻, EC: Q-value is correct as-is
+        const qKeV = Number(row.q_value_kev ?? 0);
+        const A = Number(row.A);
+        let energyKeV: number;
+        if (channel === "beta+") {
+          energyKeV = Math.max(0, qKeV - 1022);
+        } else if (channel === "alpha") {
+          energyKeV = A > 4 ? qKeV * (A - 4) / A : qKeV;
+        } else {
+          energyKeV = qKeV;
+        }
         bucket.push({
           channel,
-          energyKeV: Number(row.q_value_kev ?? 0),
+          energyKeV,
           intensity: Number(row.branching ?? 0),
           ...(SHELL_MAP[mode] ? { shell: SHELL_MAP[mode] } : {}),
         });


### PR DESCRIPTION
## Summary

Two data quality fixes for the emission table:

- **#240 β⁺ energy**: was showing Q-value (1656 keV for F-18) instead of endpoint energy (634 keV). Fix: `endpoint = Q − 2mₑc²`. Also: α recoil correction `kinetic = Q × (A−4)/A`.
- **#242 γ intensity**: ENSDF data is per-level relative, not absolute per-decay. Labeled column "Rel. I (%)" with tooltip. Filed nucl-parquet#196 for upstream absolute values.

Tests: F-18 β⁺ ≈ 634 keV, Ra-226 α ≈ 4784 keV.

Fixes #240, refs #242

## Test plan

- [x] 17 emission tests pass (including 2 new energy correction tests)
- [x] 545 frontend tests pass, build succeeds
- [ ] CI e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)