### PR TITLE
fix(frontend): isomeric state + emission SSoT + enrichment save

### DIFF
--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -60,19 +60,19 @@
     if (!db?.emissionDataLoaded) return {};
     const has: Record<string, boolean> = {};
     // Collect all isotopes passing the filter (same logic as render)
-    const isos: { Z: number; A: number }[] = [];
+    const isos: { Z: number; A: number; state: string }[] = [];
     for (const layer of (result?.layers ?? [])) {
       if (sharedFilter.layers.size > 0 && !sharedFilter.layers.has(layer.layer_index)) continue;
       for (const iso of layer.isotopes) {
         if (iso.half_life_s === null || iso.activity_Bq <= 0) continue;
         if (sharedFilter.text && !iso.name.toLowerCase().includes(sharedFilter.text.toLowerCase())) continue;
         if (selected.size > 0 && !selected.has(iso.name)) continue;
-        isos.push({ Z: iso.Z, A: iso.A });
+        isos.push({ Z: iso.Z, A: iso.A, state: iso.state ?? "" });
       }
     }
     for (const tab of EMISSION_TABS) {
       has[tab.id] = isos.some((iso) => {
-        const emissions = db.getEmissions(iso.Z, iso.A);
+        const emissions = db.getEmissions(iso.Z, iso.A, iso.state);
         return emissions.some((e) => tab.radTypes.includes(e.radType));
       });
     }
@@ -254,7 +254,7 @@
 
     for (const agg of aggregated) {
       const tabRadTypes = EMISSION_TABS.find((t) => t.id === activeEmTab)?.radTypes ?? ["gamma"];
-      const emissions: EmissionLine[] = db.getEmissions(agg.Z, agg.A)
+      const emissions: EmissionLine[] = db.getEmissions(agg.Z, agg.A, agg.state)
         .filter((e) => tabRadTypes.includes(e.radType));
       if (emissions.length === 0) continue;
 

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -21,6 +21,7 @@
   } from "../../stores/custom-materials.svelte";
   import {
     applyRowPatch,
+    collectRowEnrichments,
     generateRowId,
     isTabulatedDensity,
     parseMaterialInput,
@@ -514,6 +515,18 @@
     saving = true;
     formError = null;
     try {
+      // Merge row-level enrichments with layer-level enrichment (#304).
+      // Row enrichments (from the "enr" button) take precedence.
+      const rowEnrichment = collectRowEnrichments(rows);
+      const mergedEnrichment = (currentEnrichment || rowEnrichment)
+        ? { ...currentEnrichment, ...rowEnrichment }
+        : undefined;
+      // Snapshot to escape Svelte 5 $state proxies — IndexedDB's structured
+      // clone rejects Proxy exotic objects (#304).
+      const enrichmentForSave = mergedEnrichment
+        ? JSON.parse(JSON.stringify(mergedEnrichment))
+        : undefined;
+
       const overwriteId = intent === "overwrite"
         ? (editingCustomId ?? lastSavedSession?.id)
         : null;
@@ -525,7 +538,7 @@
           densityVal,
           massFractions,
           serialised,
-          currentEnrichment,
+          enrichmentForSave,
         );
         lastSavedSession = { id: overwriteId, name: nameVal };
       } else {
@@ -535,7 +548,7 @@
           densityVal,
           massFractions,
           serialised,
-          currentEnrichment,
+          enrichmentForSave,
         );
         lastSavedSession = { id: newId, name: nameVal };
       }
@@ -543,7 +556,7 @@
       // slot so the round-2 race (Save at second 28 silently drops
       // demoted rows) can't fire. (#95)
       clearDemote();
