### PR TITLE
feat(frontend): Cloudflare Web Analytics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,5 +80,18 @@
       <p>JavaScript is required to use this application.</p>
     </noscript>
     <script type="module" src="/src/main.ts"></script>
+
+    <!-- Cloudflare Web Analytics — privacy-respecting, no cookies, no PII.
+         Only loads on the web (not in Tauri desktop webview).
+         Token is public (shipped to every browser, write-only beacon). -->
+    <script>
+      if (!window.__TAURI_INTERNALS__) {
+        var s = document.createElement('script');
+        s.defer = true;
+        s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+        s.dataset.cfBeacon = '{"token": "eeee810c098b467bb2e2ef5aacae9d2c"}';
+        document.body.appendChild(s);
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

Adds Cloudflare Web Analytics beacon to the web frontend. Privacy-respecting (no cookies, no PII). Only loads on web — Tauri desktop is gated out.

**TODO before merge:** Replace `PLACEHOLDER_REPLACE_WITH_CF_TOKEN` in `frontend/index.html` with the real beacon token from Cloudflare dashboard.

## Test plan
- [ ] Replace placeholder token
- [ ] CI passes
- [ ] After deploy: verify pageviews appear in Cloudflare Web Analytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)