### PR TITLE
fix: SSoT for DEFAULT_LIBRARY via hyrr.json

### DIFF
--- a/core/build.rs
+++ b/core/build.rs
@@ -24,11 +24,12 @@
 use std::path::Path;
 
 fn main() {
+    // --- DATA_VERSION from nucl-parquet submodule ---
     let catalog = Path::new("../nucl-parquet/data/catalog.json");
     println!("cargo:rerun-if-changed=../nucl-parquet/data/catalog.json");
 
     let version = match std::fs::read_to_string(catalog) {
-        Ok(s) => extract_data_version(&s).unwrap_or_else(|| {
+        Ok(s) => extract_json_string(&s, "data_version").unwrap_or_else(|| {
             println!(
                 "cargo:warning=core/build.rs: could not parse top-level \"data_version\" from {}; \
                  falling back to 0.0.0-unknown. Bump the submodule cleanly.",
@@ -45,22 +46,35 @@ fn main() {
             "0.0.0-unknown".to_string()
         }
     };
-
     println!("cargo:rustc-env=HYRR_DATA_VERSION={version}");
+
+    // --- DEFAULT_LIBRARY from hyrr.json (SSoT #269) ---
+    let hyrr_json = Path::new("../hyrr.json");
+    println!("cargo:rerun-if-changed=../hyrr.json");
+
+    let default_library = match std::fs::read_to_string(hyrr_json) {
+        Ok(s) => extract_json_string(&s, "default_library").unwrap_or_else(|| {
+            println!(
+                "cargo:warning=core/build.rs: could not parse \"default_library\" from hyrr.json; \
+                 falling back to tendl-2023-iso."
+            );
+            "tendl-2023-iso".to_string()
+        }),
+        Err(_) => {
+            println!(
+                "cargo:warning=core/build.rs: hyrr.json not found; falling back to tendl-2023-iso."
+            );
+            "tendl-2023-iso".to_string()
+        }
+    };
+    println!("cargo:rustc-env=HYRR_DEFAULT_LIBRARY={default_library}");
 }
 
-/// Tiny JSON walker — avoids pulling a `serde_json` build-dep for one
-/// string field. Matches the top-level `"data_version": "..."` pair.
-/// Tolerates whitespace variation around `:` and between the key and
-/// its value. JSON is unambiguous about string quoting (always `"`),
-/// so this is simpler than the previous hand-rolled TOML walker.
-fn extract_data_version(content: &str) -> Option<String> {
-    // Quick-and-dirty: scan for the `"data_version"` key, then read the
-    // following quoted string. Sufficient for a fixed top-level field
-    // in a generated catalog.json — we don't need to parse nested
-    // objects or escape sequences.
-    let key = "\"data_version\"";
-    let idx = content.find(key)?;
+/// Extract a top-level `"key": "value"` string from JSON without
+/// pulling a `serde_json` build-dep. Tolerates whitespace around `:`.
+fn extract_json_string(content: &str, field: &str) -> Option<String> {
+    let key = format!("\"{}\"", field);
+    let idx = content.find(&key)?;
     let rest = &content[idx + key.len()..];
     // Skip whitespace and the colon.
     let after_colon = rest.trim_start().strip_prefix(':')?.trim_start();

--- a/core/src/mcp/transport.rs
+++ b/core/src/mcp/transport.rs
@@ -67,10 +67,10 @@ const SERVER_NAME: &str = "hyrr";
 const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const PROTOCOL_VERSION: &str = "2024-11-05";
 
-/// Default nuclear data library when none is specified.
+/// Default nuclear data library — sourced from `hyrr.json` at build time (#269).
 /// tendl-2023-iso has full ground/metastable isomeric splitting;
 /// tendl-2025 dropped the g/m split entirely (#265).
-pub const DEFAULT_LIBRARY: &str = "tendl-2023-iso";
+pub const DEFAULT_LIBRARY: &str = env!("HYRR_DEFAULT_LIBRARY");
 
 /// Run the MCP stdio server loop with the default library.
 ///

--- a/frontend/src/lib/compute/data-fetch-meta.ts
+++ b/frontend/src/lib/compute/data-fetch-meta.ts
@@ -76,8 +76,10 @@ export async function getCacheRootPattern(): Promise<string | null> {
   return (await loadMeta())?.cacheRootPattern ?? null;
 }
 
-/** Default nuclear-data library identifier. Mirrors
- * `hyrr_core::mcp::transport::DEFAULT_LIBRARY`. Kept as a literal here so
- * non-Tauri (browser, Node) callers get a synchronous answer; if it ever
- * needs to vary, route through a `data_default_library` command. */
-export const DEFAULT_LIBRARY = "tendl-2023-iso";
+/** Default nuclear-data library identifier — injected at build time from
+ *  `hyrr.json::default_library` via Vite's `define` (#269). SSoT shared
+ *  with Rust (`core/build.rs` → `HYRR_DEFAULT_LIBRARY` env). */
+declare const __DEFAULT_LIBRARY__: string;
+export const DEFAULT_LIBRARY: string = typeof __DEFAULT_LIBRARY__ !== "undefined"
+  ? __DEFAULT_LIBRARY__
+  : "tendl-2023-iso"; // fallback for non-Vite contexts (tests, Node)

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, type Plugin } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { svelteTesting } from "@testing-library/svelte/vite";
 import pkg from "./package.json" with { type: "json" };
+import hyrrConfig from "../hyrr.json" with { type: "json" };
 
 // Web base path resolution:
 //   - Tauri bundle  → "./"               (relative; bundled webview)
@@ -56,6 +57,7 @@ export default defineConfig({
   base: resolvedBase,
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __DEFAULT_LIBRARY__: JSON.stringify(hyrrConfig.default_library),
   },
   resolve: {
     alias: process.env.TAURI_ENV_PLATFORM

--- a/hyrr.json
+++ b/hyrr.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "HYRR project-wide configuration — SSoT for values shared across Rust, TypeScript, Python, CI.",
+  "default_library": "tendl-2023-iso"
+}


### PR DESCRIPTION
## Summary

Adds `hyrr.json` at project root as the single source of truth for `default_library`:

```json
{ "default_library": "tendl-2023-iso" }
```

Read at build time by both ecosystems:
- **Rust**: `core/build.rs` → `env!("HYRR_DEFAULT_LIBRARY")` → `transport.rs::DEFAULT_LIBRARY`
- **TypeScript**: `vite.config.ts` → `__DEFAULT_LIBRARY__` define → `data-fetch-meta.ts`

Changing the default library is now a **one-file edit**. The old pattern required updating 32 files across 5 languages (PR #268).

## Test plan

- [x] `cargo test -- --include-ignored` — all pass, const resolves correctly
- [x] `svelte-check` — clean
- [ ] CI green

Fixes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)