### PR TITLE
fix: emission tabs grey + hover info

### DIFF
--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -23,13 +23,13 @@
   import { aggregateByIsotopeName } from "../plotting/aggregate-isotopes";
 
   const EMISSION_TABS = [
-    { id: "gamma", label: "\u03B3", radTypes: ["gamma", "annihilation"] as EmissionRadType[] },
-    { id: "alpha", label: "\u03B1", radTypes: ["alpha"] as EmissionRadType[] },
-    { id: "beta-", label: "\u03B2\u207B", radTypes: ["beta-"] as EmissionRadType[] },
-    { id: "beta+", label: "\u03B2\u207A", radTypes: ["beta+"] as EmissionRadType[] },
-    { id: "CE", label: "CE", radTypes: ["ce"] as EmissionRadType[] },
-    { id: "xray", label: "X-ray", radTypes: ["xray"] as EmissionRadType[] },
-    { id: "auger", label: "Auger", radTypes: ["auger"] as EmissionRadType[] },
+    { id: "gamma", label: "\u03B3", desc: "gamma", radTypes: ["gamma", "annihilation"] as EmissionRadType[] },
+    { id: "alpha", label: "\u03B1", desc: "alpha", radTypes: ["alpha"] as EmissionRadType[] },
+    { id: "beta-", label: "\u03B2\u207B", desc: "beta-minus", radTypes: ["beta-"] as EmissionRadType[] },
+    { id: "beta+", label: "\u03B2\u207A", desc: "beta-plus", radTypes: ["beta+"] as EmissionRadType[] },
+    { id: "CE", label: "CE", desc: "conversion electron", radTypes: ["ce"] as EmissionRadType[] },
+    { id: "xray", label: "X-ray", desc: "X-ray", radTypes: ["xray"] as EmissionRadType[] },
+    { id: "auger", label: "Auger", desc: "Auger electron", radTypes: ["auger"] as EmissionRadType[] },
   ] as const;
 
   type EmTabId = (typeof EMISSION_TABS)[number]["id"];
@@ -449,8 +449,12 @@
       <button
         class="ctrl-btn"
         class:active={activeEmTab === tab.id}
+        class:empty-tab={tabHasData[tab.id] === false}
         disabled={tabHasData[tab.id] === false}
         onclick={() => { activeEmTab = tab.id; }}
+        title={tabHasData[tab.id] === false
+          ? `No ${tab.desc} emissions`
+          : `Show ${tab.desc} emissions`}
       >
         {tab.label}
       </button>
@@ -557,6 +561,12 @@
     background: var(--c-bg-active);
     border-color: var(--c-accent);
     color: var(--c-accent);
+  }
+
+  .ctrl-btn.empty-tab {
+    opacity: 0.35;
+    cursor: not-allowed;
+    text-decoration: line-through;
   }
 
   .plot {

--- a/frontend/src/lib/components/EmissionPlot.svelte
+++ b/frontend/src/lib/components/EmissionPlot.svelte
@@ -9,6 +9,7 @@
    * Issue #219 — P0: gamma sticks at EOB/EOC with per-isotope colors.
    */
   import { onMount, onDestroy } from "svelte";
+  import { betaSpectrum } from "../plotting/beta-spectrum";
   import type { SimulationResult, IsotopeResultData } from "../types";
   import { darkLayout, PLOTLY_CONFIG, TRACE_COLORS, themeColors } from "../plotting/plotly-helpers";
   import type { CsvTrace } from "../plotting/csv-export";
@@ -106,9 +107,6 @@
   // β spectrum shape (Fermi function × phase space)
   // ---------------------------------------------------------------------------
 
-  const ME_KEV = 510.999; // electron rest mass in keV
-  const ALPHA_FS = 1 / 137.036; // fine-structure constant
-
   /**
    * Compute the allowed β spectrum shape N(E) for a single transition.
    * Returns arrays of (energy_keV, N) normalized so ∫N dE = 1.
@@ -118,44 +116,7 @@
    * @param isPlus - true for β⁺, false for β⁻
    * @param nPts - number of energy bins
    */
-  function betaSpectrum(
-    E0: number, Z: number, isPlus: boolean, nPts = 100,
-  ): { energies: number[]; shape: number[] } {
-    if (E0 <= 0) return { energies: [], shape: [] };
-    const energies: number[] = [];
-    const shape: number[] = [];
-    const dE = E0 / nPts;
-
-    for (let i = 1; i < nPts; i++) {
-      const E = i * dE; // kinetic energy
-      const Etot = E + ME_KEV; // total energy
-      const p = Math.sqrt(Etot * Etot - ME_KEV * ME_KEV); // momentum (keV/c)
-      const phasespace = p * Etot * (E0 - E) * (E0 - E);
-
-      // Fermi function (non-relativistic approximation)
-      const eta = (isPlus ? -1 : 1) * Z * ALPHA_FS * Etot / p;
-      const twoPiEta = 2 * Math.PI * eta;
-      const fermi = Math.abs(twoPiEta) < 1e-6
-        ? 1.0 // limit for small η
-        : twoPiEta / (1 - Math.exp(-twoPiEta));
-
-      energies.push(E);
-      shape.push(fermi * phasespace);
-    }
-
-    // Normalize to unit area
-    let area = 0;
-    for (let i = 0; i < shape.length - 1; i++) {
-      area += 0.5 * (shape[i] + shape[i + 1]) * dE;
-    }
-    if (area > 0) {
-      for (let i = 0; i < shape.length; i++) {
-        shape[i] /= area;
-      }
-    }
-
-    return { energies, shape };
-  }
+  // betaSpectrum extracted to plotting/beta-spectrum.ts for testability (#380)
 
   const BETA_TABS = new Set(["beta-", "beta+"]);
 
@@ -380,8 +341,8 @@
           type: "scatter",
           mode: "lines",
           line: { color: "#fff", width: 2, dash: "dash" },
-          name: "Sum",
-          hoverinfo: "skip",
+          name: "Σ Sum",
+          hovertemplate: "%{x:.1f} keV<br>Σ %{y:.2e} /s/keV<extra></extra>",
         });
       }
     }

