### PR TITLE
fix: density flows from material popup to layer config

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -275,7 +275,7 @@
     materialPopupOpen = true;
   }
 
-  function onMaterialSelected(material: string, enrichment?: Record<string, Record<number, number>>) {
+  function onMaterialSelected(material: string, enrichment?: Record<string, Record<number, number>>, density_g_cm3?: number) {
     if (materialPopupGroupIndex !== undefined) {
       const group = getGroup(materialPopupGroupIndex);
       const existing = group?.layers[materialPopupLayerIndex];
@@ -283,9 +283,9 @@
         ...(existing ?? { thickness_cm: 0.01 }),
         material,
         enrichment,
+        density_g_cm3,
       }, materialPopupGroupIndex);
     } else {
-      // Use internal items (not expanded layers) — index matches the items array
       const items = getInternalItems();
       const existing = items[materialPopupLayerIndex];
       if (existing && !('mode' in existing)) {
@@ -293,6 +293,7 @@
           ...existing,
           material,
           enrichment,
+          density_g_cm3,
         });
       }
     }

--- a/frontend/src/lib/components/MaterialPopup.svelte
+++ b/frontend/src/lib/components/MaterialPopup.svelte
@@ -16,7 +16,7 @@
   interface Props {
     open: boolean;
     onclose: () => void;
-    onselect: (material: string, enrichment?: Record<string, Record<number, number>>) => void;
+    onselect: (material: string, enrichment?: Record<string, Record<number, number>>, density_g_cm3?: number) => void;
     /** Open the enrichment popup for an element */
     onenrichment?: (element: string) => void;
     /** Current layer's enrichment overrides (for display) */
@@ -186,8 +186,8 @@
     }
   }
 
-  function handleCommit(material: string, enrichment?: Record<string, Record<number, number>>) {
-    onselect(material, enrichment);
+  function handleCommit(material: string, enrichment?: Record<string, Record<number, number>>, density_g_cm3?: number) {
+    onselect(material, enrichment, density_g_cm3);
     onclose();
   }
 

--- a/frontend/src/lib/components/material/DefineForm.svelte
+++ b/frontend/src/lib/components/material/DefineForm.svelte
@@ -42,7 +42,7 @@
     currentEnrichment?: Record<string, Record<number, number>>;
     onenrichment?: (element: string) => void;
     /** Called when the user commits a material (save & use OR use-without-saving). */
-    oncommit: (material: string, enrichment?: Record<string, Record<number, number>>) => void;
+    oncommit: (material: string, enrichment?: Record<string, Record<number, number>>, density_g_cm3?: number) => void;
   }
 
   let { editInitial, currentEnrichment, onenrichment, oncommit }: Props = $props();
@@ -556,7 +556,7 @@
       // slot so the round-2 race (Save at second 28 silently drops
       // demoted rows) can't fire. (#95)
       clearDemote();
-      oncommit(nameVal, enrichmentForSave);
+      oncommit(nameVal, enrichmentForSave, effectiveDensity ?? undefined);
       // Mark first-time guidance done after a successful save.
       dismissModeFirstTime();
     } catch {
@@ -568,7 +568,7 @@
 
   function useFormula() {
     if (rows.length === 0) return;
-    oncommit(mode === "single" ? serialised : displayFormula);
+    oncommit(mode === "single" ? serialised : displayFormula, undefined, effectiveDensity ?? undefined);
   }
 </script>
 

--- a/frontend/src/lib/components/material/SearchView.svelte
+++ b/frontend/src/lib/components/material/SearchView.svelte
@@ -11,7 +11,7 @@
     query: string;
     onQueryChange: (q: string) => void;
     materials: MaterialInfo[];
-    onselect: (material: string, enrichment?: Record<string, Record<number, number>>) => void;
+    onselect: (material: string, enrichment?: Record<string, Record<number, number>>, density_g_cm3?: number) => void;
     onclose: () => void;
     oneditRequest: (customId: string) => void;
     /** Catalog edit-as-fork: open DefineForm seeded with the catalog entry's
@@ -132,14 +132,9 @@
     const custom = findCustomEntry(entry);
     if (custom) {
       const cm = getCustomMaterials().find((m) => m.id === custom.customId);
-      onselect(custom.name, cm?.enrichment);
+      onselect(custom.name, cm?.enrichment, cm?.density ?? entry.density_g_cm3);
     } else {
-      // Pass the canonical path (catalog key like "havar", or the formula
-      // for compound/element entries) so picking Havar writes "havar" into
-      // the layer name rather than the expanded mass-fraction string. The
-      // resolver in core/src/materials.rs falls back to formula parsing if
-      // the path isn't a known catalog key. (#57)
-      onselect(entry.path);
+      onselect(entry.path, undefined, entry.density_g_cm3);
     }
     onclose();
   }

--- a/frontend/src/lib/compute/backend.ts
+++ b/frontend/src/lib/compute/backend.ts
@@ -142,7 +142,7 @@ export async function initBackend(
  *  material names (e.g. "H2O-custom") into something the Rust resolver can
  *  handle. Returns the formula to substitute, or null to leave unchanged. */
 let customMaterialExpander: ((name: string) => { formula: string; density: number } | null) | null = null;
-export function setCustomMaterialExpander(fn: (name: string) => { formula: string; density: number } | null): void {
+export function setCustomMaterialExpander(fn: ((name: string) => { formula: string; density: number } | null) | null): void {
   customMaterialExpander = fn;
 }
 

--- a/frontend/src/lib/config-url-v2.test.ts
+++ b/frontend/src/lib/config-url-v2.test.ts
@@ -190,3 +190,94 @@ describe("v3 inline composition (#96)", () => {
     expect(r.density).toBeCloseTo(2.5);
   });
 });
