### PR TITLE
feat: catalog.json as SSoT for data file discovery (#257)

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -224,9 +224,69 @@ use std::sync::Mutex;
 use arrow::array::Array;
 use crate::types::DecayMode;
 
+/// Catalog-derived path resolver for meta/stopping files (#257).
+///
+/// Reads `catalog.json` once and resolves file paths from the `shared`
+/// section, falling back to hardcoded defaults if the catalog is absent
+/// or missing a field.
+struct CatalogPaths {
+    meta_dir: PathBuf,
+    stopping_dir: PathBuf,
+    meta_files: HashMap<String, String>,
+}
+
+impl CatalogPaths {
+    fn from_data_dir(data_dir: &Path) -> Self {
+        let catalog_path = data_dir.join("catalog.json");
+        if let Ok(text) = std::fs::read_to_string(&catalog_path) {
+            if let Ok(cat) = serde_json::from_str::<serde_json::Value>(&text) {
+                let shared = &cat["shared"];
+                let meta_path = shared["meta"]["path"].as_str().unwrap_or("meta/");
+                let stop_path = shared["stopping"]["path"].as_str().unwrap_or("stopping/");
+                let mut meta_files = HashMap::new();
+                if let Some(files) = shared["meta"]["files"].as_object() {
+                    for (key, val) in files {
+                        if let Some(s) = val.as_str() {
+                            meta_files.insert(key.clone(), s.to_string());
+                        }
+                    }
+                }
+                return Self {
+                    meta_dir: data_dir.join(meta_path),
+                    stopping_dir: data_dir.join(stop_path),
+                    meta_files,
+                };
+            }
+        }
+        // Fallback: hardcoded defaults
+        Self {
+            meta_dir: data_dir.join("meta"),
+            stopping_dir: data_dir.join("stopping"),
+            meta_files: HashMap::new(),
+        }
+    }
+
+    fn meta_file(&self, name: &str) -> PathBuf {
+        let filename = self.meta_files
+            .get(name)
+            .cloned()
+            .unwrap_or_else(|| format!("{}.parquet", name));
+        self.meta_dir.join(filename)
+    }
+
+    fn stopping_file(&self, source: &str) -> PathBuf {
+        self.stopping_dir.join(format!("{}.parquet", source))
+    }
+
+    fn stopping_compounds_dir(&self) -> PathBuf {
+        self.stopping_dir.join("compounds")
+    }
+}
+
 /// Parquet-backed nuclear data store.
 pub struct ParquetDataStore {
     data_dir: PathBuf,
+    catalog: CatalogPaths,
     pub library: String,
     // Eagerly loaded at startup
     elements: HashMap<u32, String>,
@@ -250,9 +310,11 @@ impl ParquetDataStore {
         library: &str,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let data_dir = data_dir.as_ref().to_path_buf();
+        let catalog = CatalogPaths::from_data_dir(&data_dir);
 
         let mut store = Self {
             data_dir,
+            catalog,
             library: library.to_string(),
             elements: HashMap::new(),
             symbol_to_z: HashMap::new(),
@@ -281,7 +343,7 @@ impl ParquetDataStore {
         // Mark as attempted immediately so we don't retry on error
         guard.1.insert(source.to_string());
 
-        let path = self.data_dir.join("stopping").join(format!("{}.parquet", source));
+        let path = self.catalog.stopping_file(source);
         if !path.exists() {
             return;
         }
@@ -321,7 +383,7 @@ impl ParquetDataStore {
         guard.1 = true;
 
         for filename in &["PSTAR_compounds.parquet", "ASTAR_compounds.parquet"] {
-            let path = self.data_dir.join("stopping").join("compounds").join(filename);
+            let path = self.catalog.stopping_compounds_dir().join(filename);
             if !path.exists() { continue; }
             let file = match std::fs::File::open(&path) {
                 Ok(f) => f,
@@ -354,7 +416,7 @@ impl ParquetDataStore {
     }
 
     fn load_elements(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let path = self.data_dir.join("meta").join("elements.parquet");
+        let path = self.catalog.meta_file("elements");
         if !path.exists() {
             return Ok(());
         }
@@ -386,7 +448,7 @@ impl ParquetDataStore {
     }
 
     fn load_abundances(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let path = self.data_dir.join("meta").join("abundances.parquet");
+        let path = self.catalog.meta_file("abundances");
         if !path.exists() {
             return Ok(());
         }
@@ -417,7 +479,7 @@ impl ParquetDataStore {
     }
 
     fn load_decay(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let path = self.data_dir.join("meta").join("decay.parquet");
+        let path = self.catalog.meta_file("decay");
         if !path.exists() {
             return Ok(());
         }
@@ -481,7 +543,7 @@ impl ParquetDataStore {
 
 
     fn load_dose_constants(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        let path = self.data_dir.join("meta").join("dose_constants.parquet");
+        let path = self.catalog.meta_file("dose_constants");
         if !path.exists() {
             return Ok(());
         }

--- a/data/parquet/catalog.json
+++ b/data/parquet/catalog.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./catalog.schema.json",
-  "version": 1,
+  "version": 2,
   "data_version": "2026.5.4",
   "data_sha256": "a4edf294f82c4b540c7fbe443a97e2c793a05bee08c256a89224c261377fbfb3",
   "description": "Registry of available nuclear data libraries",
@@ -270,7 +270,10 @@
         "compound_compositions": "compound_compositions.parquet",
         "nudex_shellcor": "nudex_shellcor.parquet",
         "nudex_special_inputs": "nudex_special_inputs.parquet",
-        "nudex_general_stat": "nudex_general_stat.parquet"
+        "nudex_general_stat": "nudex_general_stat.parquet",
+        "dose_constants": "dose_constants.parquet",
+        "decay_detailed": "decay_detailed.parquet",
+        "nudex_level_gammas": "nudex_level_gammas.parquet"
       },
       "spectrum_xs_note": "Spectrum-averaged neutron XS for thermal (Maxwellian kT=0.0253eV), epithermal (1/E), and fast (Watt fission) spectra. Built by nucl_parquet.build_spectrum_xs.",
       "compound_compositions_note": "Elemental compositions (Z, weight_fraction) for the 33 NIST XCOM standard materials (water, air, tissue, bone, plastics, glasses, …). One row per (material, Z); weight fractions sum to 1.0 ± 1e-6 per material. Source: NIST XCOM Table 4 + ICRU-44. Join on `material` to xcom_compounds (integrated µ/ρ) or to photon_pe_total/photon_compton/photon_pair for Bragg-additive per-process σ. Built by nucl_parquet.build_compound_compositions.",

--- a/docs/adr/0002-catalog-ssot-data-layout.md
+++ b/docs/adr/0002-catalog-ssot-data-layout.md
@@ -1,0 +1,68 @@
+# ADR 0002 — catalog.json as SSoT for nuclear data file discovery
+
+- **Status**: accepted
+- **Date**: 2026-05-21
+- **Implements**: #257
+
+## Context
+
+HYRR has three runtime clients consuming nuclear data from parquet files:
+
+- **Rust** (`core/src/db.rs`) — Tauri desktop + WASM + MCP
+- **TypeScript** (`packages/compute/src/data-store.ts`, `node-data-store.ts`) — browser frontend + Node CLI
+- **Python** (`src/hyrr/db.py`) — library + notebooks + CLI
+
+All three hardcoded paths like `meta/decay.parquet`, `stopping/stopping.parquet`,
+`{library}/xs/{proj}_{El}.parquet`. When nucl-parquet shipped per-source stopping
+files (data-2026.5.1) and library-prefixed xs (data-2026.5.4), each client needed
+manual patching. Python lacked dose_constants and emission data entirely. Adding a
+new meta file required editing 3+ codebases.
+
+Meanwhile, `catalog.json` already existed in nucl-parquet with a `shared.meta.files`
+manifest and `shared.stopping.sources` list — but no client read it.
+
+## Decision
+
+**Make `catalog.json` the single surface all clients read for discovering data file
+paths.** One hardcoded path (the catalog location), everything else resolved from it.
+
+### Schema extension (catalog version 2)
+
+Add `dose_constants`, `decay_detailed`, and `nudex_level_gammas` to `shared.meta.files`.
+The existing `shared.stopping.sources` and `shared.stopping.path` are already usable.
+
+### Client changes
+
+- **Rust**: `CatalogPaths` struct reads catalog once, provides `meta_file(name)`,
+  `stopping_file(source)`, `stopping_compounds_dir()`. Falls back to hardcoded
+  defaults if catalog absent.
+- **TypeScript**: `metaUrl(name)`, `stoppingUrl(source)`, `emissionsPath()` resolve
+  from `this.catalog` loaded at init. Stopping source list read from catalog.
+- **Python**: `_resolve_meta(name)` and `_resolve_stopping()` read from catalog.
+  Lazy-load all DataFrames via properties. New `get_dose_constant()` method.
+
+### Backward compatibility
+
+All three clients fall back to hardcoded paths if `catalog.json` is absent or
+missing fields. Existing data directories without a catalog continue to work.
+
+## Alternatives considered
+
+### Column-level schema introspection
+Over-engineering for 20-30 files. The file-level manifest grouped by role is the
+right granularity.
+
+### Directory-convention-only (no manifest)
+What we had. Already drifting — Python needed a concatenated `stopping.parquet`
+shim that Rust didn't, TS loaded emissions from a path Python didn't know about.
+
+### Strict schema validation (JSON Schema enforcement on load)
+The catalog is an internal contract, not a public API. Version check + fallback
+is sufficient. Adding JSON Schema validation would add a dependency for no gain.
+
+## Consequences
+
+- Adding a new meta file = one catalog entry in nucl-parquet, zero code changes in hyrr
+- Python notebooks now have `db.get_dose_constant(Z, A, state)` for the first time
+- Phase 2 (follow-up): remove vendored `data/parquet/` from git, all clients download
+  on demand like Rust already does — saves ~117MB per version from git history

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -146,9 +146,16 @@ export class DataStore implements DatabaseProtocol {
     this.baseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   }
 
+  /** Normalize a path segment to end with '/'. */
+  private static ensureTrailingSlash(p: string): string {
+    return p.endsWith("/") ? p : `${p}/`;
+  }
+
   /** Resolve a meta file URL via catalog, with hardcoded fallback. */
   private metaUrl(name: string): string {
-    const metaPath = this.catalog?.shared?.meta?.path ?? "meta/";
+    const metaPath = DataStore.ensureTrailingSlash(
+      this.catalog?.shared?.meta?.path ?? "meta/",
+    );
     const files = this.catalog?.shared?.meta?.files as Record<string, string> | undefined;
     const filename = files?.[name] ?? `${name}.parquet`;
     return `${this.baseUrl}/${metaPath}${filename}`;
@@ -156,7 +163,9 @@ export class DataStore implements DatabaseProtocol {
 
   /** Resolve a stopping file URL via catalog, with hardcoded fallback. */
   private stoppingUrl(source: string): string {
-    const stopPath = this.catalog?.shared?.stopping?.path ?? "stopping/";
+    const stopPath = DataStore.ensureTrailingSlash(
+      this.catalog?.shared?.stopping?.path ?? "stopping/",
+    );
     return `${this.baseUrl}/${stopPath}${source}.parquet`;
   }
 
@@ -273,7 +282,9 @@ export class DataStore implements DatabaseProtocol {
 
   /** Resolve the emissions directory path via catalog. */
   private emissionsPath(): string {
-    const emPath = this.catalog?.shared?.emissions?.path ?? "meta/ensdf/emissions/";
+    const emPath = DataStore.ensureTrailingSlash(
+      this.catalog?.shared?.emissions?.path ?? "meta/ensdf/emissions/",
+    );
     return `${this.baseUrl}/${emPath}`;
   }
 

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -146,10 +146,35 @@ export class DataStore implements DatabaseProtocol {
     this.baseUrl = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
   }
 
-  /** Initialize by loading meta + stopping tables. Must be called before use. */
+  /** Resolve a meta file URL via catalog, with hardcoded fallback. */
+  private metaUrl(name: string): string {
+    const metaPath = this.catalog?.shared?.meta?.path ?? "meta/";
+    const files = this.catalog?.shared?.meta?.files as Record<string, string> | undefined;
+    const filename = files?.[name] ?? `${name}.parquet`;
+    return `${this.baseUrl}/${metaPath}${filename}`;
+  }
+
+  /** Resolve a stopping file URL via catalog, with hardcoded fallback. */
+  private stoppingUrl(source: string): string {
+    const stopPath = this.catalog?.shared?.stopping?.path ?? "stopping/";
+    return `${this.baseUrl}/${stopPath}${source}.parquet`;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private catalog: any = null;
+
+  /** Initialize by loading catalog + meta + stopping tables. Must be called before use. */
   async init(onProgress?: (msg: string, fraction?: number) => void): Promise<void> {
+    // Load catalog.json — SSoT for data file discovery (#257)
+    try {
+      const catResp = await fetch(`${this.baseUrl}/catalog.json`);
+      if (catResp.ok) this.catalog = await catResp.json();
+    } catch {
+      // No catalog — fall back to hardcoded paths
+    }
+
     onProgress?.("Loading element data...", 0);
-    const elements = await readParquetRows(`${this.baseUrl}/meta/elements.parquet`);
+    const elements = await readParquetRows(this.metaUrl("elements"));
     for (const row of elements) {
       const Z = Number(row.Z);
       const symbol = String(row.symbol);
@@ -158,14 +183,14 @@ export class DataStore implements DatabaseProtocol {
     }
 
     onProgress?.("Loading abundance data...", 0.25);
-    this.abundanceData = await readParquetRows(`${this.baseUrl}/meta/abundances.parquet`);
+    this.abundanceData = await readParquetRows(this.metaUrl("abundances"));
 
     onProgress?.("Loading decay data...", 0.5);
-    this.decayData = await readParquetRows(`${this.baseUrl}/meta/decay.parquet`);
+    this.decayData = await readParquetRows(this.metaUrl("decay"));
 
     onProgress?.("Loading dose constants...", 0.65);
     try {
-      const doseRows = await readParquetRows(`${this.baseUrl}/meta/dose_constants.parquet`);
+      const doseRows = await readParquetRows(this.metaUrl("dose_constants"));
       for (const row of doseRows) {
         const key = `${row.Z}_${row.A}_${row.state ?? ""}`;
         this.doseConstants.set(key, {
@@ -178,24 +203,17 @@ export class DataStore implements DatabaseProtocol {
     }
 
     onProgress?.("Loading stopping power data...", 0.7);
-    // Light-ion sources (PSTAR, ASTAR, dSTAR, tSTAR) plus heavy-ion
-    // catima pre-split tables (catima_C12, catima_O16, …). The catima
-    // files have the same (source, target_Z, energy_MeV, dedx) schema
-    // as the light-ion files — added in nucl-parquet data-2026.5.1.
-    //
-    // He3STAR removed in data-2026.5.0: ³He routes through ASTAR with
-    // velocity-scaling (E × 4/3). See _energy-loss.ts.
-    const stoppingSources = [
-      // Light ions
-      "PSTAR", "ASTAR", "dSTAR", "tSTAR",
-      // Heavy ions — pre-split catima tables (synced with
-      // BUNDLED_CATIMA_PROJECTILES in core/src/stopping.rs)
-      "catima_C12", "catima_O16", "catima_Ne20",
-      "catima_Si28", "catima_Ar40", "catima_Fe56",
-    ];
+    // Resolve stopping sources from catalog, with hardcoded fallback
+    const catalogSources: string[] =
+      (this.catalog?.shared?.stopping?.sources as string[]) ?? [];
+    const stoppingSources = catalogSources.length > 0
+      ? catalogSources
+      : ["PSTAR", "ASTAR", "dSTAR", "tSTAR",
+         "catima_C12", "catima_O16", "catima_Ne20",
+         "catima_Si28", "catima_Ar40", "catima_Fe56"];
     const stoppingFiles = await Promise.all(
       stoppingSources.map((src) =>
-        readParquetRows(`${this.baseUrl}/stopping/${src}.parquet`).catch(() => [] as ParquetRow[]),
+        readParquetRows(this.stoppingUrl(src)).catch(() => [] as ParquetRow[]),
       ),
     );
     for (const rows of stoppingFiles) {
@@ -210,13 +228,12 @@ export class DataStore implements DatabaseProtocol {
       bucket.push(row);
     }
 
-    // Load NIST compound stopping tables (PSTAR/ASTAR compounds).
-    // Schema: { source, compound, energy_MeV, dedx } — keyed by compound
-    // name, not target_Z. (#193)
+    // Load NIST compound stopping tables
+    const stopPath = this.catalog?.shared?.stopping?.path ?? "stopping/";
     const compoundSources = ["compounds/PSTAR_compounds", "compounds/ASTAR_compounds"];
     const compoundFiles = await Promise.all(
       compoundSources.map((src) =>
-        readParquetRows(`${this.baseUrl}/stopping/${src}.parquet`).catch(() => [] as ParquetRow[]),
+        readParquetRows(`${this.baseUrl}/${stopPath}${src}.parquet`).catch(() => [] as ParquetRow[]),
       ),
     );
     for (const rows of compoundFiles) {
@@ -254,18 +271,25 @@ export class DataStore implements DatabaseProtocol {
     await Promise.all(promises);
   }
 
+  /** Resolve the emissions directory path via catalog. */
+  private emissionsPath(): string {
+    const emPath = this.catalog?.shared?.emissions?.path ?? "meta/ensdf/emissions/";
+    return `${this.baseUrl}/${emPath}`;
+  }
+
   /** Load emissions for elements by symbol (lazy, idempotent).
-   *  Fetches `meta/ensdf/emissions/{Symbol}.parquet` for each new symbol. */
+   *  Fetches emissions/{Symbol}.parquet for each new symbol. */
   async ensureEmissions(symbols: string[]): Promise<void> {
     const toLoad = symbols.filter((s) => !this.emissionLoadedSymbols.has(s));
     if (toLoad.length === 0) return;
 
+    const emBase = this.emissionsPath();
     await Promise.all(
       toLoad.map(async (symbol) => {
         this.emissionLoadedSymbols.add(symbol);
         try {
           const rows = await readParquetRows(
-            `${this.baseUrl}/meta/ensdf/emissions/${symbol}.parquet`,
+            `${emBase}${symbol}.parquet`,
           );
           // Aggregate same-energy lines across decay modes.
           // The upstream data has one row per (decay_mode, transition) —

--- a/packages/compute/src/node-data-store.ts
+++ b/packages/compute/src/node-data-store.ts
@@ -112,6 +112,9 @@ export class NodeDataStore implements DatabaseProtocol {
 
   private initialized = false;
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private catalog: any = null;
+
   constructor(dataDir: string) {
     this.dataDir = dataDir.endsWith("/") ? dataDir.slice(0, -1) : dataDir;
   }
@@ -125,11 +128,38 @@ export class NodeDataStore implements DatabaseProtocol {
     throw new Error(`Cannot find ${name}/ directory in ${this.dataDir} or its parent`);
   }
 
+  /** Resolve a meta file path via catalog, with hardcoded fallback. */
+  private metaFile(name: string): string {
+    const metaPath = this.catalog?.shared?.meta?.path ?? "meta/";
+    const files = this.catalog?.shared?.meta?.files as Record<string, string> | undefined;
+    const filename = files?.[name] ?? `${name}.parquet`;
+    // Try catalog-resolved path first, fall back to resolveSharedDir
+    const catalogPath = join(this.dataDir, metaPath, filename);
+    if (existsSync(catalogPath)) return catalogPath;
+    const sharedPath = join(this.resolveSharedDir("meta"), filename);
+    return sharedPath;
+  }
+
   async init(onProgress?: (msg: string, fraction?: number) => void): Promise<void> {
-    const metaDir = this.resolveSharedDir("meta");
+    // Load catalog.json — SSoT for data file discovery (#257)
+    try {
+      const catPath = join(this.dataDir, "..", "catalog.json");
+      if (existsSync(catPath)) {
+        const text = await readFile(catPath, "utf-8");
+        this.catalog = JSON.parse(text);
+      } else {
+        const catLocal = join(this.dataDir, "catalog.json");
+        if (existsSync(catLocal)) {
+          const text = await readFile(catLocal, "utf-8");
+          this.catalog = JSON.parse(text);
+        }
+      }
+    } catch {
+      // No catalog — fall back to hardcoded paths
+    }
 
     onProgress?.("Loading element data...", 0);
-    const elementsPath = join(metaDir, "elements.parquet");
+    const elementsPath = this.metaFile("elements");
     if (existsSync(elementsPath)) {
       const elements = await readParquetFile(elementsPath);
       for (const row of elements) {
@@ -141,14 +171,14 @@ export class NodeDataStore implements DatabaseProtocol {
     }
 
     onProgress?.("Loading abundance data...", 0.25);
-    this.abundanceData = await readParquetFile(join(metaDir, "abundances.parquet"));
+    this.abundanceData = await readParquetFile(this.metaFile("abundances"));
 
     onProgress?.("Loading decay data...", 0.5);
-    this.decayData = await readParquetFile(join(metaDir, "decay.parquet"));
+    this.decayData = await readParquetFile(this.metaFile("decay"));
 
     onProgress?.("Loading dose constants...", 0.65);
     try {
-      const doseRows = await readParquetFile(join(metaDir, "dose_constants.parquet"));
+      const doseRows = await readParquetFile(this.metaFile("dose_constants"));
       for (const row of doseRows) {
         const key = `${row.Z}_${row.A}_${row.state ?? ""}`;
         this.doseConstants.set(key, {
@@ -157,7 +187,7 @@ export class NodeDataStore implements DatabaseProtocol {
         });
       }
     } catch {
-      // dose_constants.parquet may not exist in all libraries
+      // dose_constants.parquet may not exist in all data sets
     }
 
     onProgress?.("Loading stopping power data...", 0.75);

--- a/src/hyrr/db.py
+++ b/src/hyrr/db.py
@@ -83,6 +83,18 @@ class DatabaseProtocol(Protocol):
         """
         ...
 
+    def get_dose_constant(
+        self,
+        Z: int,
+        A: int,
+        state: str = "",
+    ) -> tuple[float, str] | None:
+        """Get gamma dose rate constant k (µSv·m²/MBq·h) and source quality tag.
+
+        Returns None if not available.
+        """
+        ...
+
     def get_element_symbol(self, Z: int) -> str:
         """Get element symbol from atomic number."""
         ...
@@ -280,6 +292,9 @@ class DataStore:
             msg = f"Data directory not found: {self._data_dir}"
             raise FileNotFoundError(msg)
 
+        # Load catalog.json — SSoT for data file discovery (#257)
+        self._catalog = load_catalog(self._data_dir)
+
         self._library = library
         self._xs_dir = self._data_dir / library / "xs"
         if not self._xs_dir.is_dir():
@@ -289,18 +304,9 @@ class DataStore:
             )
             raise FileNotFoundError(msg)
 
-        # Eagerly load small metadata tables
+        # Elements are eagerly loaded (needed for all lookups)
         self._elements: pl.DataFrame = pl.read_parquet(
-            self._data_dir / "meta" / "elements.parquet"
-        )
-        self._abundances: pl.DataFrame = pl.read_parquet(
-            self._data_dir / "meta" / "abundances.parquet"
-        )
-        self._decay: pl.DataFrame = pl.read_parquet(
-            self._data_dir / "meta" / "decay.parquet"
-        )
-        self._stopping: pl.DataFrame = pl.read_parquet(
-            self._data_dir / "stopping" / "stopping.parquet"
+            self._resolve_meta("elements")
         )
 
         # Build element lookup dicts from the elements table
@@ -313,6 +319,12 @@ class DataStore:
         )
         self._symbol_to_z: dict[str, int] = {s: z for z, s in self._z_to_symbol.items()}
 
+        # Lazy-loaded DataFrames — populated on first access
+        self._abundances: pl.DataFrame | None = None
+        self._decay: pl.DataFrame | None = None
+        self._stopping: pl.DataFrame | None = None
+        self._dose_constants: pl.DataFrame | None = None
+
         # Lazy-loaded cross-section DataFrames: (projectile, symbol) -> DataFrame
         self._xs_cache: dict[str, pl.DataFrame] = {}
 
@@ -321,6 +333,55 @@ class DataStore:
             tuple[str, int],
             tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]],
         ] = {}
+
+    def _resolve_meta(self, name: str) -> Path:
+        """Resolve a meta file path via catalog, with hardcoded fallback."""
+        shared = self._catalog.get("shared", {})
+        meta = shared.get("meta", {})
+        meta_path = meta.get("path", "meta/")
+        files = meta.get("files", {})
+        filename = files.get(name, f"{name}.parquet")
+        return self._data_dir / meta_path / filename
+
+    def _resolve_stopping(self) -> Path:
+        """Resolve the concatenated stopping file path via catalog."""
+        shared = self._catalog.get("shared", {})
+        stopping = shared.get("stopping", {})
+        stop_path = stopping.get("path", "stopping/")
+        # Prefer concatenated stopping.parquet for Python compatibility
+        return self._data_dir / stop_path / "stopping.parquet"
+
+    @property
+    def abundances(self) -> pl.DataFrame:
+        """Natural isotopic abundances (lazy-loaded)."""
+        if self._abundances is None:
+            self._abundances = pl.read_parquet(self._resolve_meta("abundances"))
+        return self._abundances
+
+    @property
+    def decay(self) -> pl.DataFrame:
+        """Decay data (lazy-loaded)."""
+        if self._decay is None:
+            self._decay = pl.read_parquet(self._resolve_meta("decay"))
+        return self._decay
+
+    @property
+    def stopping(self) -> pl.DataFrame:
+        """Stopping power data (lazy-loaded)."""
+        if self._stopping is None:
+            self._stopping = pl.read_parquet(self._resolve_stopping())
+        return self._stopping
+
+    @property
+    def dose_constants(self) -> pl.DataFrame | None:
+        """Dose constants (lazy-loaded). None if file not available."""
+        if self._dose_constants is None:
+            path = self._resolve_meta("dose_constants")
+            if path.exists():
+                self._dose_constants = pl.read_parquet(path)
+            else:
+                return None
+        return self._dose_constants
 
     # -- context manager -----------------------------------------------------
 
@@ -430,7 +491,7 @@ class DataStore:
         if key in self._sp_cache:
             return self._sp_cache[key]
 
-        filtered = self._stopping.filter(
+        filtered = self.stopping.filter(
             (pl.col("source") == source) & (pl.col("target_Z") == target_Z)
         ).sort("energy_MeV")
 
@@ -445,7 +506,7 @@ class DataStore:
         Z: int,
     ) -> dict[int, tuple[float, float]]:
         """Get natural isotopic abundances for an element."""
-        filtered = self._abundances.filter(pl.col("Z") == Z)
+        filtered = self.abundances.filter(pl.col("Z") == Z)
         return {
             int(row["A"]): (float(row["abundance"]), float(row["atomic_mass"]))
             for row in filtered.iter_rows(named=True)
@@ -461,7 +522,7 @@ class DataStore:
         # Normalize "g" → "" — xs data uses "g" for ground-state products,
         # but decay data uses "" for ground state (#254).
         norm = "" if state == "g" else state
-        filtered = self._decay.filter(
+        filtered = self.decay.filter(
             (pl.col("Z") == Z) & (pl.col("A") == A) & (pl.col("state") == norm)
         )
         if filtered.is_empty():
@@ -485,6 +546,29 @@ class DataStore:
             half_life_s=rows[0]["half_life_s"],
             decay_modes=modes,
         )
+
+    def get_dose_constant(
+        self,
+        Z: int,
+        A: int,
+        state: str = "",
+    ) -> tuple[float, str] | None:
+        """Get gamma dose rate constant k (µSv·m²/MBq·h) and source quality tag.
+
+        Returns None if dose_constants.parquet is not available or the nuclide
+        is not found. Normalizes state='g' → '' for ground-state lookups (#254).
+        """
+        dc = self.dose_constants
+        if dc is None:
+            return None
+        norm = "" if state == "g" else state
+        filtered = dc.filter(
+            (pl.col("Z") == Z) & (pl.col("A") == A) & (pl.col("state") == norm)
+        )
+        if filtered.is_empty():
+            return None
+        row = filtered.row(0, named=True)
+        return (float(row["k_uSv_m2_MBq_h"]), str(row.get("source", "ensdf")))
 
     def get_element_symbol(self, Z: int) -> str:
         """Get element symbol from atomic number."""

--- a/src/hyrr/db.py
+++ b/src/hyrr/db.py
@@ -324,6 +324,7 @@ class DataStore:
         self._decay: pl.DataFrame | None = None
         self._stopping: pl.DataFrame | None = None
         self._dose_constants: pl.DataFrame | None = None
+        self._dose_constants_checked = False
 
         # Lazy-loaded cross-section DataFrames: (projectile, symbol) -> DataFrame
         self._xs_cache: dict[str, pl.DataFrame] = {}
@@ -375,12 +376,11 @@ class DataStore:
     @property
     def dose_constants(self) -> pl.DataFrame | None:
         """Dose constants (lazy-loaded). None if file not available."""
-        if self._dose_constants is None:
+        if not self._dose_constants_checked:
+            self._dose_constants_checked = True
             path = self._resolve_meta("dose_constants")
             if path.exists():
                 self._dose_constants = pl.read_parquet(path)
-            else:
-                return None
         return self._dose_constants
 
     # -- context manager -----------------------------------------------------

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -261,6 +261,73 @@ class TestGetElement:
             db.get_element_Z("Xx")
 
 
+class TestCatalogDriven:
+    """Tests for catalog.json-driven data discovery (#257)."""
+
+    def test_lazy_loading_defers_parquet_reads(self, data_dir) -> None:
+        """DataStore init should not load decay/abundances/stopping eagerly."""
+        store = DataStore(data_dir, library="test-lib")
+        # Internal state should be None until first access
+        assert store._abundances is None
+        assert store._decay is None
+        assert store._stopping is None
+        # Accessing the property triggers the load
+        assert len(store.abundances) > 0
+        assert store._abundances is not None
+
+    def test_catalog_resolves_meta_paths(self, data_dir) -> None:
+        """With a catalog.json, meta paths are resolved from it."""
+        # Write a catalog that remaps elements to a custom filename
+        import json
+        catalog = {
+            "version": 2,
+            "shared": {
+                "meta": {
+                    "path": "meta/",
+                    "files": {
+                        "elements": "elements.parquet",
+                        "abundances": "abundances.parquet",
+                        "decay": "decay.parquet",
+                    }
+                },
+                "stopping": {"path": "stopping/"},
+            },
+            "libraries": {},
+        }
+        (data_dir / "catalog.json").write_text(json.dumps(catalog))
+        store = DataStore(data_dir, library="test-lib")
+        # Should load fine via catalog-resolved paths
+        assert store.get_element_symbol(42) == "Mo"
+
+    def test_dose_constant_returns_none_when_missing(self, db: DataStore) -> None:
+        """get_dose_constant returns None when dose_constants.parquet doesn't exist."""
+        assert db.get_dose_constant(21, 44) is None
+
+    def test_dose_constant_loads_when_available(self, data_dir) -> None:
+        """get_dose_constant works when dose_constants.parquet is present."""
+        meta_dir = data_dir / "meta"
+        pl.DataFrame({
+            "Z": [21, 21],
+            "A": [44, 44],
+            "state": ["", "m"],
+            "k_uSv_m2_MBq_h": [0.153, 0.0],
+            "source": ["ensdf", "zero"],
+        }).cast({"Z": pl.Int32, "A": pl.Int32}).write_parquet(
+            meta_dir / "dose_constants.parquet"
+        )
+        store = DataStore(data_dir, library="test-lib")
+        # Ground state lookup
+        result = store.get_dose_constant(21, 44)
+        assert result is not None
+        k, source = result
+        assert k == pytest.approx(0.153)
+        assert source == "ensdf"
+        # state='g' normalizes to ''
+        result_g = store.get_dose_constant(21, 44, "g")
+        assert result_g is not None
+        assert result_g[0] == pytest.approx(0.153)
+
+
 class TestContextManager:
     """Tests for context manager lifecycle."""
 


### PR DESCRIPTION
## Summary

Makes `catalog.json` the single manifest all three clients (Rust, TS, Python) read for discovering data file paths — replacing 12+ hardcoded path strings across 3 codebases.

### Changes by layer

- **catalog.json** (v2): added `dose_constants`, `decay_detailed`, `nudex_level_gammas` to `shared.meta.files`
- **Python `db.py`**: lazy-load all DataFrames via properties (init only loads elements). Catalog-driven `_resolve_meta()` / `_resolve_stopping()`. New `get_dose_constant(Z, A, state)` on Protocol + DataStore.
- **Rust `db.rs`**: `CatalogPaths` struct reads catalog once, provides `meta_file()` / `stopping_file()` / `stopping_compounds_dir()`. Replaces 6 hardcoded paths.
- **TS `data-store.ts`**: `metaUrl()` / `stoppingUrl()` / `emissionsPath()` resolve from catalog. Stopping source list from `shared.stopping.sources`.
- **TS `node-data-store.ts`**: same catalog-driven `metaFile()` resolution.
- **ADR-0002**: documents the decision, alternatives, and Phase 2 follow-up.

### Backward compatible
All clients fall back to hardcoded defaults if catalog.json is absent.

## Test plan

- [x] 21 Python tests (4 new: lazy loading, catalog resolution, dose_constant)
- [x] 4 Rust tests pass
- [x] 559 TS tests pass, svelte-check clean
- [x] End-to-end Sc-44 verification with both tendl libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)