### PR TITLE
fix(frontend): consolidate material popup UX (#341)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -92,6 +92,7 @@
   let materialPopupOpen = $state(false);
   let materialPopupLayerIndex = $state(0);
   let materialPopupEditId = $state<string | null>(null);
+  let materialPopupQuery = $state("");
   let elementPopupOpen = $state(false);
   let elementPopupSymbol = $state("");
   let elementPopupEnrichment = $state<Record<number, number> | undefined>(undefined);
@@ -270,6 +271,7 @@
     }
     const cm = mat ? getCustomMaterials().find((m) => m.name === mat || m.formula === mat) : null;
     materialPopupEditId = cm?.id ?? null;
+    materialPopupQuery = cm ? "" : (mat ?? "");
     materialPopupOpen = true;
   }
 
@@ -465,6 +467,7 @@
         : (() => { const item = getInternalItems()[materialPopupLayerIndex]; return item && !('mode' in item) ? item.enrichment : undefined; })()}
       materials={[]}
       editMaterialId={materialPopupEditId}
+      initialQuery={materialPopupQuery}
       {projectile}
     />
 

--- a/frontend/src/lib/components/MaterialPopup.svelte
+++ b/frontend/src/lib/components/MaterialPopup.svelte
@@ -27,6 +27,8 @@
     /** Active beam projectile ("p", "d", "a", …). Used to compute the
      *  PeriodicTable's TENDL-coverage disabled set in a later commit. */
     projectile?: string;
+    /** Pre-fill search query when opening (e.g. clicked material name) */
+    initialQuery?: string;
   }
 
   let {
@@ -38,6 +40,7 @@
     materials,
     editMaterialId = null,
     projectile,
+    initialQuery = "",
   }: Props = $props();
 
   let query = $state("");
@@ -99,7 +102,7 @@
 
   $effect(() => {
     if (open) {
-      query = "";
+      query = initialQuery || "";
       editInitial = null;
       view = "search";
       // Force a clean state so a stale disabledSet from a previous

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -575,11 +575,6 @@
 <svelte:window onclick={onModeMenuWindow} onkeydown={onModeMenuWindow} />
 
 <div class="define-section">
-  <button class="define-toggle" onclick={() => { defineOpen = !defineOpen; }}>
-    <span class="toggle-icon">{defineOpen ? "▾" : "▸"}</span>
-    Define &amp; save material
-  </button>
-
   {#if defineOpen}
     <div class="define-form">
       <div class="mode-chip-row">


### PR DESCRIPTION
## Summary

Closes #341.

1. Removed redundant "Define & save material" toggle from DefineForm — form opens only via triggers (new material, edit custom, edit-as-custom)
2. Clicking a material in layers pre-fills search with the material name for quick editing

566 tests pass.

## Test plan
- [ ] CI passes
- [ ] "+ New material" in search opens the define form
- [ ] Clicking a layer material shows it pre-selected in search
- [ ] No manual "Define & save" toggle visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)