### PR TITLE
fix: wire compound stopping (nucl-parquet v0.13.6) + emission plot polish

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -364,13 +364,12 @@ impl DatabaseProtocol for NpDataStore {
 
     fn get_compound_stopping_power(
         &self,
-        _source: &str,
-        _compound: &str,
+        source: &str,
+        compound: &str,
     ) -> Option<(Vec<f64>, Vec<f64>)> {
-        // TODO: nucl-parquet v0.13.5 removed compound_table() raw accessor;
-        // compound_dedx() is a scalar interpolator. File upstream issue to
-        // re-add raw table access. Bragg additivity fallback works for now.
-        None
+        self.stopping
+            .compound_table(source, compound)
+            .map(|(e, s)| (e.clone(), s.clone()))
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {
@@ -714,6 +713,16 @@ impl super::DatabaseProtocol for EmbeddedDataStore {
             .nist_table(source, target_z)
             .map(|(e, s)| (e.clone(), s.clone()))
             .unwrap_or_default()
+    }
+
+    fn get_compound_stopping_power(
+        &self,
+        source: &str,
+        compound: &str,
+    ) -> Option<(Vec<f64>, Vec<f64>)> {
+        self.stopping
+            .compound_table(source, compound)
+            .map(|(e, s)| (e.clone(), s.clone()))
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {

--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -200,7 +200,6 @@
         x: energies,
         y: rates,
         type: "bar",
-        width: 3,
         name: nucLabel(agg.name),
         marker: { color },
         hovertemplate: `%{x:.1f} keV<br>%{y:.2e} /s<br>${nucLabel(agg.name)}<extra></extra>`,
@@ -217,14 +216,23 @@
       return maxA - maxB;
     });
 
+    // Adaptive bar width: ~0.3% of the energy range so sticks are
+    // visible at any scale (X-rays ~0.1-100 keV vs gammas ~50-7000 keV).
+    const allEnergies = traces.flatMap((t: any) => t.x as number[]);
+    const eMin = Math.min(...allEnergies);
+    const eMax = Math.max(...allEnergies);
+    const barWidth = Math.max(0.3, (eMax - eMin) * 0.003 + 0.5);
+    for (const t of traces) {
+      (t as any).width = barWidth;
+    }
+
     if (!hasAnyLines) {
-      // No emission lines for the selected isotopes — show a clean
-      // empty state instead of a broken micro-plot with noise axes.
+      const tabLabel = EMISSION_TABS.find((t) => t.id === activeEmTab)?.label ?? activeEmTab;
       Plotly.react(plotDiv, [], darkLayout({
         xaxis: { title: { text: "Energy (keV)" }, gridcolor: tc.border, range: [0, 2000] },
         yaxis: { title: { text: "Emission rate (/s)" }, gridcolor: tc.border, range: [0, 1] },
         annotations: [{
-          text: "No photon emission data for selected isotopes",
+          text: `No ${tabLabel} emission data for selected isotopes`,
           xref: "paper", yref: "paper",
           x: 0.5, y: 0.5,
           showarrow: false,


### PR DESCRIPTION
## Summary

**Compound stopping (#193):** Bump nucl-parquet to v0.13.6. Wire `compound_table()` into both NpDataStore and EmbeddedDataStore. NIST PSTAR/ASTAR compound data (ICRU-49/73) is now used for known compounds (H2O, polyethylene, bone, air, etc.) instead of the Bragg additivity fallback.

**Emission plot polish:**
- Empty state message is tab-aware: "No β⁻ emission data..." not "No photon emission data..."
- Adaptive bar width: scales with energy range. X-ray sticks (1-100 keV) are thin; gamma sticks (50-7000 keV) are wide.

## Test plan

- [x] `cargo check --features embed-data` — compiles with v0.13.6
- [x] `npx tsc --noEmit` — clean
- [ ] H2O target uses NIST compound stopping (not Bragg)

🤖 Generated with [Claude Code](https://claude.com/claude-code)