### PR TITLE
fix(python): normalize 'g'→'' decay lookup + xs dedup in DataStore (#254)

### DIFF
--- a/src/hyrr/db.py
+++ b/src/hyrr/db.py
@@ -391,17 +391,29 @@ class DataStore:
         if filtered.is_empty():
             return []
 
+        # Prefer state-resolved xs over totals: when both state="" and
+        # state="g"/"m" exist for the same residual, drop the total (#254).
+        resolved: set[tuple[int, int]] = set()
+        for (rz, ra, st), _ in filtered.group_by(
+            ["residual_Z", "residual_A", "state"], maintain_order=True
+        ):
+            if str(st):
+                resolved.add((int(rz), int(ra)))
+
         results: list[CrossSectionData] = []
         for (rz, ra, st), group in filtered.group_by(
             ["residual_Z", "residual_A", "state"], maintain_order=True
         ):
+            rz_i, ra_i, st_s = int(rz), int(ra), str(st)
+            if not st_s and (rz_i, ra_i) in resolved:
+                continue  # skip total when state-resolved exist
             energies = group["energy_MeV"].to_numpy().astype(np.float64)
             xs = group["xs_mb"].to_numpy().astype(np.float64)
             results.append(
                 CrossSectionData(
-                    residual_Z=int(rz),
-                    residual_A=int(ra),
-                    state=str(st),
+                    residual_Z=rz_i,
+                    residual_A=ra_i,
+                    state=st_s,
                     energies_MeV=energies,
                     xs_mb=xs,
                 )
@@ -446,8 +458,11 @@ class DataStore:
         state: str = "",
     ) -> DecayData | None:
         """Get decay data for a nuclide. Returns None if not found."""
+        # Normalize "g" → "" — xs data uses "g" for ground-state products,
+        # but decay data uses "" for ground state (#254).
+        norm = "" if state == "g" else state
         filtered = self._decay.filter(
-            (pl.col("Z") == Z) & (pl.col("A") == A) & (pl.col("state") == state)
+            (pl.col("Z") == Z) & (pl.col("A") == A) & (pl.col("state") == norm)
         )
         if filtered.is_empty():
             return None

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -124,16 +124,18 @@ class TestProtocol:
 class TestGetCrossSections:
     """Tests for get_cross_sections."""
 
-    def test_groups_by_residual(self, db: DataStore) -> None:
+    def test_prefers_state_resolved_over_total(self, db: DataStore) -> None:
+        """When both total (state='') and resolved (state='m') exist,
+        only the resolved entry should be returned (#254)."""
         results = db.get_cross_sections("p", 42, 100)
-        assert len(results) == 2
+        assert len(results) == 1
+        assert results[0].state == "m"
         assert all(isinstance(r, CrossSectionData) for r in results)
 
     def test_array_shapes_and_values(self, db: DataStore) -> None:
         results = db.get_cross_sections("p", 42, 100)
-        by_state = {r.state: r for r in results}
-
-        meta = by_state["m"]
+        meta = results[0]
+        assert meta.state == "m"
         assert meta.residual_Z == 43
         assert meta.residual_A == 99
         assert meta.energies_MeV.shape == (3,)
@@ -141,8 +143,29 @@ class TestGetCrossSections:
         np.testing.assert_array_almost_equal(meta.energies_MeV, [5.0, 10.0, 15.0])
         np.testing.assert_array_almost_equal(meta.xs_mb, [10.0, 50.0, 30.0])
 
-        ground = by_state[""]
-        assert ground.energies_MeV.shape == (2,)
+    def test_keeps_total_when_no_resolved(self, data_dir) -> None:
+        """Total xs (state='') kept when no state-resolved entries exist."""
+        xs_dir = data_dir / "test-lib" / "xs"
+        pl.DataFrame({
+            "target_A": [44, 44],
+            "residual_Z": [21, 21],
+            "residual_A": [44, 44],
+            "state": ["", ""],
+            "energy_MeV": [5.0, 10.0],
+            "xs_mb": [200.0, 600.0],
+        }).cast({"target_A": pl.Int32, "residual_Z": pl.Int32, "residual_A": pl.Int32}).write_parquet(
+            xs_dir / "p_Ca.parquet"
+        )
+        # Add Ca element
+        meta_dir = data_dir / "meta"
+        elements = pl.read_parquet(meta_dir / "elements.parquet")
+        elements = pl.concat([elements, pl.DataFrame({"Z": [20], "symbol": ["Ca"]}).cast({"Z": pl.Int32})])
+        elements.write_parquet(meta_dir / "elements.parquet")
+
+        store = DataStore(data_dir, library="test-lib")
+        results = store.get_cross_sections("p", 20, 44)
+        assert len(results) == 1
+        assert results[0].state == ""
 
     def test_empty_result(self, db: DataStore) -> None:
         results = db.get_cross_sections("d", 1, 1)
@@ -193,6 +216,30 @@ class TestGetDecayData:
 
     def test_unknown_returns_none(self, db: DataStore) -> None:
         assert db.get_decay_data(999, 999) is None
+
+    def test_normalizes_g_to_empty(self, data_dir) -> None:
+        """Regression test for #254: state='g' from xs data should find
+        ground-state decay stored as state=''."""
+        meta_dir = data_dir / "meta"
+        decay = pl.read_parquet(meta_dir / "decay.parquet")
+        # Add Sc-44 ground state (state="")
+        sc44 = pl.DataFrame({
+            "Z": [21], "A": [44], "state": [""],
+            "half_life_s": [14551.0], "decay_mode": ["beta+"],
+            "daughter_Z": [20], "daughter_A": [44],
+            "daughter_state": [""], "branching": [1.0],
+        }).cast({"Z": pl.Int32, "A": pl.Int32, "daughter_Z": pl.Int32, "daughter_A": pl.Int32})
+        pl.concat([decay, sc44]).write_parquet(meta_dir / "decay.parquet")
+
+        store = DataStore(data_dir, library="test-lib")
+        # Lookup with "g" should find ground state stored as ""
+        dd = store.get_decay_data(21, 44, "g")
+        assert dd is not None
+        assert dd.half_life_s == pytest.approx(14551.0)
+        # Direct "" should also work
+        assert store.get_decay_data(21, 44, "").half_life_s == pytest.approx(14551.0)
+        # "m" should not match ground
+        assert store.get_decay_data(21, 44, "m") is None
 
 
 class TestGetElement:


### PR DESCRIPTION
## Summary

Python-side mirror of the Rust/TS fix from PR #253.

- **`get_decay_data()`**: normalize `state="g"` → `""` before filtering, matching the xs→decay convention difference
- **`get_cross_sections()`**: drop total (`state=""`) when state-resolved (`"g"`/`"m"`) entries exist for the same residual, preventing double-counting

## Test plan

- [x] 17 Python tests pass (3 new: g→'' normalization, dedup with resolved, total kept when no resolved)
- [x] Existing tests updated for new dedup behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)