### PR TITLE
fix: propagate inline density from share URL to Rust backend

### DIFF
--- a/core/src/materials.rs
+++ b/core/src/materials.rs
@@ -578,15 +578,11 @@ pub fn resolve_material(
                 )
             })?
         } else {
-            // No known density — warn but don't crash. Use 1.0 g/cm³ as a
-            // placeholder so the simulation runs. The frontend should surface
-            // this warning to prompt the user to set the actual density.
-            eprintln!(
-                "Warning: no density known for '{}'. Using 1.0 g/cm³. \
-                 Set density_g_cm3 on the layer or use define_material for accurate results.",
+            return Err(format!(
+                "No density known for compound '{}'. \
+                 Set the density in the material popup or use define_material.",
                 identifier
-            );
-            1.0
+            ));
         }
     };
 

--- a/desktop/src-tauri/src/commands.rs
+++ b/desktop/src-tauri/src/commands.rs
@@ -147,15 +147,14 @@ pub struct DepthPreviewPoint {
 fn config_to_layers(
     db: &EmbeddedDataStore,
     config: &SimulationConfig,
-) -> Vec<Layer> {
+) -> Result<Vec<Layer>, String> {
     config
         .layers
         .iter()
         .map(|lc| {
             let overrides = lc.enrichment.as_ref();
-            let resolution = resolve_material(db, &lc.material, overrides, None)
-                .expect("resolve_material failed");
-            Layer {
+            let resolution = resolve_material(db, &lc.material, overrides, None)?;
+            Ok(Layer {
                 density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
@@ -166,7 +165,7 @@ fn config_to_layers(
                 computed_energy_in: 0.0,
                 computed_energy_out: 0.0,
                 computed_thickness: 0.0,
-            }
+            })
         })
         .collect()
 }
@@ -284,7 +283,7 @@ pub fn run_compute_stack(
     let projectile = ProjectileType::from_str(&config.beam.projectile)
         .ok_or_else(|| format!("Invalid projectile: {}", config.beam.projectile))?;
 
-    let layers = config_to_layers(db, &config);
+    let layers = config_to_layers(db, &config)?;
 
     let current_profile = config
         .current_profile

--- a/frontend/src/lib/config-url-v2.ts
+++ b/frontend/src/lib/config-url-v2.ts
@@ -120,6 +120,9 @@ function expandLayer(cl: any): LayerConfig {
   // malformed share URL doesn't poison the session.
   if (cl.x && typeof cl.x === "object" && typeof cl.x.d === "number" && cl.x.e && typeof cl.x.e === "object") {
     registerSessionComposition(layer.material, { d: cl.x.d, e: cl.x.e });
+    // Also set density_g_cm3 on the layer so the Rust backend (which
+    // doesn't see the TS session composition) gets the custom density.
+    layer.density_g_cm3 = cl.x.d;
   }
   return layer;
 }

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -65,7 +65,8 @@ impl PyDataStore {
             pyo3::exceptions::PyValueError::new_err(format!("Invalid projectile: {projectile_str}"))
         })?;
 
-        let layers = config_to_layers(&*db, &config);
+        let layers = config_to_layers(&*db, &config)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e))?;
 
         let current_profile = config
             .current_profile
@@ -426,13 +427,13 @@ struct LayerCfg {
     density_g_cm3: Option<f64>,
 }
 
-fn config_to_layers(db: &ParquetDataStore, config: &SimConfig) -> Vec<Layer> {
+fn config_to_layers(db: &ParquetDataStore, config: &SimConfig) -> Result<Vec<Layer>, String> {
     config
         .layers
         .iter()
         .map(|lc| {
-            let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref(), None).expect("resolve_material");
-            Layer {
+            let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref(), None)?;
+            Ok(Layer {
                 density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
@@ -443,7 +444,7 @@ fn config_to_layers(db: &ParquetDataStore, config: &SimConfig) -> Vec<Layer> {
                 computed_energy_in: 0.0,
                 computed_energy_out: 0.0,
                 computed_thickness: 0.0,
-            }
+            })
         })
         .collect()
 }

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -201,7 +201,8 @@ impl WasmDataStore {
         let projectile = ProjectileType::from_str(&config.beam.projectile)
             .ok_or_else(|| JsValue::from_str(&format!("Invalid projectile: {}", config.beam.projectile)))?;
 
-        let layers = config_to_layers(&self.inner, &config);
+        let layers = config_to_layers(&self.inner, &config)
+            .map_err(|e| JsValue::from_str(&e))?;
 
         let current_profile = config
             .current_profile
@@ -705,14 +706,13 @@ fn stopping_error_to_jsvalue(err: StoppingError) -> JsValue {
     }
 }
 
-fn config_to_layers(db: &dyn DatabaseProtocol, config: &SimulationConfig) -> Vec<Layer> {
+fn config_to_layers(db: &dyn DatabaseProtocol, config: &SimulationConfig) -> Result<Vec<Layer>, String> {
     config
         .layers
         .iter()
         .map(|lc| {
-            let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref(), None)
-                .expect("resolve_material failed");
-            Layer {
+            let resolution = resolve_material(db, &lc.material, lc.enrichment.as_ref(), None)?;
+            Ok(Layer {
                 density_g_cm3: lc.density_g_cm3.unwrap_or(resolution.density),
                 elements: resolution.elements,
                 thickness_cm: lc.thickness_cm,
@@ -723,7 +723,7 @@ fn config_to_layers(db: &dyn DatabaseProtocol, config: &SimulationConfig) -> Vec
                 computed_energy_in: 0.0,
                 computed_energy_out: 0.0,
                 computed_thickness: 0.0,
-            }
+            })
         })
         .collect()
 }


### PR DESCRIPTION
Share URLs with custom materials now pass density_g_cm3 to Rust.