-      oncommit(nameVal, currentEnrichment);
+      oncommit(nameVal, enrichmentForSave);
       // Mark first-time guidance done after a successful save.
       dismissModeFirstTime();
     } catch {
@@ -617,7 +630,7 @@
               issues={issuesByRow.get(r.id) ?? []}
               onchange={(patch) => patchRow(r.id, patch)}
               onremove={() => removeRow(r.id)}
-              oneditenrichment={mode !== "single" ? openRowEnrichmentEditor : undefined}
+              oneditenrichment={openRowEnrichmentEditor}
             />
           {/each}
         {/if}

--- a/frontend/src/lib/components/material/DefineFormRow.svelte
+++ b/frontend/src/lib/components/material/DefineFormRow.svelte
@@ -75,7 +75,7 @@
       aria-label={`Edit isotope enrichment for ${singleElement}`}
       title={hasRowEnrichment ? `Row enrichment set for ${singleElement} — click to edit` : `Override natural isotope abundance for ${singleElement}`}
       onclick={() => oneditenrichment(row.id, singleElement)}
-    >E</button>
+    >enr</button>
   {/if}
 
   <button
@@ -98,7 +98,7 @@
 <style>
   .row {
     display: grid;
-    grid-template-columns: minmax(2.5rem, auto) minmax(0, 1fr) auto auto 1.5rem;
+    grid-template-columns: minmax(2.5rem, auto) minmax(0, 5rem) auto auto 1.5rem;
     gap: 0.4rem;
     align-items: center;
     padding: 0.25rem 0.4rem;
@@ -113,12 +113,13 @@
     border: 1px solid var(--c-border);
     border-radius: 3px;
     color: var(--c-text-muted);
-    font-size: 0.65rem;
-    width: 1.4rem;
+    font-size: 0.6rem;
+    padding: 0.1rem 0.25rem;
     height: 1.4rem;
     line-height: 1;
     cursor: pointer;
     font-weight: 600;
+    white-space: nowrap;
   }
   .enrich-btn:hover { color: var(--c-accent); border-color: var(--c-accent); }
   .enrich-btn.active {

--- a/frontend/src/lib/components/material/define-form-rows.test.ts
+++ b/frontend/src/lib/components/material/define-form-rows.test.ts
@@ -257,6 +257,46 @@ describe("serialise", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// #304 / #305: enrichment collection from rows
+// ---------------------------------------------------------------------------
+describe("collectRowEnrichments (#304)", () => {
+  // When the user sets per-row isotopic overrides via the "enr" button,
+  // the save flow must gather them into a single enrichment record.
+  // This helper is the unit-testable core of that logic.
+  it("merges per-row enrichment into a single record", async () => {
+    const { collectRowEnrichments } = await import("./define-form-rows");
+    const rows: Row[] = [
+      row({ formula: "Zn", value: 50, enrichment: { Zn: { 68: 0.98, 66: 0.01, 67: 0.004, 64: 0.003, 70: 0.001 } } }),
+      row({ formula: "O", value: 50 }),
+    ];
+    const result = collectRowEnrichments(rows);
+    expect(result).toEqual({ Zn: { 68: 0.98, 66: 0.01, 67: 0.004, 64: 0.003, 70: 0.001 } });
+  });
+
+  it("returns undefined when no rows have enrichment", async () => {
+    const { collectRowEnrichments } = await import("./define-form-rows");
+    const rows: Row[] = [
+      row({ formula: "Cu", value: 100 }),
+    ];
+    const result = collectRowEnrichments(rows);
+    expect(result).toBeUndefined();
+  });
+
+  it("merges enrichments from multiple rows", async () => {
+    const { collectRowEnrichments } = await import("./define-form-rows");
+    const rows: Row[] = [
+      row({ formula: "Zn", value: 50, enrichment: { Zn: { 68: 0.98 } } }),
+      row({ formula: "O", value: 50, enrichment: { O: { 18: 0.5, 16: 0.5 } } }),
+    ];
+    const result = collectRowEnrichments(rows);
+    expect(result).toEqual({
+      Zn: { 68: 0.98 },
+      O: { 18: 0.5, 16: 0.5 },
+    });
+  });
+});
+
 describe("round-trip", () => {
   it("text → parse → serialise is canonical for mass mode with balance", () => {
     const r = parseMaterialInput("Al 80%, Cu 5%, Zn bal");

--- a/frontend/src/lib/components/material/define-form-rows.ts
+++ b/frontend/src/lib/components/material/define-form-rows.ts
@@ -451,6 +451,24 @@ export function isTabulatedDensity(formula: string): boolean {
   return elements.length === 1 && elements[0] in ELEMENT_DENSITIES;
 }
 
+/**
+ * Collect per-row enrichment overrides into a single merged record.
+ * Returns undefined when no rows carry enrichment. (#304)
+ */
+export function collectRowEnrichments(
+  rows: Row[],
+): Record<string, Record<number, number>> | undefined {
+  let result: Record<string, Record<number, number>> | undefined;
+  for (const r of rows) {
+    if (!r.enrichment) continue;
+    for (const [el, vec] of Object.entries(r.enrichment)) {
+      if (!result) result = {};
+      result[el] = { ...vec };
+    }
+  }
+  return result;
+}
+
 /** Average atomic weight per row (used by the atom-mixture density estimator). */
 export function rowAverageAtomicMass(formula: string): number {
   const counts = parseFormula(formula);

--- a/frontend/src/lib/plotting/aggregate-isotopes.test.ts
+++ b/frontend/src/lib/plotting/aggregate-isotopes.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for aggregate-isotopes.ts
+ *
+ * Covers:
+ *  - #302: "Sc-44" (state="") and "Sc-44g" (state="g") are both ground state
+ *          and must be merged into one aggregated entry.
+ *  - #303: AggregatedIsotope must carry `state` so emission lookups can
+ *          pass state to db.getEmissions(Z, A, state).
+ */
+import { describe, it, expect } from "vitest";
+import {
+  aggregateByIsotopeName,
+  type PerLayerIsotope,
+  type AggregatedIsotope,
+} from "./aggregate-isotopes";
+import type { IsotopeResultData } from "../types";
+
+/** Helper: build a minimal IsotopeResultData with sensible defaults. */
+function makeIso(
+  overrides: Partial<IsotopeResultData> & Pick<IsotopeResultData, "name" | "Z" | "A" | "state">,
+): IsotopeResultData {
+  return {
+    half_life_s: 1000,
+    production_rate: 1,
+    saturation_yield_Bq_uA: 1,
+    activity_Bq: 100,
+    time_grid_s: [0, 60, 120],
+    activity_vs_time_Bq: [50, 80, 100],
+    reactions: [],
+    ...overrides,
+  };
+}
+
+describe("aggregateByIsotopeName", () => {
+  // -----------------------------------------------------------------------
+  // #302 — ground-state normalization
+  // -----------------------------------------------------------------------
+  describe("#302: ground-state normalization (Sc-44 ≡ Sc-44g)", () => {
+    it("merges Sc-44 (state='') and Sc-44g (state='g') into one entry", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Sc-44", Z: 21, A: 44, state: "", activity_Bq: 100 }),
+          layerIdx: 0,
+        },
+        {
+          iso: makeIso({ name: "Sc-44g", Z: 21, A: 44, state: "g", activity_Bq: 50 }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      const sc44entries = result.filter((r) => r.Z === 21 && r.A === 44 && r.state === "");
+      expect(sc44entries).toHaveLength(1);
+      expect(sc44entries[0].activity_Bq).toBe(150);
+    });
+
+    it("keeps Sc-44m separate from merged ground state", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Sc-44", Z: 21, A: 44, state: "", activity_Bq: 100 }),
+          layerIdx: 0,
+        },
+        {
+          iso: makeIso({ name: "Sc-44g", Z: 21, A: 44, state: "g", activity_Bq: 50 }),
+          layerIdx: 0,
+        },
+        {
+          iso: makeIso({ name: "Sc-44m", Z: 21, A: 44, state: "m", activity_Bq: 30 }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      // Ground state merged → 1 entry; metastable → 1 entry; total = 2
+      expect(result).toHaveLength(2);
+
+      const ground = result.find((r) => r.state === "");
+      expect(ground).toBeDefined();
+      expect(ground!.activity_Bq).toBe(150);
+      expect(ground!.name).toBe("Sc-44"); // canonical name without "g"
+
+      const meta = result.find((r) => r.state === "m");
+      expect(meta).toBeDefined();
+      expect(meta!.activity_Bq).toBe(30);
+    });
+
+    it("uses canonical name without g suffix", () => {
+      // Only "Sc-44g" present — name should still normalize to "Sc-44"
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Sc-44g", Z: 21, A: 44, state: "g", activity_Bq: 100 }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("Sc-44");
+      expect(result[0].state).toBe("");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // #303 — AggregatedIsotope must carry `state`
+  // -----------------------------------------------------------------------
+  describe("#303: AggregatedIsotope carries state for emission lookups", () => {
+    it("propagates state='' for ground-state isotopes", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Na-22", Z: 11, A: 22, state: "" }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty("state", "");
+    });
+
+    it("propagates state='m' for metastable isotopes", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Sc-44m", Z: 21, A: 44, state: "m" }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty("state", "m");
+    });
+
+    it("propagates state='m2' for second metastable", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Bi-210m2", Z: 83, A: 210, state: "m2" }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty("state", "m2");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Existing behavior: basic aggregation across layers
+  // -----------------------------------------------------------------------
+  describe("basic cross-layer aggregation (regression guard)", () => {
+    it("sums activity across two layers for the same isotope", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Co-58", Z: 27, A: 58, state: "", activity_Bq: 100, activity_vs_time_Bq: [10, 20, 30] }),
+          layerIdx: 0,
+        },
+        {
+          iso: makeIso({ name: "Co-58", Z: 27, A: 58, state: "", activity_Bq: 200, activity_vs_time_Bq: [5, 10, 15] }),
+          layerIdx: 1,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(1);
+      expect(result[0].activity_Bq).toBe(300);
+      expect(result[0].activity_vs_time_Bq).toEqual([15, 30, 45]);
+      expect(result[0].sourceLayers).toEqual([0, 1]);
+    });
+
+    it("skips rows without time grid", () => {
+      const rows: PerLayerIsotope[] = [
+        {
+          iso: makeIso({ name: "Na-22", Z: 11, A: 22, state: "", time_grid_s: undefined, activity_vs_time_Bq: undefined }),
+          layerIdx: 0,
+        },
+      ];
+
+      const result = aggregateByIsotopeName(rows);
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/frontend/src/lib/plotting/aggregate-isotopes.ts
+++ b/frontend/src/lib/plotting/aggregate-isotopes.ts
@@ -26,6 +26,8 @@ export interface AggregatedIsotope {
   name: string;
   Z: number;
   A: number;
+  /** Nuclear state: "" for ground, "m" for metastable, "m2" etc. */
+  state: string;
   half_life_s: number | null;
   /** Summed end-of-cooling activity (Bq). */
   activity_Bq: number;
@@ -40,25 +42,49 @@ export interface AggregatedIsotope {
 }
 
 /**
+ * Normalize nuclear state: "g" → "" (ground state convention — no suffix).
+ * Metastable states ("m", "m2", …) pass through unchanged.
+ */
+function normalizeState(state: string): string {
+  return state === "g" ? "" : state;
+}
+
+/**
+ * Canonical isotope name without the "g" suffix.
+ * "Sc-44g" → "Sc-44", "Sc-44m" → "Sc-44m", "Sc-44" → "Sc-44".
+ */
+function canonicalName(name: string, state: string): string {
+  // Strip trailing "g" that we normalized away (ground state has no suffix)
+  if (state === "g" && name.endsWith("g")) {
+    return name.slice(0, -1);
+  }
+  return name;
+}
+
+/**
  * Collapse a list of per-layer isotope rows into one aggregated entry per
- * isotope name. Rows lacking `time_grid_s` / `activity_vs_time_Bq` are
- * skipped (they can't contribute to a time series). If no rows for a name
- * have a time grid the name is dropped entirely.
+ * unique (Z, A, normalizedState). Rows lacking `time_grid_s` /
+ * `activity_vs_time_Bq` are skipped. Ground-state variants ("Sc-44" with
+ * state="" and "Sc-44g" with state="g") are merged into a single entry
+ * with state="" and canonical name "Sc-44" (#302).
  */
 export function aggregateByIsotopeName(
   rows: PerLayerIsotope[],
 ): AggregatedIsotope[] {
-  const byName = new Map<string, AggregatedIsotope>();
+  const byKey = new Map<string, AggregatedIsotope>();
 
   for (const { iso, layerIdx } of rows) {
     if (!iso.time_grid_s || !iso.activity_vs_time_Bq) continue;
 
-    const existing = byName.get(iso.name);
+    const normState = normalizeState(iso.state);
+    const key = `${iso.Z}-${iso.A}-${normState}`;
+    const existing = byKey.get(key);
     if (!existing) {
-      byName.set(iso.name, {
-        name: iso.name,
+      byKey.set(key, {
+        name: canonicalName(iso.name, iso.state),
         Z: iso.Z,
         A: iso.A,
+        state: normState,
         half_life_s: iso.half_life_s,
         activity_Bq: iso.activity_Bq,
         time_grid_s: [...iso.time_grid_s],
@@ -89,5 +115,5 @@ export function aggregateByIsotopeName(
     }
   }
 
-  return [...byName.values()];
+  return [...byKey.values()];
 }


### PR DESCRIPTION
## Summary

Fixes four freshly reported frontend bugs:

- **#302** — Sc-44g / Sc-44 / Sc-44m "mix of states": ground-state normalization in `aggregateByIsotopeName` now merges `state="g"` with `state=""` under canonical name `Sc-44`, keeping metastable `Sc-44m` separate
- **#303** — Emission plot showing wrong lines for metastable isotopes: `AggregatedIsotope` now carries `state`, passed to `db.getEmissions(Z, A, state)` in both render and tab-availability checks
- **#304** — "Failed to save" material with enrichment: row-level enrichments (from "enr" button) are now collected and merged with layer enrichment; result is JSON-snapshotted to escape Svelte 5 `$state` proxies before IndexedDB structured-clone
- **#305** — Enrichment button unavailable in stoichiometric mode, cryptic label: enabled in all modes, renamed `E` → `enr`, value input column narrowed

## Test plan

- [x] 11 new unit tests (8 aggregate-isotopes, 3 collectRowEnrichments) — RED→GREEN TDD
- [x] Full test suite: 581 passed, 0 regressions (6 pre-existing jsdom failures unchanged)
- [x] TypeScript: `tsc --noEmit` clean
- [ ] Manual: verify enrichment save round-trip in browser
- [ ] Manual: verify emission plot shows correct Sc-44m lines (not Sc-44)
- [ ] Manual: verify "enr" button visible in stoichiometric mode

Closes #302, #303, #304, #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)