### PR TITLE
feat: 3-way current profile constraint system + NshellEC fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [main]
 
 jobs:
+  lockfile-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check lockfiles in sync
+        run: bash scripts/check-lockfiles.sh
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,16 @@ repos:
         files: ^justfile(\..*)?$
         pass_filenames: false
 
+  # Lockfile staleness check
+  - repo: local
+    hooks:
+      - id: check-lockfiles
+        name: check lockfiles in sync
+        entry: scripts/check-lockfiles.sh
+        language: system
+        files: (pyproject\.toml|uv\.lock|wasm/Cargo\.(toml|lock))$
+        pass_filenames: false
+
   # Typo Linting
   - repo: https://github.com/crate-ci/typos
     rev: v1.39.0

--- a/frontend/src/lib/components/current-profile/GenerateTab.svelte
+++ b/frontend/src/lib/components/current-profile/GenerateTab.svelte
@@ -177,7 +177,7 @@
       <div class="input-row">
         {#if derivedField === "current"}
           <span class="derived-prefix">=</span>
-          <input type="number" value={effCurrentUA.toFixed(1)} disabled tabindex={-1} />
+          <input type="text" value={effCurrentUA.toFixed(1)} disabled tabindex={-1} />
         {:else}
           <input type="number" bind:value={plateauUA} oninput={onCurrentInput} min="0" step="1" />
         {/if}

--- a/frontend/src/lib/components/current-profile/GenerateTab.svelte
+++ b/frontend/src/lib/components/current-profile/GenerateTab.svelte
@@ -11,10 +11,10 @@
 
   // --- User-editable $state (only written by event handlers, never by $effect) ---
   let rampUpS = $state(60);
-  let plateauUA = $state(30);
+  let plateauUA = $state(30);       // user-set when derivedField !== "current"
   let rampDownS = $state(60);
-  let totalDurationS = $state(7200);
-  let itcUAh = $state(0);
+  let totalDurationS = $state(7200); // user-set when derivedField !== "duration"
+  let itcUAh = $state(0);           // user-set when derivedField !== "itc"
 
   /** Which field is computed from the other two. */
   let derivedField = $state<"current" | "duration" | "itc">("itc");
@@ -26,6 +26,7 @@
   let rampUpFeedback = $state("");
   let rampDownFeedback = $state("");
   let durationFeedback = $state("");
+  let itcText = $state("");
 
   function formatSeconds(s: number): string {
     if (s >= 3600) return `${(s / 3600).toPrecision(3)}h`;
@@ -42,27 +43,24 @@
     return text ? "?" : "";
   }
 
-  /** On commit (blur/Enter): resolve and replace input text with canonical form. */
-  function commitTime(text: string, setter: (s: number) => void, textSetter: (t: string) => void) {
-    const parsed = parseTime(text);
-    if (parsed) {
-      setter(parsed.seconds);
-      textSetter(formatSeconds(parsed.seconds));
-    }
-  }
-
-  // --- Ramp handlers ---
+  // --- Ramp handlers (don't change derivedField) ---
   function onRampUpInput(e: Event) {
     rampUpText = (e.target as HTMLInputElement).value;
     rampUpFeedback = handleTimeInput(rampUpText, (s) => { rampUpS = s; });
   }
-  function commitRampUp() { commitTime(rampUpText, (s) => { rampUpS = s; }, (t) => { rampUpText = t; rampUpFeedback = ""; }); }
+  function commitRampUp() {
+    const parsed = parseTime(rampUpText);
+    if (parsed) rampUpS = parsed.seconds;
+  }
 
   function onRampDownInput(e: Event) {
     rampDownText = (e.target as HTMLInputElement).value;
     rampDownFeedback = handleTimeInput(rampDownText, (s) => { rampDownS = s; });
   }
-  function commitRampDown() { commitTime(rampDownText, (s) => { rampDownS = s; }, (t) => { rampDownText = t; rampDownFeedback = ""; }); }
+  function commitRampDown() {
+    const parsed = parseTime(rampDownText);
+    if (parsed) rampDownS = parsed.seconds;
+  }
 
   // --- Field handlers (only active when field is NOT derived) ---
   function onCurrentInput(e: Event) {
@@ -74,7 +72,10 @@
     durationText = (e.target as HTMLInputElement).value;
     durationFeedback = handleTimeInput(durationText, (s) => { totalDurationS = s; });
   }
-  function commitDuration() { commitTime(durationText, (s) => { totalDurationS = s; }, (t) => { durationText = t; durationFeedback = ""; }); }
+  function commitDuration() {
+    const parsed = parseTime(durationText);
+    if (parsed) totalDurationS = parsed.seconds;
+  }
 
   function onItcInput(e: Event) {
     const v = parseFloat((e.target as HTMLInputElement).value);
@@ -82,7 +83,7 @@
   }
 
   // ---------------------------------------------------------------------------
-  // Pure $derived DAG — analytical solver, no cycles
+  // Pure $derived DAG — analytical solver, no $effect, no cycles
   // ---------------------------------------------------------------------------
 
   let solveResultCurrent: SolveResult = $derived(
@@ -103,6 +104,7 @@
       : { value: itcUAh, ok: true },
   );
 
+  /** Effective values fed to the profile generator — always valid numbers. */
   let effCurrentUA = $derived(solveResultCurrent.ok ? solveResultCurrent.value : 0);
   let effDurationS = $derived(solveResultDuration.ok ? solveResultDuration.value : 0);
   let effItcUAh = $derived(solveResultItc.ok ? solveResultItc.value : 0);
@@ -117,10 +119,20 @@
 
   let stats = $derived(profileStats(profile));
 
-  // Sync display text for derived fields
-  $effect(() => { if (derivedField === "duration") { durationText = formatSeconds(effDurationS); durationFeedback = ""; } });
-  $effect(() => { if (derivedField === "itc") { /* itc shown via effItcUAh directly */ } });
+  // Sync display text for derived fields so the user sees the computed value
+  $effect(() => {
+    if (derivedField === "duration") {
+      durationText = formatSeconds(effDurationS);
+      durationFeedback = "";
+    }
+  });
+  $effect(() => {
+    if (derivedField === "itc") {
+      itcText = effItcUAh.toFixed(2);
+    }
+  });
 
+  /** Error message for the currently derived field, if infeasible. */
   let derivedError = $derived.by(() => {
     if (derivedField === "current" && !solveResultCurrent.ok) return solveResultCurrent.error;
     if (derivedField === "duration" && !solveResultDuration.ok) return solveResultDuration.error;
@@ -130,7 +142,7 @@
 </script>
 
 <div class="generate-tab">
-  <!-- "Calculate" radio toggle -->
+  <!-- "Calculate:" radio selector -->
   <fieldset class="calculate-selector">
     <legend>Calculate</legend>
     <label class:active={derivedField === "current"}>
@@ -148,11 +160,10 @@
   </fieldset>
 
   <div class="form-grid">
-    <!-- Ramp up (always editable) -->
     <div class="form-field">
       <label>Ramp up</label>
       <div class="input-row">
-        <input type="text" value={rampUpText} oninput={onRampUpInput} onblur={commitRampUp} onkeydown={(e) => { if (e.key === 'Enter') { commitRampUp(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 1min" />
+        <input type="text" value={rampUpText} oninput={onRampUpInput} onblur={commitRampUp} onkeydown={(e) => { if (e.key === 'Enter') commitRampUp(); }} placeholder="e.g. 1min" />
         {#if rampUpFeedback && rampUpFeedback !== "?"}
           <span class="feedback ok">{rampUpFeedback}</span>
         {:else if rampUpFeedback === "?"}
@@ -161,12 +172,12 @@
       </div>
     </div>
 
-    <!-- Plateau current -->
     <div class="form-field" class:derived={derivedField === "current"}>
       <label>Plateau current</label>
       <div class="input-row">
         {#if derivedField === "current"}
-          <span class="derived-value">= {effCurrentUA.toFixed(1)}</span>
+          <span class="derived-prefix">=</span>
+          <input type="number" value={effCurrentUA.toFixed(1)} disabled tabindex={-1} />
         {:else}
           <input type="number" bind:value={plateauUA} oninput={onCurrentInput} min="0" step="1" />
         {/if}
@@ -174,11 +185,10 @@
       </div>
     </div>
 
-    <!-- Ramp down (always editable) -->
     <div class="form-field">
       <label>Ramp down</label>
       <div class="input-row">
-        <input type="text" value={rampDownText} oninput={onRampDownInput} onblur={commitRampDown} onkeydown={(e) => { if (e.key === 'Enter') { commitRampDown(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 1min" />
+        <input type="text" value={rampDownText} oninput={onRampDownInput} onblur={commitRampDown} onkeydown={(e) => { if (e.key === 'Enter') commitRampDown(); }} placeholder="e.g. 1min" />
         {#if rampDownFeedback && rampDownFeedback !== "?"}
           <span class="feedback ok">{rampDownFeedback}</span>
         {:else if rampDownFeedback === "?"}
@@ -187,17 +197,20 @@
       </div>
     </div>
 
-    <!-- Spacer -->
-    <div class="form-field"></div>
+    <div class="form-field">
+      <!-- spacer -->
+    </div>
 
-    <!-- Duration -->
     <div class="form-field" class:derived={derivedField === "duration"}>
       <label>Duration</label>
       <div class="input-row">
         {#if derivedField === "duration"}
-          <span class="derived-value">= {formatSeconds(effDurationS)}</span>
+          <span class="derived-prefix">=</span>
+          <input type="text" value={durationText} disabled tabindex={-1} />
         {:else}
-          <input type="text" value={durationText} oninput={onDurationInput} onblur={commitDuration} onkeydown={(e) => { if (e.key === 'Enter') { commitDuration(); (e.target as HTMLInputElement).blur(); }}} placeholder="e.g. 2h" />
+          <input type="text" value={durationText} oninput={onDurationInput} onblur={commitDuration} onkeydown={(e) => { if (e.key === 'Enter') commitDuration(); }} placeholder="e.g. 2h" />
+        {/if}
+        {#if derivedField !== "duration"}
           {#if durationFeedback && durationFeedback !== "?"}
             <span class="feedback ok">{durationFeedback}</span>
           {:else if durationFeedback === "?"}
@@ -207,12 +220,12 @@
       </div>
     </div>
 
-    <!-- ITC (integrated target current) -->
     <div class="form-field" class:derived={derivedField === "itc"}>
-      <label>ITC</label>
+      <label title="Integrated Target Current">ITC</label>
       <div class="input-row">
         {#if derivedField === "itc"}
-          <span class="derived-value">= {effItcUAh.toFixed(2)}</span>
+          <span class="derived-prefix">=</span>
+          <input type="number" value={effItcUAh.toFixed(2)} disabled tabindex={-1} />
         {:else}
           <input type="number" value={itcUAh.toFixed(2)} oninput={onItcInput} min="0" step="0.1" />
         {/if}
@@ -222,17 +235,17 @@
   </div>
 
   {#if derivedError}
-    <span class="solve-error">{derivedError}</span>
+    <div class="error-msg">{derivedError}</div>
   {/if}
 
   <PlotCurrentProfile {profile} />
 
   <div class="stats">
-    {stats.n} pts · {formatSeconds(stats.durationS)} · {stats.minCurrentUA.toFixed(0)}–{stats.maxCurrentUA.toFixed(0)} µA · {stats.chargeUAh.toFixed(2)} µAh
+    {stats.n} pts · {formatSeconds(stats.durationS)} · {stats.minCurrentUA.toFixed(0)}–{stats.maxCurrentUA.toFixed(0)} µA · {effItcUAh.toFixed(2)} µAh
   </div>
 
   <div class="actions">
-    <button class="confirm-btn" onclick={() => onselect(profile)}>Use this profile</button>
+    <button class="confirm-btn" onclick={() => onselect(profile)} disabled={!!derivedError}>Use this profile</button>
   </div>
 </div>
 
@@ -242,20 +255,19 @@
   .calculate-selector {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    border: none;
-    padding: 0;
+    gap: 0.6rem;
+    border: 1px solid var(--c-border);
+    border-radius: 4px;
+    padding: 0.25rem 0.5rem;
     margin: 0;
   }
 
   .calculate-selector legend {
-    font-size: 0.65rem;
-    color: var(--c-text-subtle);
+    font-size: 0.6rem;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
-    float: left;
-    margin-right: 0.5rem;
-    padding-top: 0.15rem;
+    letter-spacing: 0.05em;
+    color: var(--c-text-muted);
+    padding: 0 0.3rem;
   }
 
   .calculate-selector label {
@@ -265,15 +277,19 @@
     font-size: 0.75rem;
     color: var(--c-text-muted);
     cursor: pointer;
-    padding: 0.15rem 0.4rem;
-    border: 1px solid var(--c-border);
-    border-radius: 3px;
-    background: var(--c-bg-default);
   }
 
-  .calculate-selector label:hover { border-color: var(--c-accent); color: var(--c-text); }
-  .calculate-selector label.active { border-color: var(--c-accent); color: var(--c-accent); font-weight: 600; background: var(--c-bg-active); }
-  .calculate-selector input[type="radio"] { display: none; }
+  .calculate-selector label.active {
+    color: var(--c-accent);
+    font-weight: 600;
+  }
+
+  .calculate-selector input[type="radio"] {
+    accent-color: var(--c-accent);
+    margin: 0;
+    width: 12px;
+    height: 12px;
+  }
 
   .form-grid {
     display: grid;
@@ -287,13 +303,18 @@
     gap: 0.15rem;
   }
 
-  .form-field.derived { opacity: 0.7; }
-
   .form-field label {
     font-size: 0.65rem;
     color: var(--c-text-muted);
     text-transform: uppercase;
     letter-spacing: 0.04em;
+  }
+
+  .form-field.derived {
+    background: var(--c-accent-tint, rgba(255, 165, 0, 0.06));
+    border-radius: 4px;
+    padding: 0.2rem 0.3rem;
+    margin: -0.2rem -0.3rem;
   }
 
   .input-row {
@@ -314,12 +335,13 @@
   }
 
   .input-row input:focus { outline: none; border-color: var(--c-accent); }
+  .input-row input:disabled { opacity: 0.7; cursor: default; border-style: dashed; }
 
-  .derived-value {
-    font-size: 0.8rem;
+  .derived-prefix {
+    font-size: 0.85rem;
+    font-weight: 600;
     color: var(--c-accent);
-    font-weight: 500;
-    padding: 0.3rem 0;
+    margin-right: -0.1rem;
   }
 
   .unit { font-size: 0.7rem; color: var(--c-text-muted); }
@@ -328,7 +350,13 @@
   .feedback.ok { color: var(--c-green-text); }
   .feedback.err { color: var(--c-red); }
 
-  .solve-error { font-size: 0.75rem; color: var(--c-red); }
+  .error-msg {
+    font-size: 0.75rem;
+    color: var(--c-red);
+    padding: 0.2rem 0.4rem;
+    background: var(--c-red-tint, rgba(255, 0, 0, 0.06));
+    border-radius: 4px;
+  }
 
   .stats { font-size: 0.75rem; color: var(--c-text-muted); }
 
@@ -344,4 +372,5 @@
     cursor: pointer;
   }
   .confirm-btn:hover { background: var(--c-accent); color: var(--c-bg-default); }
+  .confirm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 </style>

--- a/frontend/src/lib/format.test.ts
+++ b/frontend/src/lib/format.test.ts
@@ -34,13 +34,15 @@ describe("formatDecayMode", () => {
     expect(formatDecayMode("EC")).toBe("EC");
   });
 
-  it("collapses K/L/M-shell EC variants to plain EC", () => {
+  it("collapses K/L/M/N-shell EC variants to plain EC", () => {
     expect(formatDecayMode("KshellEC")).toBe("EC");
     expect(formatDecayMode("LshellEC")).toBe("EC");
     expect(formatDecayMode("MshellEC")).toBe("EC");
+    expect(formatDecayMode("NshellEC")).toBe("EC");
     expect(formatDecayMode("K_shell_EC")).toBe("EC");
     expect(formatDecayMode("L_shell_EC")).toBe("EC");
     expect(formatDecayMode("M_shell_EC")).toBe("EC");
+    expect(formatDecayMode("N_shell_EC")).toBe("EC");
   });
 
   it("passes unknown / empty modes through", () => {
@@ -97,10 +99,11 @@ describe("formatReaction", () => {
     expect(formatReaction("²⁷Al(p,αn)²²Na")).toBe("²⁷Al(p,αn)²²Na");
   });
 
-  it("collapses K/L/M-shell EC notations to (EC)", () => {
+  it("collapses K/L/M/N-shell EC notations to (EC)", () => {
     expect(formatReaction("⁵¹Mn(KshellEC)")).toBe("⁵¹Mn(EC)");
     expect(formatReaction("⁵¹Mn(LshellEC)")).toBe("⁵¹Mn(EC)");
     expect(formatReaction("⁵¹Mn(MshellEC)")).toBe("⁵¹Mn(EC)");
+    expect(formatReaction("⁵⁶Fe(NshellEC)")).toBe("⁵⁶Fe(EC)");
   });
 
   it("maps decay-arrow notation", () => {
@@ -142,12 +145,14 @@ describe("reactionFilterMatches (round-trip aliases)", () => {
 });
 
 describe("isShellEC", () => {
-  it("matches Kshell/Lshell/Mshell EC in any case", () => {
+  it("matches K/L/M/N-shell EC in any case", () => {
     expect(isShellEC("KshellEC")).toBe(true);
     expect(isShellEC("LshellEC")).toBe(true);
     expect(isShellEC("MshellEC")).toBe(true);
+    expect(isShellEC("NshellEC")).toBe(true);
     expect(isShellEC("kshellec")).toBe(true);
     expect(isShellEC("L_shell_EC")).toBe(true);
+    expect(isShellEC("N_shell_EC")).toBe(true);
   });
 
   it("does not match plain EC, beta+, or other modes", () => {

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -27,9 +27,15 @@ const DECAY_MODE_MAP: Record<string, string> = {
   "kshellec": "EC",
   "lshellec": "EC",
   "mshellec": "EC",
+  "nshellec": "EC",
+  "oshellec": "EC",
+  "pshellec": "EC",
   "k_shell_ec": "EC",
   "l_shell_ec": "EC",
   "m_shell_ec": "EC",
+  "n_shell_ec": "EC",
+  "o_shell_ec": "EC",
+  "p_shell_ec": "EC",
 };
 
 const PROJECTILE_MAP: Record<string, string> = {
@@ -61,7 +67,7 @@ export function formatDecayMode(mode: string): string {
 export function isShellEC(mode: string): boolean {
   if (!mode) return false;
   const key = mode.trim().toLowerCase().replace(/_/g, "");
-  return /^[klm]shellec$/.test(key);
+  return /^[klmnop]shellec$/.test(key);
 }
 
 export interface DecayChainEntry {

--- a/packages/compute/src/generate-profile.test.ts
+++ b/packages/compute/src/generate-profile.test.ts
@@ -179,13 +179,8 @@ describe("solveForCurrent", () => {
     expect(cur.value).toBeCloseTo(30, 3);
   });
 
-  it("duration equals rSum/2 → error (zero effective plateau)", () => {
-    // T = 60, ramps = 60+60 → rSum=120, T >= rSum is false (triangle)
-    // Actually T=60 < rSum=120, so triangle formula applies, which is fine.
-    // The error case is T >= rSum and T = rSum/2 — but that's impossible (T >= rSum > rSum/2).
-    // Real error: T >= rSum and effectiveT = T - rSum/2 ≤ 0 → T ≤ rSum/2 < rSum → contradiction.
-    // So the error only happens when we'd need rSum/2 > T but T >= rSum — impossible.
-    // Test the triangle edge: very short T relative to ramps
+  it("very short T relative to ramps uses triangle formula", () => {
+    // T=1 < rSum=200 → triangle regime, always valid (I = 2 × ITC / T)
     const cur = solveForCurrent(1, 1, 100, 100);
     expect(cur.ok).toBe(true);
     expect(cur.value).toBeGreaterThan(0);
@@ -219,7 +214,7 @@ describe("analytical vs numerical charge agreement", () => {
   ];
 
   for (const { name, I, T, rU, rD } of cases) {
-    it(`${name}: analytical ≈ numerical (< 0.5% error)`, () => {
+    it(`${name}: analytical ≈ numerical (< 2% error)`, () => {
       const analytical = solveForITC(I, T, rU, rD);
       const profile = generateProfile({
         rampUpS: rU,

--- a/packages/compute/src/generate-profile.test.ts
+++ b/packages/compute/src/generate-profile.test.ts
@@ -109,11 +109,11 @@ describe("solveForITC", () => {
   });
 
   it("triangle case: ramps exceed duration", () => {
-    // 30 µA, T=100 s, ramps 80+80=160. Scaled peak = 30 × 100/160 = 18.75 µA
-    // ITC = 30 × 100² / (2 × 160) / 3600 = 30 × 10000 / 320 / 3600 = 0.2604 µAh
+    // 30 µA, T=100 s, ramps 80+80=160. Ramps scaled to fit, peak still = 30 µA.
+    // ITC = 30 × 100 / 2 / 3600 = 0.4167 µAh
     const r = solveForITC(30, 100, 80, 80);
     expect(r.ok).toBe(true);
-    expect(r.value).toBeCloseTo(0.2604, 3);
+    expect(r.value).toBeCloseTo(0.4167, 3);
   });
 
   it("zero duration → 0", () => {
@@ -200,4 +200,45 @@ describe("solveForCurrent", () => {
     expect(r.ok).toBe(false);
     expect(r.error).toBeDefined();
   });
+});
+
+// ---------------------------------------------------------------------------
+// Analytical ↔ numerical cross-check
+// ---------------------------------------------------------------------------
+
+describe("analytical vs numerical charge agreement", () => {
+  const cases = [
+    { name: "standard trapezoidal", I: 30, T: 7200, rU: 60, rD: 60 },
+    { name: "no ramps (step function)", I: 30, T: 3600, rU: 0, rD: 0 },
+    { name: "asymmetric ramps", I: 50, T: 3600, rU: 120, rD: 30 },
+    { name: "triangle (ramps exceed T)", I: 30, T: 100, rU: 80, rD: 80 },
+    { name: "short irradiation", I: 100, T: 10, rU: 2, rD: 2 },
+    { name: "long irradiation", I: 15, T: 86400, rU: 300, rD: 300 },
+    { name: "ramps exactly equal T", I: 30, T: 120, rU: 60, rD: 60 },
+    { name: "ramp-only (rUp = T, no rDown)", I: 30, T: 60, rU: 60, rD: 0 },
+  ];
+
+  for (const { name, I, T, rU, rD } of cases) {
+    it(`${name}: analytical ≈ numerical (< 0.5% error)`, () => {
+      const analytical = solveForITC(I, T, rU, rD);
+      const profile = generateProfile({
+        rampUpS: rU,
+        plateauCurrentMA: I / 1000,
+        rampDownS: rD,
+        totalDurationS: T,
+        timeStepS: 1,
+      });
+      const numerical = profileChargeUAh(profile);
+
+      // Agree within 2% — numerical has a last-point-zero artifact (the final
+      // sample is forced to 0, losing ~0.5×I×dt of charge). This is larger for
+      // short profiles where dt is a larger fraction of T.
+      if (analytical.value === 0) {
+        expect(numerical).toBeCloseTo(0, 2);
+      } else {
+        const relError = Math.abs(analytical.value - numerical) / analytical.value;
+        expect(relError).toBeLessThan(0.02);
+      }
+    });
+  }
 });

--- a/packages/compute/src/generate-profile.ts
+++ b/packages/compute/src/generate-profile.ts
@@ -73,8 +73,8 @@ export function generateProfile(params: GenerateProfileParams): CurrentProfile {
 //
 // Two regimes:
 //   Trapezoidal (T >= r_u + r_d): ITC = I × (T - (r_u + r_d) / 2)
-//   Triangle    (T <  r_u + r_d): ITC = I × T² / (2 × (r_u + r_d))
-//     (ramps scaled proportionally, peak = I × T / (r_u + r_d))
+//   Triangle    (T <  r_u + r_d): ITC = I × T / 2
+//     (ramps scaled proportionally to fit T, peak still reaches I)
 // ---------------------------------------------------------------------------
 
 export interface SolveResult {
@@ -102,8 +102,8 @@ export function solveForITC(
     // Trapezoidal: full ramps fit
     chargeUAs = plateauUA * (totalDurationS - rSum / 2);
   } else {
-    // Triangle: ramps scaled, peak = plateauUA × T / rSum
-    chargeUAs = plateauUA * totalDurationS * totalDurationS / (2 * rSum);
+    // Triangle: ramps scaled to fit T, peak still reaches plateauUA
+    chargeUAs = plateauUA * totalDurationS / 2;
   }
   return { value: chargeUAs / 3600, ok: true };
 }
@@ -127,8 +127,8 @@ export function solveForDuration(
     return { value: tTrap, ok: true };
   }
 
-  // Triangle regime: chargeUAs = I × T² / (2 × rSum) → T = sqrt(2 × rSum × chargeUAs / I)
-  const tTri = rSum > 0 ? Math.sqrt(2 * rSum * chargeUAs / plateauUA) : 0;
+  // Triangle regime: chargeUAs = I × T / 2 → T = 2 × chargeUAs / I
+  const tTri = 2 * chargeUAs / plateauUA;
   if (tTri <= 0) return { value: 0, ok: false, error: "ITC too small for these ramps" };
   return { value: tTri, ok: true };
 }
@@ -155,8 +155,8 @@ export function solveForCurrent(
     return { value: chargeUAs / effectiveT, ok: true };
   }
 
-  // Triangle: I = chargeUAs × 2 × rSum / T²
-  const current = chargeUAs * 2 * rSum / (totalDurationS * totalDurationS);
+  // Triangle: chargeUAs = I × T / 2 → I = 2 × chargeUAs / T
+  const current = 2 * chargeUAs / totalDurationS;
   return { value: current, ok: true };
 }
 

--- a/scripts/check-lockfiles.sh
+++ b/scripts/check-lockfiles.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# check-lockfiles.sh — verify lockfiles are in sync with their manifests.
+#
+# Checks:
+#   1. uv.lock matches pyproject.toml (uv lock --check)
+#   2. wasm/Cargo.lock matches wasm/Cargo.toml (cargo check --locked)
+#
+# Exits non-zero on the first mismatch with a clear fix suggestion.
+# Used by pre-commit (local hook) and CI.
+
+set -euo pipefail
+
+rc=0
+
+# --- uv.lock ---
+if command -v uv &>/dev/null; then
+  if ! uv lock --check 2>/dev/null; then
+    echo "::error::uv.lock is out of sync with pyproject.toml. Run: uv lock"
+    rc=1
+  fi
+else
+  echo "::warning::uv not found — skipping uv.lock check"
+fi
+
+# --- wasm/Cargo.lock ---
+if [ -f wasm/Cargo.toml ]; then
+  if command -v cargo &>/dev/null; then
+    if ! cargo check --locked --manifest-path wasm/Cargo.toml 2>/dev/null; then
+      echo "::error::wasm/Cargo.lock is out of sync with wasm/Cargo.toml. Run: cargo update --manifest-path wasm/Cargo.toml"
+      rc=1
+    fi
+  else
+    echo "::warning::cargo not found — skipping wasm/Cargo.lock check"
+  fi
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "Lockfiles in sync."
+fi
+
+exit "$rc"

--- a/src/hyrr/models.py
+++ b/src/hyrr/models.py
@@ -288,7 +288,7 @@ class CurrentProfile:
         return result
 
     @classmethod
-    def from_csv(cls, path: str | Path) -> "CurrentProfile":
+    def from_csv(cls, path: str | Path) -> CurrentProfile:
         """Load a current profile from a CSV/TSV file.
 
         Accepts two-column files with optional header row (time_s, current_mA).
@@ -321,7 +321,7 @@ class CurrentProfile:
         )
 
     @classmethod
-    def from_parquet(cls, path: str | Path) -> "CurrentProfile":
+    def from_parquet(cls, path: str | Path) -> CurrentProfile:
         """Load a current profile from a Parquet file.
 
         Expects columns named ``time_s`` and ``current_mA``.
@@ -337,7 +337,7 @@ class CurrentProfile:
     @classmethod
     def from_values(
         cls, values: Sequence[float], dt: float
-    ) -> "CurrentProfile":
+    ) -> CurrentProfile:
         """Create a profile from current values at uniform time spacing.
 
         Args:

--- a/tests/test_current_profile.py
+++ b/tests/test_current_profile.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import textwrap
-
 import numpy as np
 import pytest
 
 from hyrr.models import CurrentProfile
-
 
 # ---------------------------------------------------------------------------
 # from_csv

--- a/uv.lock
+++ b/uv.lock
@@ -606,6 +606,35 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/00/d579dcb2a536b6ea3a2563cdad6844f77d81a9b2d4b22a858097f2468acf/duckdb-1.5.3.tar.gz", hash = "sha256:df39428eb130faa35ae96fd35245bdeae6ecf43936250b116b5fead568eb9f16", size = 18026640, upload-time = "2026-05-20T11:55:31.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c4/2e34929b16c8d544ef664fad8f7f3a2a9db05746aae1e7c8c4ee3a8b23e4/duckdb-1.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ff11a457258148337ef9a392148a8cdbd1069b6c27c21958816c7b67fe6c542d", size = 32626494, upload-time = "2026-05-20T11:54:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/53/3af681793d03771365ae3e2215331151c196a3ac8193f613344840694671/duckdb-1.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fd25f533cb1b6b2c84cc767a9a9bab7769bb1aa44571a2a0bfc91ac3e4a38ac", size = 17301121, upload-time = "2026-05-20T11:54:36.928Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/c80af1eac2ab5d35fc2c372ef0a84668842e549fbbf7799277b3fccf3e39/duckdb-1.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10960400ed60cdf0fe05bab2086fa8eb733889cb0ceca18d07ff9a00c0e0be7b", size = 15449283, upload-time = "2026-05-20T11:54:39.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/c63af233c9f761bf5178a5210437e1bc6bcb30fa8a9073de6398cfb12c03/duckdb-1.5.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5f18e7561403054433706c187589e86629a7af09a7efc23a06a8b308e6acc68", size = 19332762, upload-time = "2026-05-20T11:54:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/2d77af4fff86012f334ef82e6d54a995a86c8745e58074f1218ed7d25171/duckdb-1.5.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fb7516255a8764545e30f7efacea408cc847764a3027b3b0b3e7d1a7bebbc5c", size = 21453290, upload-time = "2026-05-20T11:54:45.272Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5e/9bc4817a98feb4dab83e56f2245cd3a30d00ee646d4dec7926464e2b3f28/duckdb-1.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:8001eccbc28be244dfd04d708526f34ddd6460b47a8aeb5d0e39d6f7f9e3fe15", size = 13118308, upload-time = "2026-05-20T11:54:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/81/35/e3f32e4e53e2450ddb1db8312a17d1ce455d60cc4941b6ad2cfc908794b0/duckdb-1.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:6d2835e39bb6af73891f73c0f8d4324f98afe00d0b00c6d34b2a582c2256cbb0", size = 13927187, upload-time = "2026-05-20T11:54:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/a528eb09d8be51954c485864bd06753e616939a080cbc3dd4417e8c94a57/duckdb-1.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e75a6122c12579a99848517f6f00a4e342aebda3590c30fe9b5cc5f39d5e6afc", size = 32626254, upload-time = "2026-05-20T11:54:53.65Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/3c/1534c0a6db347c05eb7d0f6ecfb7aefbe74cbff398e4892a8fd1903a20e8/duckdb-1.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fd3963c1cb9d9567777f4a898a9dbe388a2fe9724681801b1e7d6d93eecf1b76", size = 17300917, upload-time = "2026-05-20T11:54:56.628Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fa/beafb91e6e152d2161c4a9cbc472334c87607eb61ad7104b5a7fa8d8d7b1/duckdb-1.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3d5db8c0b55e072cf437948ebb5d7e23d7b9d03d905fa5f9145583e65aa447f7", size = 15449411, upload-time = "2026-05-20T11:54:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/49b6fe04e2fcd63729eb607dadd44818dde77342a4f5ce086c6c92f1dd4d/duckdb-1.5.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ce80aed7a538422129a57eaca9141e3afb51f8bf562b1908b1576c9725b5b22", size = 19333120, upload-time = "2026-05-20T11:55:01.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4c/0907c3f76adb9dd90e67610b31e0304a35814e65c4c41a354a262c09b885/duckdb-1.5.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787df63824f07bf18022dbc3b8ca4b2bfab0ebe616464f55c6e8cd0f59ea762e", size = 21453266, upload-time = "2026-05-20T11:55:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9c/d2f23a7803ddbbd9413f7572ecf66a15120ed5ced7ce5c73e698c1406b76/duckdb-1.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:bb5bb5dcdd09d62ee60f0ddbbef918e71cce304ffe28428b1131949d39ffaabf", size = 13118640, upload-time = "2026-05-20T11:55:07.389Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d5/7ba2316415bcdab6edd765bbbe35c2ca8a3800f2fe695cd70e3cdb997f09/duckdb-1.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2fa17ecdd5d3db122836cb71bb93601c2106a3be883c17dffddc02fbf3fa7888", size = 13926409, upload-time = "2026-05-20T11:55:10.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/c2/d4b6f8a5e4d3bc25773be6da76a99d9661ebbf3552c007c460d2dd59dbf8/duckdb-1.5.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4bfa9a4dadf71e83e2c4eaca2f9421c82a54defecc1b0b4c0be95e2389dec4fe", size = 32636685, upload-time = "2026-05-20T11:55:13.158Z" },
+    { url = "https://files.pythonhosted.org/packages/42/58/e835c8298979d29db7a62cb5acc29e9b57aeaca7cdde2fcd3ac980f5cb18/duckdb-1.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aea7baf67ad7e1829ac76f67d7dcbd7fb1f57c3eb179d55ac30952df4709ae30", size = 17308134, upload-time = "2026-05-20T11:55:16.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/617b51363f5613418c8b224b3cce16b58e6dde80904566bec232579c1d4e/duckdb-1.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b0b4f088a65d77e1217ce5d7eff889e63fedc44281200d899ff47c84d8ff836", size = 15449891, upload-time = "2026-05-20T11:55:18.687Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/72/354146656e8d9ba3853d3a5ee80a481b8c5f70edfc3d5ae80a8c4479c967/duckdb-1.5.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe8d0c1f6a120aa03fa6e0d03897c71a1842e6cf7afd31d181348391f7108fe1", size = 19338499, upload-time = "2026-05-20T11:55:21.34Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -857,10 +886,11 @@ wheels = [
 
 [[package]]
 name = "hyrr"
-version = "0.7.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },
+    { name = "nucl-parquet" },
     { name = "numpy" },
     { name = "polars" },
     { name = "py-materials" },
@@ -951,6 +981,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24" },
     { name = "nbmake", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "nucl-parquet", specifier = ">=0.14" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.0" },
     { name = "plotly", marker = "extra == 'plotting'", specifier = ">=5.17" },
@@ -1959,6 +1990,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "nucl-parquet"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "duckdb" },
+    { name = "numpy" },
+    { name = "pycatima" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/8a/8b8ad529e76b8d946bdce1c162fb8d1e0a5db540bd9f2ce840c70628cb42/nucl_parquet-0.14.0.tar.gz", hash = "sha256:5c6ffc9264a9d8398e666b1c1b9b27cddc1c54a09853984db134843f6bf382b3", size = 152086, upload-time = "2026-05-12T10:33:31.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/e0/f7218f8b6b81ad7f84065c0d907c2f94965367220bb38aec6350c4af0a5e/nucl_parquet-0.14.0-py3-none-any.whl", hash = "sha256:7315b1e31ee08d6cd81c58ca8172de00a526c69c75b1cbef80a4cba84a397c7d", size = 115846, upload-time = "2026-05-12T10:33:29.488Z" },
 ]
 
 [[package]]
@@ -3529,4 +3575,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/2c/c06ef49dc36e7954e55b802a8b231770d286a9758b3d936bd1e04ce5ba88/xlsxwriter-3.2.9.tar.gz", hash = "sha256:254b1c37a368c444eac6e2f867405cc9e461b0ed97a3233b2ac1e574efb4140c", size = 215940, upload-time = "2025-09-16T00:16:21.63Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/0c/3662f4a66880196a590b202f0db82d919dd2f89e99a27fadef91c4a33d41/xlsxwriter-3.2.9-py3-none-any.whl", hash = "sha256:9a5db42bc5dff014806c58a20b9eae7322a134abb6fce3c92c181bfb275ec5b3", size = 175315, upload-time = "2025-09-16T00:16:20.108Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
 ]

--- a/wasm/Cargo.lock
+++ b/wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "hyrr-core"
-version = "0.1.0"
+version = "0.13.0"
 dependencies = [
  "flate2",
  "fs2",


### PR DESCRIPTION
## Summary

- **3-way constraint solver** for the current profile Generate tab: any one of {plateau current, duration, ITC} can be the derived field, selected via a "Calculate:" radio group. Replaces the old 2-way duration↔charge lock.
- **Analytical closed-form** trapezoid charge formulas with correct triangle-case branching (fixes 60% duration error when ramps exceed total duration).
- **Pure `$derived` DAG** in Svelte 5 — zero `$effect` in data flow, no circular update risk.
- **"Charge" → "ITC"** (Integrated Target Current) rename throughout the Generate tab.
- **NshellEC fix** — N/O/P-shell electron capture mapped to "EC" in the decay mode display (was showing raw `Fe(NshellEC)` in Sc-44 example).

## Design decisions

Based on 3 independent expert reviews (UI/UX, Svelte reactivity, numerical correctness):
- "Calculate:" radio group instead of lock icons or FIFO auto-lock (CAD constraint-solver convention)
- Derived field styled with tinted background, "=" prefix, dashed border
- Analytical formulas instead of numerical integration for generated trapezoids
- Two-regime formulas: trapezoidal (`T >= ramps`) and triangle (`T < ramps`)

## Test plan

- [x] 18 new solver unit tests (3 directions × trapezoidal/triangle/edge cases)
- [x] 8 parametric analytical↔numerical cross-checks (< 2% agreement)
- [x] NshellEC coverage in formatDecayMode, formatReaction, isShellEC
- [x] All 189 existing tests pass
- [x] Type check clean
- [ ] Manual: open Generate tab, switch "Calculate:" radio between all 3 modes, verify derived field updates
- [ ] Manual: enter ramps that exceed total duration, verify triangle case works
- [ ] Manual: verify ITC label and tooltip

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)