### PR TITLE
feat: preset golden tests as staging release gate

### DIFF
--- a/.github/workflows/deploy-staging-smoke.yml
+++ b/.github/workflows/deploy-staging-smoke.yml
@@ -61,8 +61,17 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: https://exoma-ch.github.io/hyrr/tst/
           CI: "1"
-        # Single viewport for speed — full multi-viewport coverage already ran on the PR.
         run: npx playwright test --grep @smoke --project=desktop-1280 --reporter=list,html
+
+      - name: Run preset golden tests (release gate)
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: https://exoma-ch.github.io/hyrr/tst/
+          CI: "1"
+        # All 5 presets must produce the expected isotope in the expected
+        # layer. Catches silent WASM/data regressions that break production
+        # for non-alloy materials, enriched targets, etc.
+        run: npx playwright test --grep @preset --project=desktop-1280 --reporter=list,html
 
       - name: Upload Playwright report
         if: always()

--- a/frontend/e2e/presets.spec.ts
+++ b/frontend/e2e/presets.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Golden tests for all "feeling lucky" presets.
+ * Golden tests for all "feeling lucky" presets — tagged @preset so the
+ * staging smoke workflow can run them as a release gate.
  *
  * Each preset must: load without errors, show the activity table,
  * and produce at least one isotope in the expected layer. These
@@ -13,69 +14,72 @@ const PRESETS = [
   {
     name: "Tc-99m",
     url: "./#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ",
-    // Mo-100 target (L2) should produce Tc-99m
     expectIsotope: /99m?Tc|Tc-99|43-99/,
     expectLayer: "L2",
   },
   {
     name: "F-18",
     url: "./#config=1:NYwxDkBQEETvMvWS9RHsCXQOIApEQoKIiOZn7275UcwU8ybPY4B4HBALYYIkJWGEcMyZElZI67EZnvu7P-1yfYxdrhRA7ZooKX-SEvbX2Lxls01VoaodYYEUjjno9QE",
-    // O-18 water target (L2) should produce F-18
     expectIsotope: /18F|F-18|9-18/,
     expectLayer: "L2",
   },
   {
     name: "Ge-68",
     url: "./#config=1:LY0xDgAgCEPvwmwk4insAXQOuBgH4-K9zfpS2nyvrYcDJ2PDIibAmEGxQurWYlXTGFPzXiYOF6hBb0IZR64P",
-    // Ga target (L1) should produce Ge-68
     expectIsotope: /68Ge|Ge-68|32-68/,
     expectLayer: "L1",
   },
   {
     name: "At-211",
     url: "./#config=1:LYwxDoAgEET_ss1aQOJPbNRGWxeNFfH3Lksxmcx_exkfD8rcOY0FGDNIb0hhglqEiA6KZ53rYuFygR70a6hh5H_3FQ",
-    // Bi target (L1) should produce At-211
     expectIsotope: /211At|At-211|85-211/,
+    expectLayer: "L1",
+  },
+  {
+    name: "Ac-225",
+    url: "./#config=1:q1ZKUrKqVipQsgJiHaVUJSsjEx2lZCUrAz0Dw1odpRwlq-hqpVygdFCirpGRGVBNCVQyVkcpU8nKwszEwMAArMXE2AjIrAUA",
+    expectIsotope: /225Ac|Ac-225|89-225/,
     expectLayer: "L1",
   },
 ];
 
-for (const preset of PRESETS) {
-  test(`preset: ${preset.name} produces ${preset.expectIsotope.source}`, async ({ page }) => {
-    test.setTimeout(120_000);
+test.describe("preset golden tests", { tag: "@preset" }, () => {
+  for (const preset of PRESETS) {
+    test(`${preset.name} produces ${preset.expectIsotope.source}`, async ({ page }) => {
+      test.setTimeout(120_000);
 
-    const errors: string[] = [];
-    page.on("pageerror", (e) => errors.push(e.message));
+      const errors: string[] = [];
+      page.on("pageerror", (e) => errors.push(e.message));
 
-    await page.goto(preset.url);
-    // Wait for compute to finish
-    await page.waitForSelector(".status-bar", { state: "hidden", timeout: 60_000 }).catch(() => {});
-    await page.waitForSelector(".activity-table-enhanced", { timeout: 60_000 });
+      await page.goto(preset.url);
+      await page.waitForSelector(".status-bar", { state: "hidden", timeout: 60_000 }).catch(() => {});
+      await page.waitForSelector(".activity-table-enhanced", { timeout: 60_000 });
 
-    // No fatal errors
-    const fatal = errors.filter(
-      (e) => e.includes("panic") || e.includes("unreachable"),
-    );
-    expect(fatal, `Fatal errors: ${fatal.join("\n")}`).toHaveLength(0);
+      // No fatal errors
+      const fatal = errors.filter(
+        (e) => e.includes("panic") || e.includes("unreachable"),
+      );
+      expect(fatal, `Fatal errors: ${fatal.join("\n")}`).toHaveLength(0);
 
-    // Expected layer has at least one row
-    const rows = page.locator(".activity-table-enhanced tbody tr");
-    await expect(rows.first()).toBeVisible();
+      // Activity table has rows
+      const rows = page.locator(".activity-table-enhanced tbody tr");
+      await expect(rows.first()).toBeVisible();
 
-    const allCellText = await page.locator(".activity-table-enhanced tbody tr").allTextContents();
+      const allCellText = await page.locator(".activity-table-enhanced tbody tr").allTextContents();
 
-    // Check expected layer has rows
-    const layerRows = allCellText.filter((t) => t.startsWith(preset.expectLayer));
-    expect(
-      layerRows.length,
-      `${preset.name}: ${preset.expectLayer} should have isotope production`,
-    ).toBeGreaterThan(0);
+      // Expected layer has production
+      const layerRows = allCellText.filter((t) => t.startsWith(preset.expectLayer));
+      expect(
+        layerRows.length,
+        `${preset.name}: ${preset.expectLayer} should have isotope production`,
+      ).toBeGreaterThan(0);
 
-    // Check expected isotope exists
-    const hasIsotope = allCellText.some((t) => preset.expectIsotope.test(t));
-    expect(
-      hasIsotope,
-      `${preset.name}: expected ${preset.expectIsotope.source} in results. Got: ${allCellText.slice(0, 5).join(" | ")}`,
-    ).toBe(true);
-  });
-}
+      // Expected isotope exists
+      const hasIsotope = allCellText.some((t) => preset.expectIsotope.test(t));
+      expect(
+        hasIsotope,
+        `${preset.name}: expected ${preset.expectIsotope.source} in results. Got: ${allCellText.slice(0, 5).join(" | ")}`,
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

All 5 feeling-lucky presets now run as a release gate after every staging deploy:

| Preset | Target | Expected isotope |
|---|---|---|
| Tc-99m | Mo-100 (L2) | ⁹⁹ᵐTc |
| F-18 | H₂O-18 (L2) | ¹⁸F |
| Ge-68 | Ga (L1) | ⁶⁸Ge |
| At-211 | Bi (L1) | ²¹¹At |
| Ac-225 | Ra-226 (L1) | ²²⁵Ac |

Wired into `deploy-staging-smoke.yml` as a `@preset` step after `@smoke`. A red preset test = don't promote this SHA to prod.

Would have caught #279 (F-18 zero production).

## Test plan

- [x] Presets verified manually on /tst
- [ ] Staging smoke workflow runs both @smoke and @preset steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)