### PR TITLE
fix(frontend): use canonical isotope name format in IsotopePopup

### DIFF
--- a/frontend/src/lib/components/IsotopePopup.svelte
+++ b/frontend/src/lib/components/IsotopePopup.svelte
@@ -282,7 +282,7 @@
                 seenIso.add(isoKey);
                 const sym = Z_TO_SYMBOL[xs.residualZ] ?? `Z${xs.residualZ}`;
                 produced.push({
-                  name: `${sym}-${xs.residualA}${xs.state ? ` (${xs.state})` : ""}`,
+                  name: `${sym}-${xs.residualA}${xs.state === "g" ? "" : xs.state}`,
                   Z: xs.residualZ, A: xs.residualA, state: xs.state || "",
                 });
               }
@@ -715,7 +715,7 @@
       }
       if (!best || !best.time_grid_s || !best.activity_vs_time_Bq) return null;
       return {
-        name: best.name + (best.state ? ` (${best.state})` : ""),
+        name: best.name,
         times: [...best.time_grid_s],
         activities: [...best.activity_vs_time_Bq],
         productionRate: best.production_rate,


### PR DESCRIPTION
## Summary

- Fix isotope name construction in `IsotopePopup.svelte` that broke `nucHtml`/`nucLabel` rendering
- **Line 285**: compare selector built names like `"Tc-95 (m)"` instead of `"Tc-95m"` — `parseIsotopeName` regex failed, element symbol dropped from spectroscopy notation
- **Line 718**: activity curve data redundantly appended `" (m)"` to `best.name` (already canonical from Rust backend) — same parse failure

## Test plan

- [ ] Open isotope popup for a metastable isotope (e.g. Tc-95m from p+havar) — element symbol should display correctly
- [ ] Compare selector dropdown should show proper notation (e.g. `⁹⁵ᵐTc` not `⁹⁵ᵐ`)
- [ ] Activity curve legend labels should include element symbol

Fixes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)