### PR TITLE
fix(e2e): test.slow() for heavy preset golden tests

### DIFF
--- a/frontend/e2e/presets.spec.ts
+++ b/frontend/e2e/presets.spec.ts
@@ -8,6 +8,10 @@ import { test, expect } from "@playwright/test";
  * and produce at least one isotope in the expected layer. These
  * catch regressions like the F-18 bug (PR #279) where a WASM
  * binding issue silently dropped all production in non-alloy layers.
+ *
+ * Heavy presets (Ge-68, At-211, Ac-225) are marked `slow: true` —
+ * their WASM simulation takes >60s on CI runners. Playwright's
+ * `test.slow()` triples the timeout to 360s.
  */
 
 const PRESETS = [
@@ -16,44 +20,51 @@ const PRESETS = [
     url: "./#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ",
     expectIsotope: /99m?Tc|Tc-99|43-99/,
     expectLayer: "L2",
+    slow: false,
   },
   {
     name: "F-18",
     url: "./#config=1:NYwxDkBQEETvMvWS9RHsCXQOIApEQoKIiOZn7275UcwU8ybPY4B4HBALYYIkJWGEcMyZElZI67EZnvu7P-1yfYxdrhRA7ZooKX-SEvbX2Lxls01VoaodYYEUjjno9QE",
     expectIsotope: /18F|F-18|9-18/,
     expectLayer: "L2",
+    slow: false,
   },
   {
     name: "Ge-68",
     url: "./#config=1:LY0xDgAgCEPvwmwk4insAXQOuBgH4-K9zfpS2nyvrYcDJ2PDIibAmEGxQurWYlXTGFPzXiYOF6hBb0IZR64P",
     expectIsotope: /68Ge|Ge-68|32-68/,
     expectLayer: "L1",
+    slow: true, // 4-layer Ga/Ge stack — WASM >60s on CI
   },
   {
     name: "At-211",
     url: "./#config=1:LYwxDoAgEET_ss1aQOJPbNRGWxeNFfH3Lksxmcx_exkfD8rcOY0FGDNIb0hhglqEiA6KZ53rYuFygR70a6hh5H_3FQ",
     expectIsotope: /211At|At-211|85-211/,
     expectLayer: "L1",
+    slow: true, // α emitter complex XS — WASM >60s on CI
   },
   {
     name: "Ac-225",
     url: "./#config=1:q1ZKUrKqVipQsgJiHaVUJSsjEx2lZCUrAz0Dw1odpRwlq-hqpVygdFCirpGRGVBNCVQyVkcpU8nKwszEwMAArMXE2AjIrAUA",
     expectIsotope: /225Ac|Ac-225|89-225/,
     expectLayer: "L1",
+    slow: true, // Ra target decay chain — WASM >60s on CI
   },
 ];
 
 test.describe("preset golden tests", { tag: "@preset" }, () => {
   for (const preset of PRESETS) {
     test(`${preset.name} produces ${preset.expectIsotope.source}`, async ({ page }) => {
+      if (preset.slow) test.slow(); // triples timeout to 360s
       test.setTimeout(120_000);
 
       const errors: string[] = [];
       page.on("pageerror", (e) => errors.push(e.message));
 
       await page.goto(preset.url);
-      // Heavy presets (Ge-68, At-211, Ac-225) need up to ~90s for WASM
-      // simulation. Align selector waits with the 120s global timeout.
+      // Heavy presets need up to ~120s for WASM simulation on CI runners.
+      // test.slow() triples the base timeout; selector waits use 110s as
+      // a safety margin under the 120s base (or 360s with slow()).
       await page.waitForSelector(".status-bar", { state: "hidden", timeout: 110_000 }).catch(() => {});
       await page.waitForSelector(".activity-table-enhanced", { timeout: 110_000 });
 


### PR DESCRIPTION
## Summary

Heavy preset golden tests (Ge-68, At-211, Ac-225) need >110s for WASM simulation on CI runners. Previous fix (#311) increased selector timeouts to 110s but that's still not enough.

Fix: `test.slow()` (Playwright built-in) triples the test timeout from 120s to 360s. Only applied to the 3 heavy presets; Tc-99m and F-18 keep the 120s base.

## Test plan
- [ ] CI passes
- [ ] After merge: staging smoke `@preset` passes all 5 presets

🤖 Generated with [Claude Code](https://claude.com/claude-code)