### PR TITLE
fix(build): SSoT script for frontend data copy — bundle emissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,16 @@ jobs:
             exit 1
           fi
 
+      # All frontend-building workflows must use the SSoT copy script.
+      - name: Assert workflows use copy-frontend-data.sh
+        run: |
+          for wf in tauri-build deploy-frontend promote-to-prod e2e e2e-tauri; do
+            if ! grep -q 'copy-frontend-data.sh' ".github/workflows/${wf}.yml"; then
+              echo "::error::${wf}.yml doesn't use scripts/copy-frontend-data.sh — data copy will drift."
+              exit 1
+            fi
+          done
+
       # release-hyrr-mcp build/sdist jobs must init the nucl-parquet
       # submodule — core depends on it via path.
       - name: Assert release-hyrr-mcp.yml inits submodule in all build jobs

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -51,18 +51,8 @@ jobs:
 
       - name: Copy nuclear data for frontend
         run: |
-          mkdir -p frontend/public/data/parquet/{meta/ensdf,stopping,xs,hi-xs-prod,neutron-xs}
-          cp nucl-parquet/data/meta/abundances.parquet nucl-parquet/data/meta/decay.parquet nucl-parquet/data/meta/elements.parquet frontend/public/data/parquet/meta/
-          cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp -f nucl-parquet/data/meta/spectrum_xs.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          # Unified per-element emissions (absolute per-decay intensities, data-2026.5.2+)
-          cp -r nucl-parquet/data/meta/ensdf/emissions frontend/public/data/parquet/meta/ensdf/emissions 2>/dev/null || true
-          # He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through ASTAR with velocity-scaling at lookup time (see packages/compute/src/_energy-loss.ts and core/src/stopping.rs).
-          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/stopping/catima_C12.parquet nucl-parquet/data/stopping/catima_O16.parquet nucl-parquet/data/stopping/catima_Ne20.parquet nucl-parquet/data/stopping/catima_Si28.parquet nucl-parquet/data/stopping/catima_Ar40.parquet nucl-parquet/data/stopping/catima_Fe56.parquet frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/hi-xs-prod/xs/*.parquet frontend/public/data/parquet/hi-xs-prod/
-          cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
+          scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+            tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -58,11 +58,7 @@ jobs:
             data/tendl-2023-iso/xs
 
       - name: Copy parquet data to frontend public dir
-        run: |
-          mkdir -p frontend/public/data/parquet/{xs,meta,stopping}
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/meta/*.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp nucl-parquet/data/stopping/*.parquet frontend/public/data/parquet/stopping/
+        run: scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet tendl-2023-iso
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,30 +55,8 @@ jobs:
 
       - name: Copy nuclear data for frontend
         run: |
-          mkdir -p frontend/public/data/parquet/{meta/ensdf,stopping,xs,hi-xs-prod,neutron-xs}
-          cp nucl-parquet/data/meta/abundances.parquet \
-             nucl-parquet/data/meta/decay.parquet \
-             nucl-parquet/data/meta/elements.parquet \
-             frontend/public/data/parquet/meta/
-          cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp -f nucl-parquet/data/meta/spectrum_xs.parquet            frontend/public/data/parquet/meta/ 2>/dev/null || true
-          # Unified per-element emissions (absolute per-decay intensities, data-2026.5.2+)
-          cp -r nucl-parquet/data/meta/ensdf/emissions frontend/public/data/parquet/meta/ensdf/emissions 2>/dev/null || true
-          cp nucl-parquet/data/stopping/PSTAR.parquet \
-             nucl-parquet/data/stopping/ASTAR.parquet \
-             nucl-parquet/data/stopping/dSTAR.parquet \
-             nucl-parquet/data/stopping/tSTAR.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/stopping/catima_C12.parquet \
-             nucl-parquet/data/stopping/catima_O16.parquet \
-             nucl-parquet/data/stopping/catima_Ne20.parquet \
-             nucl-parquet/data/stopping/catima_Si28.parquet \
-             nucl-parquet/data/stopping/catima_Ar40.parquet \
-             nucl-parquet/data/stopping/catima_Fe56.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet  frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/hi-xs-prod/xs/*.parquet  frontend/public/data/parquet/hi-xs-prod/
-          cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
+          scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+            tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -239,30 +217,8 @@ jobs:
 
       - name: Copy nuclear data for frontend
         run: |
-          mkdir -p frontend/public/data/parquet/{meta/ensdf,stopping,xs,hi-xs-prod,neutron-xs}
-          cp nucl-parquet/data/meta/abundances.parquet \
-             nucl-parquet/data/meta/decay.parquet \
-             nucl-parquet/data/meta/elements.parquet \
-             frontend/public/data/parquet/meta/
-          cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp -f nucl-parquet/data/meta/spectrum_xs.parquet            frontend/public/data/parquet/meta/ 2>/dev/null || true
-          # Unified per-element emissions (absolute per-decay intensities, data-2026.5.2+)
-          cp -r nucl-parquet/data/meta/ensdf/emissions frontend/public/data/parquet/meta/ensdf/emissions 2>/dev/null || true
-          cp nucl-parquet/data/stopping/PSTAR.parquet \
-             nucl-parquet/data/stopping/ASTAR.parquet \
-             nucl-parquet/data/stopping/dSTAR.parquet \
-             nucl-parquet/data/stopping/tSTAR.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/stopping/catima_C12.parquet \
-             nucl-parquet/data/stopping/catima_O16.parquet \
-             nucl-parquet/data/stopping/catima_Ne20.parquet \
-             nucl-parquet/data/stopping/catima_Si28.parquet \
-             nucl-parquet/data/stopping/catima_Ar40.parquet \
-             nucl-parquet/data/stopping/catima_Fe56.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet  frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/hi-xs-prod/xs/*.parquet  frontend/public/data/parquet/hi-xs-prod/
-          cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
+          scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+            tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
 
       - name: Build WASM compute engine
         run: wasm-pack build wasm/ --target web --no-opt --out-dir ../frontend/src/lib/compute/hyrr-wasm-pkg
@@ -329,30 +285,8 @@ jobs:
 
       - name: Copy nuclear data for frontend
         run: |
-          mkdir -p frontend/public/data/parquet/{meta/ensdf,stopping,xs,hi-xs-prod,neutron-xs}
-          cp nucl-parquet/data/meta/abundances.parquet \
-             nucl-parquet/data/meta/decay.parquet \
-             nucl-parquet/data/meta/elements.parquet \
-             frontend/public/data/parquet/meta/
-          cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp -f nucl-parquet/data/meta/spectrum_xs.parquet            frontend/public/data/parquet/meta/ 2>/dev/null || true
-          # Unified per-element emissions (absolute per-decay intensities, data-2026.5.2+)
-          cp -r nucl-parquet/data/meta/ensdf/emissions frontend/public/data/parquet/meta/ensdf/emissions 2>/dev/null || true
-          cp nucl-parquet/data/stopping/PSTAR.parquet \
-             nucl-parquet/data/stopping/ASTAR.parquet \
-             nucl-parquet/data/stopping/dSTAR.parquet \
-             nucl-parquet/data/stopping/tSTAR.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/stopping/catima_C12.parquet \
-             nucl-parquet/data/stopping/catima_O16.parquet \
-             nucl-parquet/data/stopping/catima_Ne20.parquet \
-             nucl-parquet/data/stopping/catima_Si28.parquet \
-             nucl-parquet/data/stopping/catima_Ar40.parquet \
-             nucl-parquet/data/stopping/catima_Fe56.parquet \
-             frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet  frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/hi-xs-prod/xs/*.parquet  frontend/public/data/parquet/hi-xs-prod/
-          cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
+          scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+            tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -58,18 +58,8 @@ jobs:
 
       - name: Copy nuclear data for frontend
         run: |
-          mkdir -p frontend/public/data/parquet/{meta/ensdf,stopping,xs,hi-xs-prod,neutron-xs}
-          cp nucl-parquet/data/meta/abundances.parquet nucl-parquet/data/meta/decay.parquet nucl-parquet/data/meta/elements.parquet frontend/public/data/parquet/meta/
-          cp -f nucl-parquet/data/meta/dose_constants.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp -f nucl-parquet/data/meta/spectrum_xs.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          # Unified per-element emissions (absolute per-decay intensities, data-2026.5.2+)
-          cp -r nucl-parquet/data/meta/ensdf/emissions frontend/public/data/parquet/meta/ensdf/emissions 2>/dev/null || true
-          # He3STAR removed in nucl-parquet data-2026.5.0 — ³He routes through ASTAR with velocity-scaling at lookup time.
-          cp nucl-parquet/data/stopping/PSTAR.parquet nucl-parquet/data/stopping/ASTAR.parquet nucl-parquet/data/stopping/dSTAR.parquet nucl-parquet/data/stopping/tSTAR.parquet frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/stopping/catima_C12.parquet nucl-parquet/data/stopping/catima_O16.parquet nucl-parquet/data/stopping/catima_Ne20.parquet nucl-parquet/data/stopping/catima_Si28.parquet nucl-parquet/data/stopping/catima_Ar40.parquet nucl-parquet/data/stopping/catima_Fe56.parquet frontend/public/data/parquet/stopping/
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/hi-xs-prod/xs/*.parquet frontend/public/data/parquet/hi-xs-prod/
-          cp nucl-parquet/data/endfb-8.1/xs/n_*.parquet frontend/public/data/parquet/neutron-xs/
+          scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+            tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -55,11 +55,7 @@ jobs:
 
       - name: Copy parquet data to frontend public dir
         shell: bash
-        run: |
-          mkdir -p frontend/public/data/parquet/{xs,meta,stopping}
-          cp nucl-parquet/data/tendl-2023-iso/xs/*.parquet frontend/public/data/parquet/xs/
-          cp nucl-parquet/data/meta/*.parquet frontend/public/data/parquet/meta/ 2>/dev/null || true
-          cp nucl-parquet/data/stopping/*.parquet frontend/public/data/parquet/stopping/
+        run: scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet tendl-2023-iso
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/scripts/copy-frontend-data.sh
+++ b/scripts/copy-frontend-data.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SSoT script for copying nucl-parquet data into the frontend's public dir.
+#
+# Every workflow that builds the frontend (deploy-frontend.yml,
+# tauri-build.yml, e2e.yml, promote-to-prod.yml) calls this instead
+# of maintaining its own cp block. The data manifest lives HERE — if
+# HYRR starts consuming a new view, add it once and every build picks
+# it up.
+#
+# Usage:
+#   scripts/copy-frontend-data.sh <nucl-parquet-data-dir> <frontend-public-dir> [library...]
+#
+# Libraries are specified as "catalog-name" (→ $DEST/xs/) or
+# "catalog-name:subdir" (→ $DEST/subdir/) for non-default output paths.
+#
+# Example:
+#   scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
+#     tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
+set -euo pipefail
+
+NP="${1:?Usage: $0 <nucl-parquet-data-dir> <frontend-public-dir> [library...]}"
+DEST="${2:?Usage: $0 <nucl-parquet-data-dir> <frontend-public-dir> [library...]}"
+shift 2
+LIBRARIES=("${@:-tendl-2023-iso}")
+
+# ── Meta (shared across all libraries) ────────────────────────────
+mkdir -p "$DEST/meta/ensdf/emissions"
+for f in abundances decay elements dose_constants spectrum_xs compound_compositions; do
+  [ -f "$NP/meta/${f}.parquet" ] && cp "$NP/meta/${f}.parquet" "$DEST/meta/"
+done
+
+# Per-element emission parquets (γ/α/β/CE/X-ray/Auger)
+if [ -d "$NP/meta/ensdf/emissions" ]; then
+  cp "$NP/meta/ensdf/emissions/"*.parquet "$DEST/meta/ensdf/emissions/" 2>/dev/null || true
+fi
+
+# ── Stopping ──────────────────────────────────────────────────────
+mkdir -p "$DEST/stopping/compounds"
+cp "$NP/stopping/"*.parquet "$DEST/stopping/" 2>/dev/null || true
+# NIST compound stopping (PSTAR/ASTAR compounds)
+cp "$NP/stopping/compounds/"*.parquet "$DEST/stopping/compounds/" 2>/dev/null || true
+
+# ── Cross-section libraries ───────────────────────────────────────
+# Format: "name" → xs/, or "name:subdir" → subdir/
+for spec in "${LIBRARIES[@]}"; do
+  lib="${spec%%:*}"
+  subdir="${spec#*:}"
+  [ "$subdir" = "$lib" ] && subdir="xs"  # no colon → default to xs/
+  if [ -d "$NP/$lib/xs" ]; then
+    mkdir -p "$DEST/$subdir"
+    cp "$NP/$lib/xs/"*.parquet "$DEST/$subdir/"
+  fi
+done
+
+echo "copy-frontend-data: done → $DEST (${LIBRARIES[*]})"


### PR DESCRIPTION
## Summary

5 workflows each maintained their own inline `cp` blocks for copying nucl-parquet data into the frontend public dir. The `tauri-build.yml` and `e2e-tauri.yml` workflows missed `meta/ensdf/emissions/` (subdirectory not matched by flat glob), so the desktop app had no emission plot data.

### Fix: one SSoT script

`scripts/copy-frontend-data.sh` is the single source of truth for which nucl-parquet data HYRR consumes. All 5 workflows now call it:

```bash
scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet \
  tendl-2023-iso hi-xs-prod:hi-xs-prod endfb-8.1:neutron-xs
```

- **Meta**: abundances, decay, elements, dose_constants, spectrum_xs, compound_compositions + per-element emissions
- **Stopping**: all *.parquet + compounds/
- **XS**: per-library with configurable output subdir (`lib:subdir` syntax)

CI guard verifies every frontend-building workflow uses the script.

**Before**: 5 workflows × ~15 lines each = 75 lines of drifting cp blocks
**After**: 1 script (49 lines) + 5 one-liner calls

## Test plan
- [ ] CI passes (including SSoT guard)
- [ ] After re-release: desktop app shows emission data

🤖 Generated with [Claude Code](https://claude.com/claude-code)