### PR TITLE
refactor: density as first-class layer property (#387)

### DIFF
--- a/frontend/src/lib/presets.test.ts
+++ b/frontend/src/lib/presets.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { PRESETS } from "./presets";
+
+describe("presets", () => {
+  it("every layer has explicit density_g_cm3 (#387)", () => {
+    for (const preset of PRESETS) {
+      for (const layer of preset.config.layers) {
+        expect(
+          layer.density_g_cm3,
+          `Preset "${preset.id}" layer "${layer.material}" missing density_g_cm3`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/frontend/src/lib/presets.ts
+++ b/frontend/src/lib/presets.ts
@@ -74,9 +74,9 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "p", energy_MeV: 16, current_mA: 0.15 },
       layers: [
-        { material: "havar", thickness_cm: 0.0025 },
-        { material: "Mo-100", enrichment: { Mo: { 100: 0.995 } }, energy_out_MeV: 12 },
-        { material: "Cu", thickness_cm: 0.5 },
+        { material: "havar", thickness_cm: 0.0025, density_g_cm3: 8.3 },
+        { material: "Mo-100", enrichment: { Mo: { 100: 0.995 } }, energy_out_MeV: 12, density_g_cm3: 10.28 },
+        { material: "Cu", thickness_cm: 0.5, density_g_cm3: 8.96 },
       ],
       irradiation_s: 86400,
       cooling_s: 86400,
@@ -89,8 +89,8 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "p", energy_MeV: 18, current_mA: 0.04 },
       layers: [
-        { material: "havar", thickness_cm: 0.0025 },
-        { material: "H2O-18", enrichment: { O: { 18: 0.97 } }, thickness_cm: 0.3 },
+        { material: "havar", thickness_cm: 0.0025, density_g_cm3: 8.3 },
+        { material: "H2O-18", enrichment: { O: { 18: 0.97 } }, thickness_cm: 0.3, density_g_cm3: 1.11 },
       ],
       irradiation_s: 7200,
       cooling_s: 0,
@@ -103,7 +103,7 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "p", energy_MeV: 28, current_mA: 0.2 },
       layers: [
-        { material: "Ga", energy_out_MeV: 14 },
+        { material: "Ga", energy_out_MeV: 14, density_g_cm3: 5.91 },
       ],
       irradiation_s: 86400 * 7,
       cooling_s: 86400,
@@ -116,7 +116,7 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "a", energy_MeV: 28, current_mA: 0.02 },
       layers: [
-        { material: "Bi", energy_out_MeV: 20 },
+        { material: "Bi", energy_out_MeV: 20, density_g_cm3: 9.78 },
       ],
       irradiation_s: 7200,
       cooling_s: 3600,
@@ -129,7 +129,7 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "p", energy_MeV: 24, current_mA: 0.01 },
       layers: [
-        { material: "Ra-226", thickness_cm: 0.01 },
+        { material: "Ra-226", thickness_cm: 0.01, density_g_cm3: 5.50 },
       ],
       irradiation_s: 86400 * 10,
       cooling_s: 86400 * 5,
@@ -143,8 +143,8 @@ export const PRESETS: Preset[] = [
     config: {
       beam: { projectile: "p", energy_MeV: 16, current_mA: 0.030 },
       layers: [
-        { material: "havar", thickness_cm: 0.0025 },
-        { material: "Ca-44", enrichment: { Ca: { 44: 0.98 } }, energy_out_MeV: 6 },
+        { material: "havar", thickness_cm: 0.0025, density_g_cm3: 8.3 },
+        { material: "Ca-44", enrichment: { Ca: { 44: 0.98 } }, energy_out_MeV: 6, density_g_cm3: 1.55 },
       ],
       irradiation_s: 7200,
       cooling_s: 3600,

--- a/frontend/src/lib/stores/config.svelte.ts
+++ b/frontend/src/lib/stores/config.svelte.ts
@@ -14,9 +14,10 @@ import type { StackConfig, CurrentProfile } from "@hyrr/compute";
 import { expandLayers, resolveMaterial } from "@hyrr/compute";
 import { getDataStore } from "../scheduler/sim-scheduler.svelte";
 
-/** Fill density_g_cm3 on layers that don't have it, using resolveMaterial.
- *  SSoT: every config load path calls this so density is always set. */
-function fillDensities(items: Array<LayerConfig | InternalGroup>): void {
+/** Backward-compat migration: fill density_g_cm3 on layers from configs
+ *  that predate density-as-first-class (old URLs, legacy session files).
+ *  New configs always carry density from material-select time (#387). */
+function migrateMissingDensities(items: Array<LayerConfig | InternalGroup>): void {
   const db = getDataStore();
   if (!db) return;
   for (let i = 0; i < items.length; i++) {
@@ -298,7 +299,7 @@ export function restoreSerializableConfig(c: SerializableConfig): void {
           }
           return item as LayerConfig;
         });
-        fillDensities(mapped);
+        migrateMissingDensities(mapped);
         return mapped;
       })(),
       irradiation_s: c.irradiation_s,
@@ -314,11 +315,9 @@ export function restoreSerializableConfig(c: SerializableConfig): void {
 
 export function setConfig(c: SimulationConfig): void {
   mutate(() => {
-    const items: Array<LayerConfig | InternalGroup> = c.layers.map((l) => ({ ...l }));
-    fillDensities(items);
     state = {
       beam: c.beam,
-      items,
+      items: c.layers.map((l) => ({ ...l })),
       irradiation_s: c.irradiation_s,
       cooling_s: c.cooling_s,
       currentProfile: c.currentProfile ?? null,


### PR DESCRIPTION
## Summary
- All presets now carry explicit `density_g_cm3` on every layer (self-contained, no runtime lookup)
- `fillDensities` → `migrateMissingDensities` (clarifies it's a backward-compat migration, not SSoT)
- Removed migration from `setConfig` path — callers already have density set
- Kept in `restoreSerializableConfig` for old URL/session backward compat
- RED/GREEN test: every preset layer must have `density_g_cm3 > 0`

## Test plan
- [x] RED: removing density from a preset → test fails
- [x] GREEN: 578 tests pass (577 existing + 1 new preset test)

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)