### PR TITLE
fix(release): tauri path resolution + MCP submodule init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,34 @@ jobs:
             exit 1
           }
 
+  release-workflow-guards:
+    # Catch release-workflow drift before it breaks a real release.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # tauri.conf.json beforeBuildCommand runs from desktop/src-tauri/
+      # (Tauri v2 CWD semantics). All --prefix paths must use ../../ to
+      # reach the repo-root frontend/, matching frontendDist's depth.
+      - name: Assert tauri.conf.json paths resolve from src-tauri/
+        run: |
+          CONF=desktop/src-tauri/tauri.conf.json
+          if grep -qE '"before(Build|Dev)Command".*--prefix \.\./frontend"' "$CONF"; then
+            echo "::error::beforeBuildCommand/beforeDevCommand uses --prefix ../frontend (1 level up) but Tauri v2 runs from src-tauri/ (needs ../../frontend, 2 levels up)."
+            exit 1
+          fi
+
+      # release-hyrr-mcp build/sdist jobs must init the nucl-parquet
+      # submodule — core depends on it via path.
+      - name: Assert release-hyrr-mcp.yml inits submodule in all build jobs
+        run: |
+          WF=.github/workflows/release-hyrr-mcp.yml
+          COUNT=$(grep -c 'submodule update --init' "$WF")
+          if [ "$COUNT" -lt 3 ]; then
+            echo "::error::release-hyrr-mcp.yml has only $COUNT submodule-init steps — build, sdist, and parity-test all need one (core path-depends on nucl-parquet)."
+            exit 1
+          fi
+
   supplier-catalog-freshness:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-hyrr-mcp.yml
+++ b/.github/workflows/release-hyrr-mcp.yml
@@ -41,6 +41,10 @@ jobs:
           - { name: windows-x86_64, runner: windows-latest, rust-target: x86_64-pc-windows-msvc,     maturin-target: x64,     manylinux: "" }
     steps:
       - uses: actions/checkout@v6
+      - name: Init nucl-parquet submodule (Rust client for core path dep)
+        shell: bash
+        run: |
+          git submodule update --init --depth 1 --filter=blob:none nucl-parquet
 
       - uses: actions/setup-python@v6
         with:
@@ -88,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Init nucl-parquet submodule (Rust client for core path dep)
+        run: |
+          git submodule update --init --depth 1 --filter=blob:none nucl-parquet
       - uses: actions/setup-python@v6
         with:
           python-version: "3.11"

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "frontendDist": "../../frontend/dist",
     "devUrl": "http://localhost:5173",
-    "beforeDevCommand": "npm run dev --prefix ../frontend",
-    "beforeBuildCommand": "npm run build --prefix ../frontend"
+    "beforeDevCommand": "npm run dev --prefix ../../frontend",
+    "beforeBuildCommand": "npm run build --prefix ../../frontend"
   },
   "app": {
     "windows": [


### PR DESCRIPTION
## Summary

Fixes two bugs that broke the v0.9.0 desktop and MCP wheel releases:

### Bug 1: Tauri `beforeBuildCommand` path (desktop builds)
`tauri-action@v0` updated to Tauri v2 CWD semantics — `beforeBuildCommand` now runs from `desktop/src-tauri/` not `desktop/`. The `--prefix ../frontend` (1 level up) resolves to `desktop/frontend/` which doesn't exist. Fix: `--prefix ../../frontend` (2 levels, matching `frontendDist`'s `../../frontend/dist`).

### Bug 2: MCP wheel `nucl-parquet` submodule (`release-hyrr-mcp.yml`)
The `build` and `sdist` jobs don't initialize the nucl-parquet submodule, but `core/Cargo.toml` depends on `nucl-parquet/clients/rs/nucl-parquet` via path. Fix: add `git submodule update --init` to both jobs.

### CI guards
Added `release-workflow-guards` job to CI that catches both issues with grep assertions, so they can't regress.

## Test plan
- [ ] CI `release-workflow-guards` job passes (RED→GREEN in this PR)
- [ ] After merge: re-push `v0.9.0` tag → Tauri build succeeds on all platforms
- [ ] After merge: re-push `hyrr-mcp-v0.9.0` tag → MCP wheel publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)