### PR TITLE
fix: SSoT config loading — presets get densities

### DIFF
--- a/frontend/src/lib/components/HeaderBar.svelte
+++ b/frontend/src/lib/components/HeaderBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { toggleHistory, getHistoryOpen } from "../stores/ui.svelte";
-  import { setConfig, resetConfig, getSerializableConfig, restoreSerializableConfig, getCurrentProfile } from "../stores/config.svelte";
+  import { resetConfig, getSerializableConfig, restoreSerializableConfig, getCurrentProfile } from "../stores/config.svelte";
   import { encodeConfigV2, decodeSerializableFromString } from "../config-url-v2";
   import { PRESETS } from "../presets";
   import SessionTabs from "./SessionTabs.svelte";
@@ -67,7 +67,21 @@
 
   function feelingLucky() {
     const idx = Math.floor(Math.random() * PRESETS.length);
-    setConfig({ ...PRESETS[idx].config });
+    loadSimConfig(PRESETS[idx].config);
+  }
+
+  /** SSoT config loader — converts SimulationConfig to SerializableConfig
+   *  and routes through restoreSerializableConfig. One path for all loads. */
+  function loadSimConfig(c: SimulationConfig) {
+    restoreSerializableConfig({
+      beam: c.beam,
+      items: c.layers,
+      irradiation_s: c.irradiation_s,
+      cooling_s: c.cooling_s,
+      currentProfile: c.currentProfile
+        ? { timesS: Array.from(c.currentProfile.timesS), currentsMA: Array.from(c.currentProfile.currentsMA) }
+        : undefined,
+    });
   }
 
   function saveSession(includeResult: boolean) {

--- a/frontend/src/lib/components/WelcomeScreen.svelte
+++ b/frontend/src/lib/components/WelcomeScreen.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { setConfig } from "../stores/config.svelte";
+  import { restoreSerializableConfig } from "../stores/config.svelte";
   import { PRESETS } from "../presets";
+  import type { SimulationConfig } from "../types";
   import logoUrl from "/logo.svg?url";
 
   interface Props {
@@ -10,14 +11,26 @@
   let { onstart }: Props = $props();
 
   function loadPreset(idx: number) {
-    setConfig({ ...PRESETS[idx].config });
+    loadSimConfig(PRESETS[idx].config);
     onstart?.();
   }
 
   function feelingLucky() {
     const idx = Math.floor(Math.random() * PRESETS.length);
-    setConfig({ ...PRESETS[idx].config });
+    loadSimConfig(PRESETS[idx].config);
     onstart?.();
+  }
+
+  function loadSimConfig(c: SimulationConfig) {
+    restoreSerializableConfig({
+      beam: c.beam,
+      items: c.layers,
+      irradiation_s: c.irradiation_s,
+      cooling_s: c.cooling_s,
+      currentProfile: c.currentProfile
+        ? { timesS: Array.from(c.currentProfile.timesS), currentsMA: Array.from(c.currentProfile.currentsMA) }
+        : undefined,
+    });
   }
 </script>
 

--- a/frontend/src/lib/stores/config.svelte.ts
+++ b/frontend/src/lib/stores/config.svelte.ts
@@ -11,8 +11,28 @@ import type {
   ProjectileType,
 } from "../types";
 import type { StackConfig, CurrentProfile } from "@hyrr/compute";
-import { expandLayers } from "@hyrr/compute";
+import { expandLayers, resolveMaterial } from "@hyrr/compute";
 import { getDataStore } from "../scheduler/sim-scheduler.svelte";
+
+/** Fill density_g_cm3 on layers that don't have it, using resolveMaterial.
+ *  SSoT: every config load path calls this so density is always set. */
+function fillDensities(items: Array<LayerConfig | InternalGroup>): void {
+  const db = getDataStore();
+  if (!db) return;
+  for (let i = 0; i < items.length; i++) {
+    const it = items[i];
+    if (isInternalGroup(it)) {
+      for (let j = 0; j < it.layers.length; j++) {
+        const l = it.layers[j];
+        if (!l.density_g_cm3 && l.material) {
+          try { it.layers[j] = { ...l, density_g_cm3: resolveMaterial(db, l.material).density }; } catch {}
+        }
+      }
+    } else if (!it.density_g_cm3 && it.material) {
+      try { items[i] = { ...it, density_g_cm3: resolveMaterial(db, it.material).density } as LayerConfig; } catch {}
+    }
+  }
+}
 
 // ─── Typed-array-safe JSON helpers ──────────────────────────────────
 //
@@ -265,14 +285,17 @@ export function restoreSerializableConfig(c: SerializableConfig): void {
   const profile = c.currentProfile;
   state = {
     beam: c.beam,
-    items: c.items.map((item: any) => {
-      if (item._group || item.mode) {
-        // It's a group
-        const { _group, ...group } = item;
-        return group as InternalGroup;
-      }
-      return item as LayerConfig;
-    }),
+    items: (() => {
+      const mapped = c.items.map((item: any) => {
+        if (item._group || item.mode) {
+          const { _group, ...group } = item;
+          return group as InternalGroup;
+        }
+        return item as LayerConfig;
+      });
+      fillDensities(mapped);
+      return mapped;
+    })(),
     irradiation_s: c.irradiation_s,
     cooling_s: c.cooling_s,
     // Reconstruct Float64Array from plain number[] in saved config
@@ -287,9 +310,11 @@ export function restoreSerializableConfig(c: SerializableConfig): void {
 
 export function setConfig(c: SimulationConfig): void {
   pushUndo();
+  const items: Array<LayerConfig | InternalGroup> = c.layers.map((l) => ({ ...l }));
+  fillDensities(items);
   state = {
     beam: c.beam,
-    items: c.layers.map((l) => ({ ...l })),
+    items,
     irradiation_s: c.irradiation_s,
     cooling_s: c.cooling_s,
     currentProfile: c.currentProfile ?? null,


### PR DESCRIPTION
fillDensities on every config load. Presets route through restoreSerializableConfig. One path.