### PR TITLE
fix(mcp): deterministic output ordering in MCP tools

### DIFF
--- a/core/src/mcp/tools.rs
+++ b/core/src/mcp/tools.rs
@@ -477,7 +477,12 @@ fn tool_simulate(db: &dyn DatabaseProtocol, args: &Value) -> Result<String, Stri
         );
 
         let mut sorted: Vec<_> = lr.isotope_results.values().collect();
-        sorted.sort_by(|a, b| b.activity_bq.partial_cmp(&a.activity_bq).unwrap());
+        sorted.sort_by(|a, b| {
+            b.activity_bq
+                .partial_cmp(&a.activity_bq)
+                .unwrap()
+                .then_with(|| a.name.cmp(&b.name))
+        });
 
         for iso in sorted.iter().take(20) {
             let hl = match iso.half_life_s {
@@ -559,6 +564,14 @@ fn tool_list_reaction_channels(db: &dyn DatabaseProtocol, args: &Value) -> Resul
         output.push_str("No cross-section data found. Data may need to be loaded first.\n");
         return Ok(output);
     }
+
+    let mut xs_list = xs_list;
+    xs_list.sort_by(|a, b| {
+        a.residual_z
+            .cmp(&b.residual_z)
+            .then_with(|| a.residual_a.cmp(&b.residual_a))
+            .then_with(|| a.state.cmp(&b.state))
+    });
 
     for xs in &xs_list {
         let res_sym = db.get_element_symbol(xs.residual_z);


### PR DESCRIPTION
## Summary

Root cause of the MCP parity test failure. Two HashMap-order-dependent iterations in `core/src/mcp/tools.rs`:

1. **Cross-section list** (line 563): iterated in HashMap insertion order → sort by `(residual_z, residual_a, state)` for deterministic output
2. **Isotope table** (line 480): sorted by activity descending, but stable isotopes all have `activity=0` with undefined tiebreak → add `name` as secondary sort key

PR #309 (`jq --sort-keys`) handles JSON key ordering. This PR fixes the Markdown text ordering — the actual non-determinism source.

## Test plan
- [ ] CI passes
- [ ] After merge + tag re-push: parity test passes → MCP wheel publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)