### PR TITLE
fix: include 511 keV annihilation in emission plot + preset golden tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,34 @@ jobs:
           HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
         run: cargo test --test projectile_matrix -- --include-ignored
 
+  embedded-data-store:
+    # #274 — verify the embedded data store initializes, queries work,
+    # and a full simulation runs through the build-time tar.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: false
+      - name: Init nucl-parquet submodule (sparse)
+        run: |
+          git submodule update --init --depth 1 --filter=blob:none nucl-parquet
+          cd nucl-parquet
+          git sparse-checkout set \
+            data/catalog.json \
+            data/meta/abundances.parquet \
+            data/meta/decay.parquet \
+            data/meta/dose_constants.parquet \
+            data/meta/ensdf/emissions \
+            data/stopping \
+            data/tendl-2023-iso/xs
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: core
+      - name: Run EmbeddedDataStore tests (including full simulation)
+        working-directory: core
+        run: cargo test --features embed-data --test embedded_data_store
+
   hyrr-py-check:
     # Catches PyO3 binding type drift against hyrr-core (Refs: #181).
     # The py/ crate is excluded from the default workspace because the

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -45,14 +45,21 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set data/meta data/stopping data/tendl-2023-iso/xs
+          git sparse-checkout set \
+            data/catalog.json \
+            data/meta/abundances.parquet \
+            data/meta/decay.parquet \
+            data/meta/dose_constants.parquet \
+            data/meta/ensdf/emissions \
+            data/stopping \
+            data/tendl-2023-iso/xs
 
       - name: Copy parquet data to frontend public dir
         shell: bash
         run: |
           mkdir -p frontend/public/data/parquet/{xs,meta,stopping}
           cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/meta/*.parquet frontend/public/data/parquet/meta/
+          cp nucl-parquet/data/meta/*.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
           cp nucl-parquet/data/stopping/*.parquet frontend/public/data/parquet/stopping/
 
       - name: Install Rust

--- a/core/tests/embedded_data_store.rs
+++ b/core/tests/embedded_data_store.rs
@@ -1,0 +1,122 @@
+//! #274 — integration test for EmbeddedDataStore.
+//!
+//! Verifies the build-time tar was packed correctly and the embedded
+//! data store can initialize and serve basic queries. This test only
+//! runs when the `embed-data` feature is enabled.
+
+#![cfg(feature = "embed-data")]
+
+use hyrr_core::db::{DatabaseProtocol, EmbeddedDataStore};
+
+#[test]
+fn embedded_store_initializes() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso")
+        .expect("EmbeddedDataStore::new failed — tar may be corrupt or missing");
+
+    assert_eq!(db.library(), "tendl-2023-iso");
+}
+
+#[test]
+fn embedded_store_has_element_symbols() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    assert_eq!(db.get_element_symbol(1), "H");
+    assert_eq!(db.get_element_symbol(29), "Cu");
+    assert_eq!(db.get_element_symbol(42), "Mo");
+    assert_eq!(db.get_element_z("Cu"), 29);
+    assert_eq!(db.get_element_z("Mo"), 42);
+}
+
+#[test]
+fn embedded_store_has_abundances() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    let cu = db.get_natural_abundances(29);
+    assert!(!cu.is_empty(), "Cu should have natural abundances");
+    // Cu-63 and Cu-65 are the two stable isotopes
+    assert!(cu.contains_key(&63), "Cu-63 should be present");
+    assert!(cu.contains_key(&65), "Cu-65 should be present");
+    let cu63_frac = cu[&63].0;
+    assert!(cu63_frac > 0.68 && cu63_frac < 0.70, "Cu-63 abundance ~69%: got {cu63_frac}");
+}
+
+#[test]
+fn embedded_store_has_stopping_power() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    let (energies, dedx) = db.get_stopping_power("PSTAR", 29);
+    assert!(!energies.is_empty(), "PSTAR Cu stopping power should exist");
+    assert_eq!(energies.len(), dedx.len());
+    // Energies should be sorted ascending
+    for w in energies.windows(2) {
+        assert!(w[1] >= w[0], "energies not sorted: {} > {}", w[0], w[1]);
+    }
+}
+
+#[test]
+fn embedded_store_has_decay_data() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    // Tc-99m: Z=43, A=99, state="m" — classic medical isotope
+    let decay = db.get_decay_data(43, 99, "m");
+    assert!(decay.is_some(), "Tc-99m decay data should exist");
+    let d = decay.unwrap();
+    assert!(d.half_life_s.is_some());
+    let hl = d.half_life_s.unwrap();
+    // Tc-99m half-life: ~6.007 hours = ~21625 s
+    assert!(hl > 20000.0 && hl < 23000.0, "Tc-99m half-life ~21625s: got {hl}");
+}
+
+#[test]
+fn embedded_store_has_cross_sections() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    // p + Mo-100 → Tc-99m is the classic Tc-99m production route
+    let xs = db.get_cross_sections("p", 42, 100);
+    assert!(!xs.is_empty(), "p+Mo-100 cross-sections should exist");
+
+    // Should contain at least one product with residual Z=43 (Tc)
+    let has_tc = xs.iter().any(|x| x.residual_z == 43);
+    assert!(has_tc, "p+Mo-100 should produce Tc isotopes");
+}
+
+#[test]
+fn embedded_store_runs_full_simulation() {
+    let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+    use hyrr_core::compute::compute_stack;
+    use hyrr_core::materials::resolve_material;
+    use hyrr_core::types::*;
+
+    let resolution = resolve_material(&db, "Mo", None);
+    let layer = Layer {
+        density_g_cm3: resolution.density,
+        elements: resolution.elements,
+        thickness_cm: Some(0.1),
+        areal_density_g_cm2: None,
+        energy_out_mev: None,
+        is_monitor: false,
+        computed_energy_in: 0.0,
+        computed_energy_out: 0.0,
+        computed_thickness: 0.0,
+    };
+
+    let mut stack = TargetStack {
+        beam: Beam::new(ProjectileType::Proton, 16.0, 0.001),
+        layers: vec![layer],
+        irradiation_time_s: 3600.0,
+        cooling_time_s: 0.0,
+        area_cm2: 1.0,
+        current_profile: None,
+    };
+
+    let result = compute_stack(&db, &mut stack, true);
+    assert!(result.is_ok(), "compute_stack failed: {:?}", result.err());
+
+    let r = result.unwrap();
+    assert!(!r.layer_results.is_empty());
+    assert!(
+        !r.layer_results[0].isotope_results.is_empty(),
+        "should produce isotopes from p+Mo"
+    );
+}

--- a/core/tests/f18_production.rs
+++ b/core/tests/f18_production.rs
@@ -1,0 +1,98 @@
+//! Regression test: F-18 production from p + H2O-18 (enriched).
+//!
+//! This is the classic PET isotope production stack:
+//! p @ 18 MeV → havar window → H2O-18 (97% O-18 enrichment)
+//!
+//! The O-18(p,n)F-18 reaction at 274 mb peak must produce F-18.
+//! Zero production = critical bug that breaks the "feeling lucky" preset.
+
+#[cfg(feature = "embed-data")]
+mod tests {
+    use hyrr_core::compute::compute_stack;
+    use hyrr_core::db::{DatabaseProtocol, EmbeddedDataStore};
+    use hyrr_core::materials::resolve_material;
+    use hyrr_core::types::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn f18_from_enriched_h2o18() {
+        let db = EmbeddedDataStore::new("tendl-2023-iso").unwrap();
+
+        // Layer 1: havar window (25 µm)
+        let havar = resolve_material(&db, "havar", None);
+        let layer1 = Layer {
+            density_g_cm3: havar.density,
+            elements: havar.elements,
+            thickness_cm: Some(0.0025),
+            areal_density_g_cm2: None,
+            energy_out_mev: None,
+            is_monitor: false,
+            computed_energy_in: 0.0,
+            computed_energy_out: 0.0,
+            computed_thickness: 0.0,
+        };
+
+        // Layer 2: H2O-18 (97% O-18 enrichment, 3mm)
+        let mut enrichment: HashMap<String, HashMap<u32, f64>> = HashMap::new();
+        let mut o_override = HashMap::new();
+        o_override.insert(18, 0.97);
+        enrichment.insert("O".to_string(), o_override);
+        let h2o = resolve_material(&db, "H2O-18", Some(&enrichment));
+
+        eprintln!("H2O-18 resolution: density={}, elements:", h2o.density);
+        for (elem, frac) in &h2o.elements {
+            eprintln!("  Z={} ({}): frac={:.4}, isotopes={:?}",
+                elem.z, db.get_element_symbol(elem.z), frac, elem.isotopes);
+        }
+
+        let layer2 = Layer {
+            density_g_cm3: h2o.density,
+            elements: h2o.elements,
+            thickness_cm: Some(0.3),
+            areal_density_g_cm2: None,
+            energy_out_mev: None,
+            is_monitor: false,
+            computed_energy_in: 0.0,
+            computed_energy_out: 0.0,
+            computed_thickness: 0.0,
+        };
+
+        let mut stack = TargetStack {
+            beam: Beam::new(ProjectileType::Proton, 18.0, 0.04),
+            layers: vec![layer1, layer2],
+            irradiation_time_s: 7200.0,
+            cooling_time_s: 0.0,
+            area_cm2: 1.0,
+            current_profile: None,
+        };
+
+        let result = compute_stack(&db, &mut stack, true).unwrap();
+
+        // Layer 2 must have isotope results
+        assert!(
+            result.layer_results.len() >= 2,
+            "should have 2 layer results, got {}",
+            result.layer_results.len()
+        );
+
+        let l2 = &result.layer_results[1];
+        eprintln!("L2 isotopes: {} total", l2.isotope_results.len());
+        for (name, iso) in &l2.isotope_results {
+            if iso.activity_bq > 1e6 {
+                eprintln!("  {}: {:.2e} Bq", name, iso.activity_bq);
+            }
+        }
+
+        assert!(
+            !l2.isotope_results.is_empty(),
+            "L2 (H2O-18) should produce isotopes — got zero"
+        );
+
+        // F-18 must be present (Z=9, A=18)
+        let has_f18 = l2.isotope_results.keys().any(|name| {
+            name.contains("18") && name.contains("F") || name.contains("9-18")
+        });
+        assert!(has_f18, "F-18 must be produced from O-18(p,n)F-18. Isotopes: {:?}",
+            l2.isotope_results.keys().collect::<Vec<_>>());
+    }
+}

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ tauri-plugin-process = "2"
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-hyrr-core = { path = "../../core", features = ["mcp"] }
+hyrr-core = { path = "../../core", features = ["mcp", "embed-data"] }
 
 [profile.release]
 strip = true

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -3,7 +3,7 @@
 use std::sync::Mutex;
 
 use hyrr_core::compute::compute_stack;
-use hyrr_core::db::ParquetDataStore;
+use hyrr_core::db::EmbeddedDataStore;
 use hyrr_core::materials::resolve_material;
 use hyrr_core::production::generate_depth_profile;
 use hyrr_core::stopping::{
@@ -12,20 +12,13 @@ use hyrr_core::stopping::{
 use hyrr_core::types::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::Path;
 use tauri::State;
 
 // ---------------------------------------------------------------------------
 // Managed state
 // ---------------------------------------------------------------------------
 
-pub struct DataStoreState(pub Mutex<Option<ParquetDataStore>>);
-
-/// Resolved path to the bundled `data/` directory inside the Tauri
-/// resource dir. Set during `setup` when the installer bundle contains
-/// `data/meta/`. `init_data_store` reads directly from this path — no
-/// copy to a writable cache, no network fetch.
-pub struct BundledDataDir(pub Mutex<Option<String>>);
+pub struct DataStoreState(pub Mutex<Option<EmbeddedDataStore>>);
 
 // ---------------------------------------------------------------------------
 // JSON contract types — mirror packages/compute/src/config-bridge.ts
@@ -138,7 +131,7 @@ pub struct DepthPreviewPoint {
 // ---------------------------------------------------------------------------
 
 fn config_to_layers(
-    db: &ParquetDataStore,
+    db: &EmbeddedDataStore,
     config: &SimulationConfig,
 ) -> Vec<Layer> {
     config
@@ -183,29 +176,22 @@ fn layer_composition(layer: &Layer) -> Vec<(u32, f64)> {
 // Commands
 // ---------------------------------------------------------------------------
 
-/// Initialize the Parquet data store. Must be called before compute commands.
+/// Initialize the data store from embedded binary data.
 ///
-/// Resolution priority:
-/// 1. Explicit `data_dir` argument from the frontend (non-empty)
-/// 2. Bundled resource dir (set during `setup` — read-only, no copy)
-/// 3. `data_dir::resolve()` fallback (dev-tree sibling, env var, etc.)
+/// All nuclear data is baked into the binary at build time (#274).
+/// No filesystem probing, no network, no cache — instant init.
 #[tauri::command]
 pub fn init_data_store(
     state: State<'_, DataStoreState>,
-    bundled: State<'_, BundledDataDir>,
-    data_dir: String,
     library: String,
 ) -> Result<(), String> {
-    let resolved = if !data_dir.is_empty() {
-        data_dir
-    } else if let Some(dir) = bundled.0.lock().map_err(|e| e.to_string())?.as_ref() {
-        dir.clone()
+    let lib = if library.is_empty() {
+        hyrr_core::mcp::transport::DEFAULT_LIBRARY
     } else {
-        hyrr_core::data_dir::resolve()
+        &library
     };
-    let resolved_display = hyrr_core::data_fetch::redact_home(Path::new(&resolved));
-    let store = ParquetDataStore::new(&resolved, &library)
-        .map_err(|e| format!("Failed to init DB at {resolved_display}: {e}"))?;
+    let store = EmbeddedDataStore::new(lib)
+        .map_err(|e| format!("Failed to init embedded DB: {e}"))?;
     let mut guard = state.0.lock().map_err(|e| e.to_string())?;
     *guard = Some(store);
     Ok(())

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -6,8 +6,6 @@ mod commands;
 
 use std::sync::Mutex;
 
-use tauri::Manager;
-
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
@@ -24,37 +22,14 @@ fn main() {
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
-        .plugin(tauri_plugin_opener::init())
-        .manage(commands::BundledDataDir(Mutex::new(None)));
+        .plugin(tauri_plugin_opener::init());
 
-    // Auto-updater: skip on Linux package-manager installs (.deb / .rpm),
-    // where the OS owns updates and a parallel auto-updater would conflict
-    // with apt/dnf. AppImage / DMG / MSI / NSIS installs all opt in. The
-    // env var is set by the bundler at build time per `linux.deb.depends`.
-    // See #116 — the spike resolution settled on minisign single-key with
-    // an offline backup; the runtime trust check is configured in
-    // `tauri.conf.json` under `plugins.updater.pubkey`.
     if updater_enabled() {
         builder = builder.plugin(tauri_plugin_updater::Builder::new().build());
     }
 
     builder
         .manage(commands::DataStoreState(Mutex::new(None)))
-        .setup(|app| {
-            // Resolve the bundled resource dir and store it so
-            // `init_data_store` can read directly from it — no copy to
-            // a writable cache. The installer ships meta/ + stopping/ +
-            // tendl-2023-iso/ in the bundle resources; ParquetDataStore
-            // reads them in-place (read-only is fine, we never write).
-            if let Ok(resource_root) = app.path().resource_dir() {
-                let bundled_data = resource_root.join("data");
-                if bundled_data.join("meta").is_dir() {
-                    let state = app.state::<commands::BundledDataDir>();
-                    *state.0.lock().unwrap() = Some(bundled_data.to_string_lossy().to_string());
-                }
-            }
-            Ok(())
-        })
         .invoke_handler(tauri::generate_handler![
             commands::init_data_store,
             commands::run_compute_stack,
@@ -71,9 +46,7 @@ fn main() {
 }
 
 /// Disable the updater plugin entirely on Linux package-manager installs
-/// (.deb/.rpm). Detection: the bundler sets `APPDIR` for AppImage runs and
-/// leaves it unset for system-package installs; we also honour an explicit
-/// `HYRR_DISABLE_UPDATER=1` env var so packagers can force-disable.
+/// (.deb/.rpm).
 fn updater_enabled() -> bool {
     if std::env::var("HYRR_DISABLE_UPDATER")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -81,7 +54,6 @@ fn updater_enabled() -> bool {
     {
         return false;
     }
-    // Linux: only enable for AppImage runs. apt/dnf own the rest.
     #[cfg(target_os = "linux")]
     {
         return std::env::var("APPIMAGE").is_ok() || std::env::var("APPDIR").is_ok();

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -31,13 +31,6 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": {
-      "../../nucl-parquet/data/meta": "data/meta",
-      "../../nucl-parquet/data/stopping": "data/stopping",
-      "../../nucl-parquet/data/tendl-2023-iso": "data/tendl-2023-iso",
-      "../../nucl-parquet/data/catalog.json": "data/catalog.json",
-      "../../nucl-parquet/data/suppliers.json": "data/suppliers.json"
-    },
     "windows": {
       "nsis": {
         "installMode": "perMachine"

--- a/frontend/e2e/presets.spec.ts
+++ b/frontend/e2e/presets.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Golden tests for all "feeling lucky" presets.
+ *
+ * Each preset must: load without errors, show the activity table,
+ * and produce at least one isotope in the expected layer. These
+ * catch regressions like the F-18 bug (PR #279) where a WASM
+ * binding issue silently dropped all production in non-alloy layers.
+ */
+
+const PRESETS = [
+  {
+    name: "Tc-99m",
+    url: "./#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ",
+    // Mo-100 target (L2) should produce Tc-99m
+    expectIsotope: /99m?Tc|Tc-99|43-99/,
+    expectLayer: "L2",
+  },
+  {
+    name: "F-18",
+    url: "./#config=1:NYwxDkBQEETvMvWS9RHsCXQOIApEQoKIiOZn7275UcwU8ybPY4B4HBALYYIkJWGEcMyZElZI67EZnvu7P-1yfYxdrhRA7ZooKX-SEvbX2Lxls01VoaodYYEUjjno9QE",
+    // O-18 water target (L2) should produce F-18
+    expectIsotope: /18F|F-18|9-18/,
+    expectLayer: "L2",
+  },
+  {
+    name: "Ge-68",
+    url: "./#config=1:LY0xDgAgCEPvwmwk4insAXQOuBgH4-K9zfpS2nyvrYcDJ2PDIibAmEGxQurWYlXTGFPzXiYOF6hBb0IZR64P",
+    // Ga target (L1) should produce Ge-68
+    expectIsotope: /68Ge|Ge-68|32-68/,
+    expectLayer: "L1",
+  },
+  {
+    name: "At-211",
+    url: "./#config=1:LYwxDoAgEET_ss1aQOJPbNRGWxeNFfH3Lksxmcx_exkfD8rcOY0FGDNIb0hhglqEiA6KZ53rYuFygR70a6hh5H_3FQ",
+    // Bi target (L1) should produce At-211
+    expectIsotope: /211At|At-211|85-211/,
+    expectLayer: "L1",
+  },
+];
+
+for (const preset of PRESETS) {
+  test(`preset: ${preset.name} produces ${preset.expectIsotope.source}`, async ({ page }) => {
+    test.setTimeout(120_000);
+
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(e.message));
+
+    await page.goto(preset.url);
+    // Wait for compute to finish
+    await page.waitForSelector(".status-bar", { state: "hidden", timeout: 60_000 }).catch(() => {});
+    await page.waitForSelector(".activity-table-enhanced", { timeout: 60_000 });
+
+    // No fatal errors
+    const fatal = errors.filter(
+      (e) => e.includes("panic") || e.includes("unreachable"),
+    );
+    expect(fatal, `Fatal errors: ${fatal.join("\n")}`).toHaveLength(0);
+
+    // Expected layer has at least one row
+    const rows = page.locator(".activity-table-enhanced tbody tr");
+    await expect(rows.first()).toBeVisible();
+
+    const allCellText = await page.locator(".activity-table-enhanced tbody tr").allTextContents();
+
+    // Check expected layer has rows
+    const layerRows = allCellText.filter((t) => t.startsWith(preset.expectLayer));
+    expect(
+      layerRows.length,
+      `${preset.name}: ${preset.expectLayer} should have isotope production`,
+    ).toBeGreaterThan(0);
+
+    // Check expected isotope exists
+    const hasIsotope = allCellText.some((t) => preset.expectIsotope.test(t));
+    expect(
+      hasIsotope,
+      `${preset.name}: expected ${preset.expectIsotope.source} in results. Got: ${allCellText.slice(0, 5).join(" | ")}`,
+    ).toBe(true);
+  });
+}

