### PR TITLE
fix(compute): normalize state in chain-solver result (#323)

### DIFF
--- a/core/src/compute.rs
+++ b/core/src/compute.rs
@@ -555,7 +555,7 @@ fn apply_chain_solver_by_component(
                     name,
                     z: ciso.z,
                     a: ciso.a,
-                    state: ciso.state.clone(),
+                    state: if ciso.state == "g" { String::new() } else { ciso.state.clone() },
                     half_life_s: ciso.half_life_s,
                     production_rate: prod_rate,
                     saturation_yield_bq_ua: sat_yield,


### PR DESCRIPTION
## Summary

Missed normalization site from #316: the chain-solver's `IsotopeResult.state` passed `ciso.state` raw (`"g"`) while the name was already normalized. This was the last un-normalized path.

Without this, Sc-44 from direct `Ca-44(p,n)` and Sc-44 from `IT(Sc-44m)` could get different state values, causing the frontend to render them as separate entries.

One-line fix: `state: if ciso.state == "g" { String::new() } else { ciso.state.clone() }`

Closes #323

## Test plan
- [ ] CI passes
- [ ] Sc-44 config from the bug report shows one merged row

🤖 Generated with [Claude Code](https://claude.com/claude-code)