### PR TITLE
refactor: eliminate WASM dual location (#385)

### DIFF
--- a/scripts/deploy-staging-manual.sh
+++ b/scripts/deploy-staging-manual.sh
@@ -17,7 +17,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo "=== 1/4 Building WASM ==="
-(cd wasm && wasm-pack build --target web --out-dir ../frontend/src/lib/wasm-pkg)
+(cd wasm && wasm-pack build --target web --out-dir ../frontend/src/lib/compute/hyrr-wasm-pkg)
 
 echo "=== 2/4 Copying nuclear data ==="
 scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet tendl-2023-iso


### PR DESCRIPTION
## Summary
- Fix `scripts/deploy-staging-manual.sh` to output WASM to canonical `frontend/src/lib/compute/hyrr-wasm-pkg/` path (was using legacy `wasm-pkg/`)
- Remove orphaned `frontend/src/lib/wasm-pkg/` directory (untracked, contained `.gitignore *`)
- All CI workflows already use the canonical path — this was the last reference

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)