### PR TITLE
fix(frontend): merge constant/profile current into single toggle

### DIFF
--- a/frontend/e2e/current-profile.spec.ts
+++ b/frontend/e2e/current-profile.spec.ts
@@ -7,8 +7,15 @@ import os from "node:os";
  * E2e tests for current profile upload (#328, #395).
  *
  * Tests two paths:
- * 1. File upload via the UI: upload CSV → profile card → preview → simulation
+ * 1. File upload via the UI: upload CSV → profile pill → detail + plot → simulation
  * 2. Preset-based profile: Sc-44 preset (7200-pt beam profile)
+ *
+ * Expected CSV format: two columns, header row.
+ *   time_s,current_mA
+ *   0.0,0.000
+ *   2.0,0.015
+ *   ...
+ * Time in seconds from start, current in milliamperes.
  */
 
 const TC99M_HASH =
@@ -50,70 +57,59 @@ test.afterAll(() => {
 test.describe("current profile — file upload", () => {
   test.setTimeout(90_000);
 
-  test("upload CSV → profile card with stats + preview plot", async ({ page }) => {
+  test("upload CSV → profile pill with stats in beam bar", async ({ page }) => {
     await page.goto(`./${TC99M_HASH}`);
     await waitForSimulation(page);
 
-    // File input should be visible (upload area)
-    const fileInput = page.locator("input.file-input");
+    // Upload via hidden file input
+    const fileInput = page.locator("input.file-input-hidden");
     await expect(fileInput).toBeAttached();
-
-    // Upload test CSV
     await fileInput.setInputFiles(csvPath);
 
-    // Profile card should appear
-    const profileLabel = page.locator(".profile-label");
-    await expect(profileLabel).toBeVisible({ timeout: 5_000 });
-    await expect(profileLabel).toHaveText("Current profile");
+    // Profile pill should appear in beam bar
+    const pill = page.locator(".profile-pill");
+    await expect(pill).toBeVisible({ timeout: 5_000 });
+    const pillText = await pill.textContent();
+    expect(pillText).toContain("50 pts");
 
-    // Stats should show 50 pts
-    const statsText = await page.locator(".profile-stats").textContent();
-    expect(statsText, "Stats should show point count").toContain("50 pts");
-
-    // Profile toggle should show Profile as active
-    const profileBtn = page.locator(".cm-btn").nth(1);
+    // Profile toggle should show PROFILE as active
+    const profileBtn = page.locator(".ct-btn").nth(1);
     await expect(profileBtn).toHaveClass(/active/);
 
-    // Upload area should be gone (replaced by profile card)
-    await expect(fileInput).not.toBeAttached();
+    // Detail section should appear below beam bar
+    await expect(page.locator(".profile-detail")).toBeVisible();
   });
 
   test("upload CSV → simulation recomputes with profile", async ({ page }) => {
     await page.goto(`./${TC99M_HASH}`);
     await waitForSimulation(page);
 
-    // Upload profile
-    await page.locator("input.file-input").setInputFiles(csvPath);
-    await expect(page.locator(".profile-label")).toBeVisible({ timeout: 5_000 });
-
-    // Wait for recompute
+    await page.locator("input.file-input-hidden").setInputFiles(csvPath);
+    await expect(page.locator(".profile-pill")).toBeVisible({ timeout: 5_000 });
     await waitForSimulation(page);
 
-    // Results should exist
     const rows = page.locator(".activity-table-enhanced tbody tr");
     await expect(rows.first()).toBeVisible();
     expect(await rows.count()).toBeGreaterThan(0);
   });
 
-  test("clear profile → reverts to constant mode + upload reappears", async ({ page }) => {
+  test("clear profile → reverts to constant mode", async ({ page }) => {
     await page.goto(`./${TC99M_HASH}`);
     await waitForSimulation(page);
 
-    // Upload then clear
-    await page.locator("input.file-input").setInputFiles(csvPath);
-    await expect(page.locator(".profile-label")).toBeVisible({ timeout: 5_000 });
+    await page.locator("input.file-input-hidden").setInputFiles(csvPath);
+    await expect(page.locator(".profile-pill")).toBeVisible({ timeout: 5_000 });
 
-    await page.locator(".profile-clear-btn").click();
+    // Click the pill to clear (pill hover = red, click clears)
+    await page.locator(".profile-pill").click();
 
-    // Profile card should disappear
-    await expect(page.locator(".profile-label")).not.toBeVisible();
+    // Profile should disappear, constant input should return
+    await expect(page.locator(".profile-pill")).not.toBeVisible();
+    await expect(page.locator("#bcb-current")).toBeVisible();
 
-    // Upload area should reappear
-    await expect(page.locator("input.file-input")).toBeAttached();
-
-    // Constant toggle should be active
-    const constantBtn = page.locator(".cm-btn").first();
-    await expect(constantBtn).toHaveClass(/active/);
+    // CONST toggle should be active
+    const constBtn = page.locator(".ct-btn").first();
+    await expect(constBtn).toHaveClass(/active/);
   });
 
   test("invalid CSV shows error, no crash", async ({ page }) => {
@@ -123,13 +119,10 @@ test.describe("current profile — file upload", () => {
     const badPath = path.join(os.tmpdir(), "hyrr-e2e-bad.csv");
     fs.writeFileSync(badPath, "not,a,valid,profile\nfoo,bar,baz,qux\n");
 
-    await page.locator("input.file-input").setInputFiles(badPath);
+    await page.locator("input.file-input-hidden").setInputFiles(badPath);
 
-    // Error should show
-    await expect(page.locator(".upload-error")).toBeVisible({ timeout: 3_000 });
-
-    // Profile card should NOT appear
-    await expect(page.locator(".profile-label")).not.toBeVisible();
+    await expect(page.locator(".upload-error-bar")).toBeVisible({ timeout: 3_000 });
+    await expect(page.locator(".profile-pill")).not.toBeVisible();
 
     fs.unlinkSync(badPath);
   });
@@ -141,8 +134,8 @@ test.describe("current profile — file upload", () => {
     await page.goto(`./${TC99M_HASH}`);
     await waitForSimulation(page);
 
-    await page.locator("input.file-input").setInputFiles(csvPath);
-    await expect(page.locator(".profile-label")).toBeVisible({ timeout: 5_000 });
+    await page.locator("input.file-input-hidden").setInputFiles(csvPath);
+    await expect(page.locator(".profile-pill")).toBeVisible({ timeout: 5_000 });
     await waitForSimulation(page);
 
     const fatal = errors.filter(
@@ -154,7 +147,6 @@ test.describe("current profile — file upload", () => {
 
 // ─── Preset-based profile tests ────────────────────────────────────
 
-/** Click Feeling Lucky until Sc-44 preset loads (has "Ca-44" in layer stack). */
 async function loadSc44ViaFeelingLucky(page: import("@playwright/test").Page) {
   for (let i = 0; i < 40; i++) {
     await page.locator(".lucky-tab").click();
@@ -170,7 +162,7 @@ async function loadSc44ViaFeelingLucky(page: import("@playwright/test").Page) {
 test.describe("current profile — Sc-44 preset", () => {
   test.setTimeout(120_000);
 
-  test("Sc-44 preset shows profile card + produces Sc isotopes", async ({ page }) => {
+  test("Sc-44 preset shows profile pill + detail + produces Sc isotopes", async ({ page }) => {
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(e.message));
 
@@ -178,17 +170,17 @@ test.describe("current profile — Sc-44 preset", () => {
     await waitForSimulation(page);
 
     const found = await loadSc44ViaFeelingLucky(page);
-    expect(found, "Could not load Sc-44 preset via Feeling Lucky after 40 tries").toBe(true);
+    expect(found, "Could not load Sc-44 preset after 40 tries").toBe(true);
 
-    // Profile card should be visible (Sc-44 preset has a built-in profile)
-    await expect(page.locator(".profile-label")).toBeVisible({ timeout: 5_000 });
+    // Profile pill should be visible (Sc-44 preset has a built-in profile)
+    await expect(page.locator(".profile-pill")).toBeVisible({ timeout: 5_000 });
+    // Detail section should show stats
+    await expect(page.locator(".profile-detail")).toBeVisible();
 
-    // Wait for recompute
     await page.waitForSelector(".status-dot.busy", { timeout: 5_000 }).catch(() => {});
     await page.waitForSelector(".status-dot.ready", { timeout: 60_000 }).catch(() => {});
     await page.waitForTimeout(1_000);
 
-    // Activity table should have Ca-44 reaction products
     const cellText = await page.locator(".activity-table-enhanced td").allTextContents();
     const hasCaProducts = cellText.some(
       (t) => t.includes("Sc") || t.includes("44K") || t.includes("Ti") || t.includes("Z21"),

--- a/frontend/src/lib/components/BeamConfigBar.svelte
+++ b/frontend/src/lib/components/BeamConfigBar.svelte
@@ -143,6 +143,7 @@
   // --- Current profile ---
   let currentProfile = $derived(getCurrentProfile());
   let profileMode = $derived<"constant" | "profile">(currentProfile ? "profile" : "constant");
+  let fileInputEl = $state<HTMLInputElement | null>(null);
   let uploadError = $state<string | null>(null);
   let parseWarnings = $state<string[]>([]);
   let showAllWarnings = $state(false);
@@ -227,12 +228,28 @@
     </div>
   </div>
 
-  <div class="field">
-    <label for="bcb-current">Current</label>
-    <div class="input-group">
-      <input id="bcb-current" type="text" inputmode="decimal" value={beam.current_mA * 1000} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onCurrentChange} />
-      <span class="unit">µA</span>
+  <div class="field current-field">
+    <!-- Constant / Profile toggle replaces the label -->
+    <div class="current-toggle">
+      <button class="ct-btn" class:active={profileMode === "constant"} onclick={clearProfile}>Const</button>
+      <button class="ct-btn" class:active={profileMode === "profile"} onclick={() => fileInputEl?.click()}>Profile</button>
     </div>
+    {#if profileMode === "constant" && !currentProfile}
+      <div class="input-group">
+        <input id="bcb-current" type="text" inputmode="decimal" value={beam.current_mA * 1000} onfocus={(e) => (e.target as HTMLInputElement).select()} onchange={onCurrentChange} />
+        <span class="unit">µA</span>
+      </div>
+    {:else if currentProfile && stats}
+      <button class="profile-pill" onclick={clearProfile} title="Click to clear profile and revert to constant current">
+        {stats.n} pts · {stats.minI_uA.toFixed(0)}–{stats.maxI_uA.toFixed(0)} µA
+      </button>
+    {:else}
+      <button class="upload-pill" onclick={() => fileInputEl?.click()}>
+        Upload CSV
+      </button>
+    {/if}
+    <!-- Hidden file input -->
+    <input bind:this={fileInputEl} type="file" accept=".csv,.tsv,.txt" onchange={handleCurrentUpload} class="file-input-hidden" />
   </div>
 
   <div class="field">
@@ -269,30 +286,19 @@
     <span class="status-dot" class:busy={isBusy} class:ready={simStatus === "ready"} class:error={simStatus === "error"} title={schedulerState}></span>
   </div>
 
-  <!-- Current mode toggle -->
-  <div class="current-mode-toggle">
-    <button class="cm-btn" class:active={profileMode === "constant"} onclick={clearProfile}>Constant</button>
-    <button class="cm-btn" class:active={profileMode === "profile"} onclick={() => {}}>Profile</button>
   </div>
-</div>
 
-<!-- Profile section (below beam bar) -->
-{#if profileMode === "profile" && currentProfile && stats}
-  <div class="profile-section">
-    <div class="profile-card">
-      <div class="profile-card-header">
-        <span class="profile-label">Current profile</span>
-        <div class="profile-stats">
-          <span>{stats.n} pts</span>
-          <span>{stats.durMin.toFixed(1)} min</span>
-          <span>{stats.minI_uA.toFixed(0)}–{stats.maxI_uA.toFixed(0)} µA</span>
-          <span>{(stats.charge / 1000).toFixed(4)} C</span>
-        </div>
-        <button class="profile-clear-btn" onclick={clearProfile} title="Remove profile, use constant current">Clear</button>
-      </div>
+<!-- Profile detail (below beam bar, only when profile loaded) -->
+{#if currentProfile && stats}
+  <div class="profile-detail">
+    <div class="profile-detail-header">
+      <span class="profile-detail-stats">
+        {stats.n} pts · {stats.durMin.toFixed(1)} min · {stats.minI_uA.toFixed(0)}–{stats.maxI_uA.toFixed(0)} µA · {(stats.charge / 1000).toFixed(4)} C
+      </span>
       {#if chargeDiscrepancy !== null}
-        <div class="charge-warning">Charge differs from constant by {chargeDiscrepancy.toFixed(1)}%</div>
+        <span class="charge-warning">Δ {chargeDiscrepancy.toFixed(1)}% vs constant</span>
       {/if}
+      <button class="profile-clear-btn" onclick={clearProfile} title="Remove profile, use constant current">Clear</button>
     </div>
     <PlotCurrentProfile profile={currentProfile} />
     {#if parseWarnings.length > 0}
@@ -308,22 +314,9 @@
       </div>
     {/if}
   </div>
-{:else if profileMode === "constant" && !currentProfile}
-  <!-- Upload area only shows inline, below the toggle -->
 {/if}
-
-<!-- Upload area (always accessible when no profile is loaded) -->
-{#if !currentProfile}
-  <div class="profile-upload">
-    <div class="upload-row">
-      <input type="file" accept=".csv,.tsv,.txt" onchange={handleCurrentUpload} class="file-input" />
-      <button class="paste-btn" onclick={handlePaste} title="Paste tab/comma-separated data from clipboard">Paste</button>
-    </div>
-    <span class="upload-hint">CSV: time_s, current_mA (or paste from clipboard)</span>
-    {#if uploadError}
-      <span class="upload-error">{uploadError}</span>
-    {/if}
-  </div>
+{#if uploadError}
+  <div class="upload-error-bar">{uploadError}</div>
 {/if}
 
 <style>
@@ -493,65 +486,78 @@
     50% { opacity: 0.3; }
   }
 
-  /* --- Current mode toggle --- */
-  .current-mode-toggle {
+  /* ─── Merged current field: Const/Profile toggle ─── */
+  .current-field { min-width: 100px; }
+
+  .current-toggle {
     display: flex;
     border: 1px solid var(--c-border);
-    border-radius: 4px;
+    border-radius: 3px;
     overflow: hidden;
-    align-self: flex-end;
   }
 
-  .cm-btn {
-    padding: 0.25rem 0.5rem;
+  .ct-btn {
+    flex: 1;
+    padding: 0.1rem 0.35rem;
     background: var(--c-bg-default);
     border: none;
     border-right: 1px solid var(--c-border);
     color: var(--c-text-muted);
-    font-size: 0.7rem;
+    font-size: 0.6rem;
     font-weight: 500;
     cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    white-space: nowrap;
   }
 
-  .cm-btn:last-child { border-right: none; }
-  .cm-btn:hover { color: var(--c-text); }
-  .cm-btn.active { background: var(--c-bg-active); color: var(--c-accent); font-weight: 600; }
+  .ct-btn:last-child { border-right: none; }
+  .ct-btn:hover { color: var(--c-text); }
+  .ct-btn.active { background: var(--c-bg-active); color: var(--c-accent); font-weight: 600; }
 
-  /* --- Profile section --- */
-  .profile-section {
+  .file-input-hidden {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .upload-pill, .profile-pill {
+    background: var(--c-bg-default);
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    color: var(--c-text-muted);
+    padding: 0.3rem 0.4rem;
+    font-size: 0.75rem;
+    cursor: pointer;
+    white-space: nowrap;
+    text-align: center;
+  }
+
+  .upload-pill:hover { border-color: var(--c-accent); color: var(--c-accent); }
+  .profile-pill { border-color: var(--c-accent); color: var(--c-accent); font-size: 0.65rem; }
+  .profile-pill:hover { border-color: var(--c-red); color: var(--c-red); }
+
+  /* ─── Profile detail (below beam bar) ─── */
+  .profile-detail {
     background: var(--c-bg-subtle);
     border: 1px solid var(--c-border);
     border-radius: 3px;
-    padding: 0.5rem;
+    padding: 0.4rem 0.5rem;
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.3rem;
   }
 
-  .profile-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-  }
-
-  .profile-card-header {
+  .profile-detail-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     flex-wrap: wrap;
   }
 
-  .profile-label {
-    color: var(--c-accent);
-    font-weight: 600;
-    font-size: 0.7rem;
-    white-space: nowrap;
-  }
-
-  .profile-stats {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.15rem 0.5rem;
+  .profile-detail-stats {
     font-size: 0.65rem;
     color: var(--c-text-muted);
   }
@@ -593,44 +599,11 @@
 
   .warnings-toggle:hover { color: var(--c-text-muted); }
 
-  /* --- Upload area --- */
-  .profile-upload {
-    background: var(--c-bg-subtle);
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    padding: 0.4rem 0.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.2rem;
-  }
-
-  .upload-row {
-    display: flex;
-    gap: 0.3rem;
-    align-items: center;
-  }
-
-  .file-input {
-    flex: 1;
+  .upload-error-bar {
     font-size: 0.7rem;
-    color: var(--c-text-muted);
+    color: var(--c-red);
+    padding: 0.25rem 0.5rem;
   }
-
-  .paste-btn {
-    background: none;
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    color: var(--c-text-muted);
-    padding: 0.2rem 0.5rem;
-    font-size: 0.7rem;
-    cursor: pointer;
-    white-space: nowrap;
-  }
-
-  .paste-btn:hover { border-color: var(--c-accent); color: var(--c-text); }
-
-  .upload-hint { font-size: 0.65rem; color: var(--c-text-subtle); }
-  .upload-error { font-size: 0.65rem; color: var(--c-red); }
 
   @media (max-width: 640px) {
     .beam-bar {


### PR DESCRIPTION
## Summary
- Unified CONST | PROFILE toggle replaces separate Current input + upload area
- Const: standard µA input. Profile: accent pill with stats, click to clear
- Hidden file input (no unstyled browser chrome), dark-mode native
- Profile detail below beam bar: stats, charge discrepancy, preview plot, warnings
- CSV format: `time_s,current_mA` — seconds from start, milliamperes
- 6 e2e tests updated for new selectors, all pass

## Test plan
- [x] 578 unit tests pass
- [x] 6/6 Playwright e2e tests pass (18s)
- [x] Visual verification: const mode, profile mode (Sc-44 preset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)