### PR TITLE
chore: dev script + just recipes for local development

### DIFF
--- a/justfile.project
+++ b/justfile.project
@@ -23,14 +23,37 @@ info:
 # PROJECT-SPECIFIC RECIPES
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Uncomment and customize for your project:
+# Full local dev: build WASM + copy data + start vite
+[group('dev')]
+dev *args:
+    scripts/dev.sh {{args}}
 
-# # Run the application
-# [group('app')]
-# run *args:
-#     uv run python -m {{project}} {{args}}
+# Dev server without WASM rebuild (fast restart)
+[group('dev')]
+dev-fast *args:
+    scripts/dev.sh --skip-wasm {{args}}
 
-# # Run database migrations (if using sidecar)
-# [group('app')]
-# migrate:
-#     just sidecar postgres migrate
+# Build WASM only
+[group('dev')]
+wasm:
+    wasm-pack build wasm/ --target web --out-dir ../frontend/src/lib/compute/hyrr-wasm-pkg
+
+# Copy nuclear data to frontend
+[group('dev')]
+data:
+    scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet tendl-2023-iso
+
+# Manual deploy to GitHub Pages tst/
+[group('deploy')]
+deploy-tst:
+    scripts/deploy-staging-manual.sh
+
+# Run frontend unit tests
+[group('test')]
+test-frontend:
+    cd frontend && npx vitest run
+
+# Run Playwright e2e tests (requires running dev server)
+[group('test')]
+test-e2e project="desktop-1280":
+    cd frontend && npx playwright test --project={{project}}

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Local development server — builds WASM, copies data, starts vite.
+#
+# Usage:
+#   scripts/dev.sh              # full build + dev server
+#   scripts/dev.sh --skip-wasm  # skip WASM rebuild (use existing)
+#   scripts/dev.sh --port 3000  # custom port
+#
+# Prerequisites:
+#   - wasm-pack installed (cargo install wasm-pack)
+#   - npm dependencies installed (cd frontend && npm install)
+#   - nucl-parquet submodule checked out (git submodule update --init)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SKIP_WASM=false
+PORT=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-wasm) SKIP_WASM=true; shift ;;
+    --port) PORT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1"; exit 1 ;;
+  esac
+done
+
+# 1. Submodule
+if [ ! -f nucl-parquet/data/catalog.json ]; then
+  echo "==> Initializing nucl-parquet submodule..."
+  git submodule update --init
+fi
+
+# 2. WASM
+if [ "$SKIP_WASM" = false ]; then
+  echo "==> Building WASM..."
+  wasm-pack build wasm/ --target web --out-dir ../frontend/src/lib/compute/hyrr-wasm-pkg
+else
+  echo "==> Skipping WASM build (--skip-wasm)"
+  if [ ! -f frontend/src/lib/compute/hyrr-wasm-pkg/hyrr_wasm_bg.wasm ]; then
+    echo "ERROR: No WASM binary found. Run without --skip-wasm first."
+    exit 1
+  fi
+fi
+
+# 3. Nuclear data
+echo "==> Copying nuclear data..."
+scripts/copy-frontend-data.sh nucl-parquet/data frontend/public/data/parquet tendl-2023-iso
+
+# 4. NPM deps
+if [ ! -d frontend/node_modules ]; then
+  echo "==> Installing npm dependencies..."
+  (cd frontend && npm install)
+fi
+
+# 5. Dev server
+echo "==> Starting vite dev server..."
+PORT_ARG=""
+[ -n "$PORT" ] && PORT_ARG="--port $PORT"
+cd frontend && exec npx vite --host 0.0.0.0 $PORT_ARG


### PR DESCRIPTION
## Summary
- New `scripts/dev.sh` — one command for full local dev setup (WASM + data + vite)
- Just recipes: `dev`, `dev-fast`, `wasm`, `data`, `deploy-tst`, `test-frontend`, `test-e2e`
- Prevents the "stale WASM" problem after git pulls

## Why
The WASM binary committed to git doesn't track new Rust exports. After a `git pull`, the committed WASM may lack functions added in recent PRs (e.g. `loadCompoundStoppingData`), causing "No compute backend available" errors. `just dev` rebuilds from source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)