--- a/frontend/src/lib/plotting/beta-spectrum.test.ts
+++ b/frontend/src/lib/plotting/beta-spectrum.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { betaSpectrum } from "./beta-spectrum";
+
+describe("betaSpectrum", () => {
+  it("returns empty for E0 <= 0", () => {
+    expect(betaSpectrum(0, 20, false).energies).toHaveLength(0);
+    expect(betaSpectrum(-10, 20, false).energies).toHaveLength(0);
+  });
+
+  it("first point is (0, 0) for β⁻ (#380)", () => {
+    const { energies, shape } = betaSpectrum(500, 20, false);
+    expect(energies[0]).toBe(0);
+    expect(shape[0]).toBe(0);
+  });
+
+  it("first point is (0, 0) for β⁺", () => {
+    const { energies, shape } = betaSpectrum(500, 20, true);
+    expect(energies[0]).toBe(0);
+    expect(shape[0]).toBe(0);
+  });
+
+  it("last point has E < E0 (spectrum doesn't include endpoint)", () => {
+    const { energies } = betaSpectrum(1000, 10, false);
+    expect(energies[energies.length - 1]).toBeLessThan(1000);
+  });
+
+  it("spectrum integrates to ~1 (unit area normalization)", () => {
+    const { energies, shape } = betaSpectrum(500, 20, false);
+    let area = 0;
+    for (let i = 0; i < shape.length - 1; i++) {
+      area += 0.5 * (shape[i] + shape[i + 1]) * (energies[i + 1] - energies[i]);
+    }
+    expect(area).toBeCloseTo(1.0, 1);
+  });
+
+  it("all shape values are non-negative", () => {
+    const { shape } = betaSpectrum(500, 20, false);
+    for (const v of shape) expect(v).toBeGreaterThanOrEqual(0);
+  });
+
+  it("β⁻ and β⁺ spectra have different shapes (Coulomb effect)", () => {
+    const minus = betaSpectrum(500, 20, false);
+    const plus = betaSpectrum(500, 20, true);
+    // They should differ — Coulomb attraction vs repulsion
+    const midIdx = Math.floor(minus.shape.length / 2);
+    // Compare at low energy where Coulomb effect is strongest
+    const lowIdx = 2;
+    const ratio = minus.shape[lowIdx] / plus.shape[lowIdx];
+    expect(ratio).toBeGreaterThan(1.1); // β⁻ enhanced at low E by Coulomb attraction
+  });
+});

--- a/frontend/src/lib/plotting/beta-spectrum.ts
+++ b/frontend/src/lib/plotting/beta-spectrum.ts
@@ -1,0 +1,46 @@
+/**
+ * Fermi function β spectrum shape.
+ *
+ * N(E) ∝ F(Z,E) × p × E_total × (E₀ - E)²
+ * Normalized to unit area. First point is always (0, 0).
+ */
+
+const ME_KEV = 510.999; // electron rest mass in keV
+const ALPHA_FS = 1 / 137.036;
+
+export function betaSpectrum(
+  E0: number, Z: number, isPlus: boolean, nPts = 100,
+): { energies: number[]; shape: number[] } {
+  if (E0 <= 0) return { energies: [], shape: [] };
+
+  const energies: number[] = [0]; // start at E=0
+  const shape: number[] = [0];     // N(0) = 0 (p→0, phasespace→0)
+  const dE = E0 / nPts;
+
+  for (let i = 1; i < nPts; i++) {
+    const E = i * dE;
+    const Etot = E + ME_KEV;
+    const p = Math.sqrt(Etot * Etot - ME_KEV * ME_KEV);
+    const phasespace = p * Etot * (E0 - E) * (E0 - E);
+
+    const eta = (isPlus ? -1 : 1) * Z * ALPHA_FS * Etot / p;
+    const twoPiEta = 2 * Math.PI * eta;
+    const fermi = Math.abs(twoPiEta) < 1e-6
+      ? 1.0
+      : twoPiEta / (1 - Math.exp(-twoPiEta));
+
+    energies.push(E);
+    shape.push(fermi * phasespace);
+  }
+
+  // Normalize to unit area
+  let area = 0;
+  for (let i = 0; i < shape.length - 1; i++) {
+    area += 0.5 * (shape[i] + shape[i + 1]) * (energies[i + 1] - energies[i]);
+  }
+  if (area > 0) {
+    for (let i = 0; i < shape.length; i++) shape[i] /= area;
+  }
+
+  return { energies, shape };
+}


### PR DESCRIPTION
Empty emission tabs visually greyed (opacity + strikethrough). Hover shows 'Show γ emissions' or 'No α emissions'.