### PR TITLE
fix(ci): tauri-build shell: bash for Windows

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -42,6 +42,7 @@ jobs:
           submodules: false
 
       - name: Init nucl-parquet submodule (sparse)
+        shell: bash
         run: |
           git submodule update --init --depth 1 --filter=blob:none nucl-parquet
           cd nucl-parquet


### PR DESCRIPTION
## Summary

The `--no-cone` sparse-checkout step in `tauri-build.yml` uses bash line continuation (`\`) and single-quoted paths. On Windows runners, the default shell is PowerShell which doesn't understand this syntax. Add `shell: bash` to force bash on all platforms.

## Test plan
- [ ] CI passes
- [ ] After merge: re-push v0.9.0 tag → Tauri build succeeds on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)