### PR TITLE
fix(ci): MCP linux-aarch64 continue-on-error

### DIFF
--- a/.github/workflows/release-hyrr-mcp.yml
+++ b/.github/workflows/release-hyrr-mcp.yml
@@ -29,6 +29,10 @@ jobs:
   build:
     name: build (${{ matrix.target.name }})
     runs-on: ${{ matrix.target.runner }}
+    # linux-aarch64 cross-compiles ring via QEMU/manylinux and is fragile
+    # (ring's ARM asm needs __ARM_ARCH from the cross-compiler). Don't let
+    # it block parity-test + publish for the other 3 targets.
+    continue-on-error: ${{ matrix.target.name == 'linux-aarch64' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

`ring` 0.17 cross-compilation for aarch64 on x86_64 GitHub runners fails because the manylinux cross-compiler doesn't define `__ARM_ARCH`. This blocks parity-test and PyPI publish for the 3 healthy targets.

Fix: `continue-on-error: ${{ matrix.target.name == 'linux-aarch64' }}` on the build job. The aarch64 build still runs and reports its status, but doesn't gate the pipeline.

## Test plan
- [ ] CI passes
- [ ] After merge: re-push `hyrr-mcp-v0.9.0` → publish fires with 3 wheels + sdist

🤖 Generated with [Claude Code](https://claude.com/claude-code)