### PR TITLE
fix(frontend): stack emission bars instead of overlay (#324)

### DIFF
--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -339,7 +339,7 @@
           y: rates,
           type: "bar",
           name: nucLabel(agg.name),
-          marker: { color },
+          marker: { color, opacity: 0.85 },
           hovertemplate: `%{x:.1f} keV<br>%{y:.2e} /s<br>${nucLabel(agg.name)}<extra></extra>`,
         });
         colorIdx++;
@@ -433,7 +433,7 @@
         gridcolor: tc.border,
         type: logY ? "log" : "linear",
       },
-      barmode: "overlay",
+      barmode: "stack",
       bargap: 0,
       hovermode: "closest",
       hoverdistance: 30,


### PR DESCRIPTION
## Summary

Closes #324. 511 keV emission line from multiple β⁺ emitters overlapped — only the tallest bar visible. 

Fix: `barmode: "overlay"` → `"stack"`. Plotly renders stacked colored segments showing each isotope's contribution. Total height = sum. Hover shows per-isotope info (already worked). Added 0.85 opacity for segment distinction.

β spectrum tabs unaffected — they use scatter traces, not bars.

## Test plan
- [ ] CI passes
- [ ] 511 keV line shows stacked contributions from multiple isotopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)