### PR TITLE
feat(mcp): auto-fetch nuclear data for uvx hyrr-mcp

### DIFF
--- a/.github/workflows/e2e-tauri.yml
+++ b/.github/workflows/e2e-tauri.yml
@@ -8,6 +8,7 @@ name: E2E Tauri (WebDriver smoke)
 # support (no WKWebView driver exists).
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     paths:

--- a/desktop/tests/specs/golden-sim.spec.js
+++ b/desktop/tests/specs/golden-sim.spec.js
@@ -1,0 +1,116 @@
+/**
+ * Golden simulation test — Tier 3 desktop smoke.
+ *
+ * Loads the Tc-99m "feeling lucky" preset via URL hash, waits for the
+ * activity table to appear with production data, and asserts Tc-99
+ * is among the produced isotopes.
+ *
+ * This catches the class of bugs where the desktop app launches and
+ * shows the stopping profile but produces no isotopes — e.g. missing
+ * XS data in the embedded tar, Tauri IPC errors in compute_stack, or
+ * silent fallback to an uninitialised WASM backend.
+ *
+ * Refs: #315, #318
+ */
+
+// Tc-99m preset — fast, single-layer, always produces Tc-99.
+const PRESET_URL =
+  "#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+
+describe("Golden simulation (Tc-99m preset)", () => {
+  before(async () => {
+    // Wait for app init
+    const appFlow = await $(".app-flow");
+    await appFlow.waitForExist({ timeout: 30_000 });
+  });
+
+  it("should load a Cu target config and trigger simulation", async function () {
+    this.timeout(60_000);
+
+    // The hash is only read on initial page load (finishPostDataLoad).
+    // After boot, set config programmatically via the Svelte store.
+    // Use a minimal Cu target at 18 MeV — guaranteed to produce Zn-63.
+    const applied = await browser.execute(() => {
+      try {
+        // The config store is not directly on window, but we can
+        // trigger a full page reload with the hash set.
+        window.location.hash =
+          "#config=1:NY27CoRADEX_5dbZJSM7sqa19gvEQkVQ8IWozZB_N6NYBJKck5uABhKwQqwIHcSlhBbCX-eVMELKgMlwX5_1ZsoeGXNi9AHF8nHMRhY7TghzDCxsCIh7s7PMq756frwhXivCAPmnP-b76d3pBQ";
+        window.location.reload();
+        return "reloading";
+      } catch (e) {
+        return "error: " + e.message;
+      }
+    });
+
+    // Wait for app to fully reinitialize after reload
+    const appFlow = await $(".app-flow");
+    await appFlow.waitForExist({ timeout: 30_000 });
+
+    // Give simulation time to run
+    await browser.pause(5000);
+  });
+
+  it("should show the activity table with production data", async function () {
+    this.timeout(180_000);
+
+    // Wait 5s for config to be applied and simulation to start
+    await browser.pause(5000);
+
+    // Dump page state for diagnosis
+    const diag = await browser.execute(() => {
+      const hash = window.location.hash;
+      const statusBar = document.querySelector(".status-bar");
+      const errorCard = document.querySelector(".error-card");
+      const actTable = document.querySelector(".activity-table-enhanced");
+      const configRow = document.querySelector(".config-row");
+      const layers = document.querySelectorAll(".layer-row");
+      return {
+        hash: hash.slice(0, 50) + "...",
+        hasStatusBar: !!statusBar,
+        statusBarText: statusBar?.textContent?.slice(0, 100) || null,
+        hasErrorCard: !!errorCard,
+        errorCardText: errorCard?.textContent?.slice(0, 200) || null,
+        hasActivityTable: !!actTable,
+        hasConfigRow: !!configRow,
+        layerCount: layers.length,
+        bodyClasses: document.body.className,
+      };
+    });
+    // Fail with diagnosis if table is not already visible
+    if (!diag.hasActivityTable) {
+      throw new Error(
+        `Activity table not found after 5s. Diagnosis: ${JSON.stringify(diag)}`
+      );
+    }
+
+    const rows = await $$(".activity-table-enhanced tbody tr");
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("should produce Tc-99 in the results", async () => {
+    // Get all cell text from the activity table
+    const rows = await $$(".activity-table-enhanced tbody tr");
+    const texts = [];
+    for (const row of rows) {
+      texts.push(await row.getText());
+    }
+    const allText = texts.join(" ");
+
+    // Tc-99 (or Tc-99m) must appear
+    const hasTc99 = /Tc-99|99m?Tc|43-99/.test(allText);
+    expect(hasTc99).toBe(true);
+  });
+
+  it("should have used the Tauri backend (not WASM fallback)", async () => {
+    // Verify the backend is "tauri" — if it fell through to WASM,
+    // the compute might silently fail with no XS loaded.
+    const backend = await browser.execute(() => {
+      // The backend module exposes getActiveBackend() on window for debug
+      // If not available, check for Tauri internals as proxy
+      return "__TAURI_INTERNALS__" in window ? "tauri" : "unknown";
+    });
+    expect(backend).toBe("tauri");
+  });
+});
+// trigger CI

--- a/hyrr-mcp/src/main.rs
+++ b/hyrr-mcp/src/main.rs
@@ -137,8 +137,9 @@ fn print_help() {
              NUCL_PARQUET_DATA  Nucl-parquet data directory (alternative)\n    \
              HYRR_LIBRARY       Nuclear data library (if --library not set)\n\
          \n\
-         On first run, required data files are fetched lazily from GitHub\n\
-         (~30 MB for a typical session). Cached in ~/.nucl-parquet/.\n\
+         On first run, ~5 MB of metadata is fetched from GitHub.\n\
+         Cross-section data is fetched per-element on demand as tools\n\
+         query it. Cached in ~/.nucl-parquet/.\n\
          \n\
          Register with Claude Code:\n    \
              claude mcp add hyrr -- hyrr-mcp\n",

--- a/py-mcp/Cargo.toml
+++ b/py-mcp/Cargo.toml
@@ -13,4 +13,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 hyrr-core = { path = "../core", features = ["mcp"] }
+nucl-parquet = { path = "../nucl-parquet/clients/rs/nucl-parquet", features = ["fetch"] }
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py311"] }

--- a/py-mcp/python/hyrr_mcp/__init__.py
+++ b/py-mcp/python/hyrr_mcp/__init__.py
@@ -30,8 +30,9 @@ def _print_help() -> None:
         "ENVIRONMENT:\n"
         "    HYRR_DATA         Nucl-parquet data directory (if --data-dir not set)\n"
         "    HYRR_LIBRARY      Nuclear data library (if --library not set)\n\n"
-        "On first run, required data files are fetched lazily from GitHub\n"
-        "(~30 MB for a typical session). Cached in ~/.nucl-parquet/.\n\n"
+        "On first run, ~5 MB of metadata is fetched from GitHub.\n"
+        "Cross-section data is fetched per-element on demand as tools\n"
+        "query it. Cached in ~/.nucl-parquet/.\n\n"
         "Register with Claude Code:\n"
         "    claude mcp add hyrr -- uvx hyrr-mcp\n"
     )

--- a/py-mcp/python/hyrr_mcp/__init__.py
+++ b/py-mcp/python/hyrr_mcp/__init__.py
@@ -30,6 +30,8 @@ def _print_help() -> None:
         "ENVIRONMENT:\n"
         "    HYRR_DATA         Nucl-parquet data directory (if --data-dir not set)\n"
         "    HYRR_LIBRARY      Nuclear data library (if --library not set)\n\n"
+        "On first run, required data files are fetched lazily from GitHub\n"
+        "(~30 MB for a typical session). Cached in ~/.nucl-parquet/.\n\n"
         "Register with Claude Code:\n"
         "    claude mcp add hyrr -- uvx hyrr-mcp\n"
     )
@@ -51,14 +53,14 @@ def main() -> int:
         _print_help()
         return 0
 
-    # Resolve data dir: explicit --data-dir wins, otherwise fall back to
-    # the shared Rust resolver (env + sibling + home).
-    data_dir = _arg_value(argv, "--data-dir")
-    if data_dir is None:
-        data_dir = os.environ.get("HYRR_DATA") or _native.resolve_data_dir()
-
     # Resolve library: --library arg → HYRR_LIBRARY env → DEFAULT_LIBRARY.
     library = _arg_value(argv, "--library") or os.environ.get("HYRR_LIBRARY") or None
+
+    # Resolve data dir: explicit --data-dir / HYRR_DATA wins, otherwise
+    # resolve locally → auto-fetch from GitHub on first run (~30 MB).
+    data_dir = _arg_value(argv, "--data-dir") or os.environ.get("HYRR_DATA")
+    if data_dir is None:
+        data_dir = _native.ensure_data(library)
 
     _native.run(data_dir, library)
     return 0

--- a/py-mcp/src/lib.rs
+++ b/py-mcp/src/lib.rs
@@ -24,6 +24,57 @@ fn resolve_data_dir() -> String {
     hyrr_core::data_dir::resolve()
 }
 
+/// Resolve the data directory with auto-fetch fallback.
+/// Same 3-tier logic as the standalone Rust binary:
+///   1. nucl-parquet DataDir::resolve() (existing local data)
+///   2. nucl-parquet DataDir::ensure_lazy() (lazy HTTP fetch on first run)
+/// Returns the data root path or raises RuntimeError.
+#[pyfunction]
+#[pyo3(signature = (library=None))]
+fn ensure_data(library: Option<String>) -> PyResult<String> {
+    // Try existing local data first
+    if let Ok(dd) = nucl_parquet::DataDir::resolve() {
+        return Ok(dd.root().to_string_lossy().to_string());
+    }
+
+    // No local data — lazy-fetch from GitHub
+    let dd = nucl_parquet::DataDir::ensure_lazy().map_err(|e| {
+        pyo3::exceptions::PyRuntimeError::new_err(format!(
+            "Failed to resolve or fetch nuclear data: {e}\n\n\
+             Set HYRR_DATA or NUCL_PARQUET_DATA to point at a nucl-parquet data directory,\n\
+             or check your network connection."
+        ))
+    })?;
+
+    // Pre-fetch eager files that NpDataStore::new() needs
+    let eager = [
+        "meta/abundances.parquet",
+        "meta/decay.parquet",
+        "meta/dose_constants.parquet",
+        "stopping/PSTAR.parquet",
+        "stopping/ASTAR.parquet",
+        "stopping/dSTAR.parquet",
+        "stopping/tSTAR.parquet",
+        "stopping/catima/catima.parquet",
+        "stopping/compounds/PSTAR_compounds.parquet",
+        "stopping/compounds/ASTAR_compounds.parquet",
+    ];
+    for f in &eager {
+        if let Err(e) = dd.fetch_file(f) {
+            eprintln!("hyrr-mcp: warning: failed to fetch {f}: {e}");
+        }
+    }
+
+    // Pre-fetch library manifest
+    let lib = library.unwrap_or_else(|| {
+        hyrr_core::mcp::transport::DEFAULT_LIBRARY.to_string()
+    });
+    let manifest = format!("{lib}/manifest.json");
+    let _ = dd.fetch_file(&manifest);
+
+    Ok(dd.root().to_string_lossy().to_string())
+}
+
 /// Default nuclear data library identifier (e.g. "tendl-2023-iso").
 #[pyfunction]
 fn default_library() -> &'static str {
@@ -34,6 +85,7 @@ fn default_library() -> &'static str {
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run, m)?)?;
     m.add_function(wrap_pyfunction!(resolve_data_dir, m)?)?;
+    m.add_function(wrap_pyfunction!(ensure_data, m)?)?;
     m.add_function(wrap_pyfunction!(default_library, m)?)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())


### PR DESCRIPTION
## Summary

Consumer reported: `uvx hyrr-mcp` on a clean machine errors with "no nucl-parquet data found". The standalone Rust binary had `ensure_lazy()` but the PyPI wheel's Python entry point skipped it.

Fix: expose `ensure_data()` from the native module (same 3-tier logic as the Rust binary), call it from the Python `main()` when no explicit data dir is set. ~30 MB fetched on first run, cached in `~/.nucl-parquet/`.

## Test plan
- [ ] CI passes
- [ ] `uvx hyrr-mcp` from clean machine auto-fetches and starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)