### PR TITLE
feat: α emission tab + compound stopping (nucl-parquet v0.13.6)

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -364,13 +364,12 @@ impl DatabaseProtocol for NpDataStore {
 
     fn get_compound_stopping_power(
         &self,
-        _source: &str,
-        _compound: &str,
+        source: &str,
+        compound: &str,
     ) -> Option<(Vec<f64>, Vec<f64>)> {
-        // TODO: nucl-parquet v0.13.5 removed compound_table() raw accessor;
-        // compound_dedx() is a scalar interpolator. File upstream issue to
-        // re-add raw table access. Bragg additivity fallback works for now.
-        None
+        self.stopping
+            .compound_table(source, compound)
+            .map(|(e, s)| (e.clone(), s.clone()))
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {
@@ -714,6 +713,16 @@ impl super::DatabaseProtocol for EmbeddedDataStore {
             .nist_table(source, target_z)
             .map(|(e, s)| (e.clone(), s.clone()))
             .unwrap_or_default()
+    }
+
+    fn get_compound_stopping_power(
+        &self,
+        source: &str,
+        compound: &str,
+    ) -> Option<(Vec<f64>, Vec<f64>)> {
+        self.stopping
+            .compound_table(source, compound)
+            .map(|(e, s)| (e.clone(), s.clone()))
     }
 
     fn get_natural_abundances(&self, z: u32) -> HashMap<u32, (f64, f64)> {

--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -200,7 +200,6 @@
         x: energies,
         y: rates,
         type: "bar",
-        width: 3,
         name: nucLabel(agg.name),
         marker: { color },
         hovertemplate: `%{x:.1f} keV<br>%{y:.2e} /s<br>${nucLabel(agg.name)}<extra></extra>`,
@@ -217,14 +216,23 @@
       return maxA - maxB;
     });
 
+    // Adaptive bar width: ~0.3% of the energy range so sticks are
+    // visible at any scale (X-rays ~0.1-100 keV vs gammas ~50-7000 keV).
+    const allEnergies = traces.flatMap((t: any) => t.x as number[]);
+    const eMin = Math.min(...allEnergies);
+    const eMax = Math.max(...allEnergies);
+    const barWidth = Math.max(0.3, (eMax - eMin) * 0.003 + 0.5);
+    for (const t of traces) {
+      (t as any).width = barWidth;
+    }
+
     if (!hasAnyLines) {
-      // No emission lines for the selected isotopes — show a clean
-      // empty state instead of a broken micro-plot with noise axes.
+      const tabLabel = EMISSION_TABS.find((t) => t.id === activeEmTab)?.label ?? activeEmTab;
       Plotly.react(plotDiv, [], darkLayout({
         xaxis: { title: { text: "Energy (keV)" }, gridcolor: tc.border, range: [0, 2000] },
         yaxis: { title: { text: "Emission rate (/s)" }, gridcolor: tc.border, range: [0, 1] },
         annotations: [{
-          text: "No photon emission data for selected isotopes",
+          text: `No ${tabLabel} emission data for selected isotopes`,
           xref: "paper", yref: "paper",
           x: 0.5, y: 0.5,
           showarrow: false,

--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -23,6 +23,7 @@
 
   const EMISSION_TABS = [
     { id: "gamma", label: "\u03B3", radTypes: ["gamma", "annihilation"] as EmissionRadType[] },
+    { id: "alpha", label: "\u03B1", radTypes: ["alpha"] as EmissionRadType[] },
     { id: "beta-", label: "\u03B2\u207B", radTypes: ["beta-"] as EmissionRadType[] },
     { id: "beta+", label: "\u03B2\u207A", radTypes: ["beta+"] as EmissionRadType[] },
     { id: "CE", label: "CE", radTypes: ["ce"] as EmissionRadType[] },

--- a/frontend/src/lib/components/EmissionsTable.svelte
+++ b/frontend/src/lib/components/EmissionsTable.svelte
@@ -13,6 +13,7 @@
   // --- Emission channel tabs ---
   const TABS = [
     { id: "gamma", label: "\u03B3" },
+    { id: "alpha", label: "\u03B1" },
     { id: "beta-", label: "\u03B2\u207B" },
     { id: "beta+", label: "\u03B2\u207A" },
     { id: "CE", label: "CE" },
@@ -49,6 +50,7 @@
   /** Map from tab ID to the rad_type(s) it shows. */
   const TAB_RAD_TYPES: Record<TabId, EmissionRadType[]> = {
     "gamma": ["gamma", "annihilation"],
+    "alpha": ["alpha"],
     "beta-": ["beta-"],
     "beta+": ["beta+"],
     "CE": ["ce"],

--- a/packages/compute/src/data-store.ts
+++ b/packages/compute/src/data-store.ts
@@ -68,7 +68,8 @@ export type EmissionRadType =
   | "auger"
   | "annihilation"
   | "beta+"
-  | "beta-";
+  | "beta-"
+  | "alpha";
 
 // --- Backward-compat type aliases (deprecated) ---
 


### PR DESCRIPTION
## Summary

- **α emission tab**: Alpha particle emission data existed in ENSDF parquets but `"alpha"` wasn't in `EmissionRadType`. Added α tab to both EmissionPlot and EmissionsTable. At-211, Po-210, Ra-226 etc. now show alpha emission spectra.
- **Compound stopping (#193)**: nucl-parquet v0.13.6 `compound_table()` wired into NpDataStore + EmbeddedDataStore. NIST ICRU-49/73 compound data for H₂O, polyethylene, etc.
- **Emission polish**: Tab-aware empty state message, adaptive bar width.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `cargo check --features embed-data` — compiles
- [ ] At-211 preset shows α tab with emission lines
- [ ] H₂O target uses NIST compound stopping

🤖 Generated with [Claude Code](https://claude.com/claude-code)