### PR TITLE
feat(frontend): paste URL to load config (#332)

### DIFF
--- a/frontend/src/lib/components/HeaderBar.svelte
+++ b/frontend/src/lib/components/HeaderBar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { toggleHistory, getHistoryOpen } from "../stores/ui.svelte";
   import { setConfig, resetConfig, getSerializableConfig, restoreSerializableConfig } from "../stores/config.svelte";
-  import { encodeConfigV2 } from "../config-url-v2";
+  import { encodeConfigV2, decodeSerializableFromString } from "../config-url-v2";
   import { PRESETS } from "../presets";
   import SessionTabs from "./SessionTabs.svelte";
   import HelpModal from "./HelpModal.svelte";
@@ -22,6 +22,20 @@
   let resolved = $derived(getResolvedTheme());
   let saveMenuOpen = $state(false);
   let copied = $state<"hash" | "share" | null>(null);
+  let loadError = $state("");
+
+  function loadFromUrl(input: string) {
+    loadError = "";
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    const config = decodeSerializableFromString(trimmed);
+    if (config) {
+      restoreSerializableConfig(config);
+      saveMenuOpen = false;
+    } else {
+      loadError = "Could not parse config from URL";
+    }
+  }
 
   let currentHash = $derived(encodeConfigV2(getSerializableConfig()));
   let shareUrl = $derived(`${SHARE_BASE}${currentHash}`);
@@ -120,14 +134,25 @@
       {#if saveMenuOpen}
         <div class="save-menu" role="menu">
           <div class="share-section">
-            <label class="share-label">Share link</label>
+            <label class="share-label" for="share-url-input">Share / load config</label>
             <div class="share-row">
               <input
+                id="share-url-input"
                 class="share-input"
                 type="text"
-                readonly
                 value={shareUrl}
-                onclick={(e) => (e.target as HTMLInputElement).select()}
+                placeholder="Paste a HYRR URL to load…"
+                onfocus={(e) => (e.target as HTMLInputElement).select()}
+                onkeydown={(e) => {
+                  if (e.key === "Enter") loadFromUrl((e.target as HTMLInputElement).value);
+                }}
+                onpaste={(e) => {
+                  const text = e.clipboardData?.getData("text");
+                  if (text && text.includes("#config=")) {
+                    e.preventDefault();
+                    loadFromUrl(text);
+                  }
+                }}
               />
               <button
                 class="share-btn"
@@ -152,6 +177,9 @@
                 {/if}
               </button>
             </div>
+            {#if loadError}
+              <p class="load-error">{loadError}</p>
+            {/if}
           </div>
           <div class="menu-sep"></div>
           <button class="menu-item" role="menuitem" onclick={() => saveSession(true)}>
@@ -274,6 +302,11 @@
     outline: none;
   }
   .share-input:focus { border-color: var(--c-accent); }
+  .load-error {
+    margin: 4px 0 0;
+    font-size: 0.7rem;
+    color: var(--c-red, #c00);
+  }
   .share-btn {
     display: flex;
     align-items: center;

--- a/frontend/src/lib/config-url-v2.ts
+++ b/frontend/src/lib/config-url-v2.ts
@@ -223,9 +223,16 @@ export function decodeConfigV2(encoded: string): SimulationConfig | null {
   }
 }
 
-/** Decode from hash — returns SerializableConfig (preserving groups). */
-export function decodeSerializableFromHash(): SerializableConfig | null {
-  const hash = window.location.hash.slice(1);
+/**
+ * Decode a config from a hash fragment string (without the leading "#").
+ * Accepts both v1 (plain base64) and v2 (compressed) formats.
+ * Works with raw hash ("config=1:...") or full URLs ("https://...#config=1:...").
+ */
+export function decodeSerializableFromString(input: string): SerializableConfig | null {
+  // Extract hash fragment from full URL if needed
+  const hashIdx = input.indexOf("#");
+  const hash = hashIdx >= 0 ? input.slice(hashIdx + 1) : input;
+
   if (!hash.startsWith("config=")) return null;
   const payload = hash.slice("config=".length);
 
@@ -247,6 +254,11 @@ export function decodeSerializableFromHash(): SerializableConfig | null {
   } catch {
     return null;
   }
+}
+
+/** Decode from current window hash. */
+export function decodeSerializableFromHash(): SerializableConfig | null {
+  return decodeSerializableFromString(window.location.hash.slice(1));
 }
 
 /** Decode from hash — flat SimulationConfig (legacy, for backward compat). */


### PR DESCRIPTION
## Summary

Closes #332. The share URL input is now editable — paste a HYRR URL to instantly load the config.

- `onpaste`: auto-detects `#config=` in clipboard text, parses and applies
- `Enter`: parses the current input value
- Extracted `decodeSerializableFromString()` to accept full URLs or raw hash fragments
- Error message shown on parse failure

562 tests pass, 0 regressions.

## Test plan
- [ ] CI passes
- [ ] Paste a share URL → config loads
- [ ] Enter on edited URL → config loads
- [ ] Invalid URL → error message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)