### PR TITLE
fix(ci): version test + workflow_dispatch for release.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,13 @@ name: Release Please
 # On every push to main, release-please scans conventional commits since the
 # last release tag and either creates/updates a "Release vX.Y.Z" PR (with
 # CHANGELOG + version bumps) or — if that PR was just merged — creates the
-# tag + GitHub Release, which triggers the downstream publish workflows
-# (release.yml, tauri-build.yml, release-hyrr-mcp.yml).
+# tag + GitHub Release.
+#
+# IMPORTANT: Tags created by GITHUB_TOKEN don't trigger other workflows.
+# After release-please creates a tag, manually dispatch the downstream
+# publish workflows (release.yml, tauri-build.yml) or re-push the tag
+# from a local clone. See ADR 0002 for details. A PAT-based approach
+# would eliminate this step but adds secret management overhead.
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -45,14 +45,12 @@ jobs:
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet
-          git sparse-checkout set \
-            data/catalog.json \
-            data/meta/abundances.parquet \
-            data/meta/decay.parquet \
-            data/meta/dose_constants.parquet \
-            data/meta/ensdf/emissions \
-            data/stopping \
-            data/tendl-2023-iso/xs
+          git sparse-checkout set --no-cone \
+            'clients/rs/nucl-parquet/' \
+            'data/catalog.json' \
+            'data/meta/' \
+            'data/stopping/' \
+            'data/tendl-2023-iso/xs/'
 
       - name: Copy parquet data to frontend public dir
         shell: bash

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,8 +1,10 @@
 """Smoke test for hyrr package."""
 
+from importlib.metadata import version
+
 
 def test_import() -> None:
-    """Verify hyrr can be imported."""
+    """Verify hyrr can be imported and __version__ matches pyproject.toml."""
     import hyrr
 
-    assert hyrr.__version__ == "0.1.0"
+    assert hyrr.__version__ == version("hyrr")


### PR DESCRIPTION
## Summary

- `tests/test_example.py`: assert `__version__` matches pyproject.toml via `importlib.metadata` instead of hardcoding `"0.1.0"` (broke after release-please bumped `__init__.py` to 0.9.0)
- `release.yml`: add `workflow_dispatch` trigger for manual PyPI publishes (needed when GITHUB_TOKEN-created tags don't fire push events)
- `release-please.yml`: document the GITHUB_TOKEN tag limitation

## Test plan
- [ ] CI passes (the version assertion no longer hardcodes a string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)