+
+describe("density_g_cm3 roundtrip", () => {
+  it("density_g_cm3 survives encode → decode", () => {
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 18, current_mA: 0.04 },
+      items: [{ material: "Ca44O", thickness_cm: 0.05, density_g_cm3: 3.34 }],
+      irradiation_s: 3600,
+      cooling_s: 3600,
+    };
+    const hash = encodeConfigV2(cfg);
+    const payload = hash.replace("#config=1:", "");
+    const decoded = decodeConfigV2Ser(payload);
+    expect(decoded).not.toBeNull();
+    const layer = decoded!.items[0] as { density_g_cm3?: number };
+    expect(layer.density_g_cm3).toBeCloseTo(3.34);
+  });
+
+  it("layer with density_g_cm3 set preserves it through URL", () => {
+    // When the material popup correctly sets density_g_cm3, URLs carry it.
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 18, current_mA: 0.04 },
+      items: [{ material: "Ca44O", thickness_cm: 0.05, density_g_cm3: 3.34 }],
+      irradiation_s: 3600,
+      cooling_s: 3600,
+    };
+    const hash = encodeConfigV2(cfg);
+    const payload = hash.replace("#config=1:", "");
+    const decoded = decodeConfigV2Ser(payload);
+    const layer = decoded!.items[0] as { density_g_cm3?: number };
+    expect(layer.density_g_cm3).toBeCloseTo(3.34);
+  });
+
+  it("layer WITHOUT density_g_cm3 does NOT carry it — the gap", () => {
+    // This documents the current gap: if density_g_cm3 is not set
+    // on the layer (because onMaterialSelected doesn't pass it),
+    // the URL can't preserve it. See #361.
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 18, current_mA: 0.04 },
+      items: [{ material: "Ca44O", thickness_cm: 0.05 }],
+      irradiation_s: 3600,
+      cooling_s: 3600,
+    };
+    const hash = encodeConfigV2(cfg);
+    const payload = hash.replace("#config=1:", "");
+    const decoded = decodeConfigV2Ser(payload);
+    const layer = decoded!.items[0] as { density_g_cm3?: number };
+    expect(layer.density_g_cm3).toBeUndefined();
+  });
+
+  it("custom material density survives full encode→decode→compute roundtrip", async () => {
+    // Set up custom material resolver (simulates saved custom in IndexedDB)
+    const { setCustomMaterialResolver } = await import("./config-url-v2");
+    setCustomMaterialResolver((name) =>
+      name === "Ca44O"
+        ? { density: 3.34, massFractions: { Ca: 0.524, O: 0.476 } }
+        : null,
+    );
+
+    // Set up custom material expander (simulates what App.svelte registers)
+    const { setCustomMaterialExpander } = await import("./compute/backend");
+    setCustomMaterialExpander((name) =>
+      name === "Ca44O" ? { formula: "Ca44O", density: 3.34 } : null,
+    );
+
+    // 1. Create config with custom material
+    const cfg: SerializableConfig = {
+      beam: { projectile: "p", energy_MeV: 18, current_mA: 0.04 },
+      items: [{ material: "Ca44O", thickness_cm: 0.05 }],
+      irradiation_s: 3600,
+      cooling_s: 3600,
+    };
+
+    // 2. Encode to URL hash
+    const hash = encodeConfigV2(cfg);
+
+    // 3. Drop resolvers (simulate recipient with no IndexedDB)
+    setCustomMaterialResolver(null);
+    setCustomMaterialExpander(null);
+
+    // 4. Decode from URL hash
+    const payload = hash.replace("#config=1:", "");
+    const decoded = decodeConfigV2Ser(payload);
+    expect(decoded).not.toBeNull();
+
+    // 5. The decoded layer MUST carry density_g_cm3 so the Rust backend
+    //    can use it even without a custom material in IndexedDB.
+    const layer = decoded!.items[0] as { material: string; density_g_cm3?: number };
+    expect(layer.material).toBe("Ca44O");
+    expect(layer.density_g_cm3).toBeCloseTo(3.34);
+  });
+});


### PR DESCRIPTION
The missing link — density was known at selection time but never written to the layer. Now it is.