--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -152,9 +152,9 @@
     let hasAnyLines = false;
 
     for (const agg of aggregated) {
-      // Get gamma emissions for this isotope (absolute per-decay intensities)
+      // Get photon emissions: gamma lines + 511 keV annihilation (β⁺ emitters)
       const emissions: EmissionLine[] = db.getEmissions(agg.Z, agg.A)
-        .filter((e) => e.radType === "gamma");
+        .filter((e) => e.radType === "gamma" || e.radType === "annihilation");
       if (emissions.length === 0) continue;
 
       // Get activity at chosen time
@@ -233,7 +233,7 @@
 
 <div class="emission-plot">
   <div class="controls">
-    <span class="section-label">{"\u03B3"} emission spectrum</span>
+    <span class="section-label">{"\u03B3"} + annihilation emission spectrum</span>
 
     <button
       class="ctrl-btn"

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -54,10 +54,7 @@ export async function initBackend(
       const { invoke } = await import("@tauri-apps/api/core");
       const lib = library ?? DEFAULT_LIBRARY;
 
-      await invoke("init_data_store", {
-        dataDir: dataDir ?? "",
-        library: lib,
-      });
+      await invoke("init_data_store", { library: lib });
       activeBackend = "tauri";
       return "tauri";
     } catch (e) {

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -427,7 +427,7 @@ impl WasmDataStore {
 
     /// Parse a chemical formula. Returns JSON `{"H": 2, "O": 1}`.
     #[wasm_bindgen(js_name = parseFormula)]
-    pub fn parse_formula_js(formula: &str) -> Result<String, JsValue> {
+    pub fn parse_formula_js(&self, formula: &str) -> Result<String, JsValue> {
         let result = parse_formula(formula);
         serde_json::to_string(&result).map_err(|e| JsValue::from_str(&e.to_string()))
     }


### PR DESCRIPTION
## Summary

Two fixes:

1. **511 keV annihilation in emission plot**: The plot filtered `radType === "gamma"` only, missing the 511 keV annihilation line from β⁺ emitters like F-18. For PET isotope production, this is THE most important emission. Now includes `radType === "annihilation"` alongside gamma.

2. **WASM parseFormula static→instance** (PR #280): Already merged.

Also includes from earlier commits on this branch:
- Wiring EmbeddedDataStore into Tauri (#277)
- EmbeddedDataStore integration tests + CI (#278)  
- Preset golden Playwright tests (Tc-99m, F-18, Ge-68, At-211)
- F-18 regression test

## Test plan

- [x] F-18 preset on /tst shows production in L2
- [ ] Emission plot shows 511 keV stick for F-18 after deploy
- [x] `npx vitest run` — 545 tests pass
- [x] `cargo test --features embed-data --test f18_production` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)