### PR TITLE
fix: custom material density affects implantation depth

### DIFF
--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -61,6 +61,9 @@ pub struct LayerConfig {
     pub areal_density_g_cm2: Option<f64>,
     pub energy_out_MeV: Option<f64>,
     pub is_monitor: Option<bool>,
+    /// Override resolved density (g/cm³). If set, takes precedence over
+    /// the density from resolve_material / material catalog.
+    pub density_g_cm3: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -152,7 +155,7 @@ fn config_to_layers(
             let overrides = lc.enrichment.as_ref();
             let resolution = resolve_material(db, &lc.material, overrides);
             Layer {
-                density_g_cm3: resolution.density,
+                density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
                 areal_density_g_cm2: lc.areal_density_g_cm2,

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -176,7 +176,7 @@
     setPkgCustomCompositionLookup(compositionFn);
     setCustomMaterialExpander((name) => {
       const cm = getCustomMaterials().find((m) => m.name === name);
-      return cm ? cm.formula : null;
+      return cm ? { formula: cm.formula, density: cm.density } : null;
     });
     setCustomMaterialResolver((identifier) => {
       const cm = getCustomMaterials().find((m) => m.name === identifier || m.formula === identifier);

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -141,8 +141,8 @@ export async function initBackend(
 /** Optional hook injected by the UI so the compute backend can expand custom
  *  material names (e.g. "H2O-custom") into something the Rust resolver can
  *  handle. Returns the formula to substitute, or null to leave unchanged. */
-let customMaterialExpander: ((name: string) => string | null) | null = null;
-export function setCustomMaterialExpander(fn: (name: string) => string | null): void {
+let customMaterialExpander: ((name: string) => { formula: string; density: number } | null) | null = null;
+export function setCustomMaterialExpander(fn: (name: string) => { formula: string; density: number } | null): void {
   customMaterialExpander = fn;
 }
 
@@ -150,8 +150,13 @@ function expandCustomMaterials(config: SimulationConfig): SimulationConfig {
   if (!customMaterialExpander) return config;
   const expand = customMaterialExpander;
   const layers = config.layers.map((layer) => {
-    const formula = expand(layer.material);
-    return formula && formula !== layer.material ? { ...layer, material: formula } : layer;
+    const result = expand(layer.material);
+    if (!result) return layer;
+    return {
+      ...layer,
+      material: result.formula,
+      density_g_cm3: layer.density_g_cm3 ?? result.density,
+    };
   });
   return { ...config, layers };
 }

--- a/packages/compute/src/config-bridge.ts
+++ b/packages/compute/src/config-bridge.ts
@@ -30,6 +30,9 @@ export interface LayerConfig {
   areal_density_g_cm2?: number;
   energy_out_MeV?: number;
   is_monitor?: boolean;
+  /** Override resolved density (g/cm³). If set, takes precedence over
+   *  the density from resolve_material / custom material catalog. */
+  density_g_cm3?: number;
 }
 
 export interface LayerGroup {
@@ -146,7 +149,7 @@ export function buildTargetStack(
     const { elements, density } = resolveMaterial(db, layerCfg.material, overrides);
 
     return {
-      densityGCm3: density,
+      densityGCm3: layerCfg.density_g_cm3 ?? density,
       elements,
       thicknessCm: layerCfg.thickness_cm ?? null,
       arealDensityGCm2: layerCfg.areal_density_g_cm2 ?? null,

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -423,6 +423,7 @@ struct LayerCfg {
     #[serde(alias = "energy_out_MeV")]
     energy_out_mev: Option<f64>,
     is_monitor: Option<bool>,
+    density_g_cm3: Option<f64>,
 }
 
 fn config_to_layers(db: &ParquetDataStore, config: &SimConfig) -> Vec<Layer> {
@@ -432,7 +433,7 @@ fn config_to_layers(db: &ParquetDataStore, config: &SimConfig) -> Vec<Layer> {
         .map(|lc| {
             let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref());
             Layer {
-                density_g_cm3: resolution.density,
+                density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
                 areal_density_g_cm2: lc.areal_density_g_cm2,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -574,6 +574,7 @@ struct LayerConfig {
     #[serde(alias = "energy_out_MeV")]
     energy_out_mev: Option<f64>,
     is_monitor: Option<bool>,
+    density_g_cm3: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -709,7 +710,7 @@ fn config_to_layers(db: &dyn DatabaseProtocol, config: &SimulationConfig) -> Vec
         .map(|lc| {
             let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref());
             Layer {
-                density_g_cm3: resolution.density,
+                density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
                 areal_density_g_cm2: lc.areal_density_g_cm2,


### PR DESCRIPTION
## Summary

Custom material density was ignored in simulation — Rust always used the default element/catalog density because `LayerConfig` had no `density_g_cm3` field.

Fix: add optional `density_g_cm3` to `LayerConfig` in all 4 surfaces (TS, Tauri, WASM, PyO3). Custom material expander now injects the density. All `config_to_layers` functions respect the override.

566 TS tests pass, Rust compiles clean.

## Test plan
- [ ] CI passes
- [ ] Create custom material with different density → implantation depth changes
- [ ] Default materials unaffected (field absent, falls back to resolved density)

🤖 Generated with [Claude Code](https://claude.com/claude-code)