### PR TITLE
test(e2e): fix stale "Define & save" material selector (root cause 1 of #426)

### DIFF
--- a/frontend/e2e/material-define-rows.spec.ts
+++ b/frontend/e2e/material-define-rows.spec.ts
@@ -21,7 +21,7 @@ test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
 
     // Open the define-form section.
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     // First "+ element" → PT modal.
     await page.getByRole("button", { name: "+ element" }).click();
@@ -64,7 +64,7 @@ test.describe("DefineForm — rows-based UI (Phase 3 of #64)", () => {
   test("paste-formula input commits on blur and populates rows", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     const paste = page.getByPlaceholder(/Al2O3/);
     await paste.fill("Al 80%, Cu 5%, Zn %");

--- a/frontend/e2e/material-form-redesign.spec.ts
+++ b/frontend/e2e/material-form-redesign.spec.ts
@@ -18,7 +18,7 @@ test.describe("Material-form redesign (#92)", () => {
   test("paste 'SiO2 80%, H2O 20%' → mode flips to wt %, rows materialize", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     // In Single mode, bottom paste-formula field is visible. Type a mass mixture.
     const paste = page.getByPlaceholder(/Al2O3/);
@@ -38,7 +38,7 @@ test.describe("Material-form redesign (#92)", () => {
   test("clearing the paste field on blur is a no-op on rows (#87)", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     const paste = page.getByPlaceholder(/Al2O3/);
     await paste.fill("Al 80%, Cu 20%");
@@ -67,7 +67,7 @@ test.describe("Material-form redesign (#92)", () => {
   test("glassy mass mixture renders amber low-confidence chip with mol% nudge", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     const paste = page.getByPlaceholder(/Al2O3/);
     await paste.fill("SiO2 75%, Na2O 14%, CaO 11%");
@@ -83,7 +83,7 @@ test.describe("Material-form redesign (#92)", () => {
   test("per-row 'E' enrichment button appears for single-element rows in mixture mode (#93)", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     await page.getByPlaceholder(/Al2O3/).fill("Cu 80%, H2O 20%");
     await page.getByPlaceholder(/Al2O3/).blur();
@@ -100,7 +100,7 @@ test.describe("Material-form redesign (#92)", () => {
   test("density renders as suggestion only — Save disabled until accepted", async ({ page }) => {
     await page.locator(".material-name").first().click();
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     await page.getByPlaceholder(/Al2O3/).fill("Al 80%, Cu 20%");
     await page.getByPlaceholder(/Al2O3/).blur();

--- a/frontend/e2e/material-soda-lime.spec.ts
+++ b/frontend/e2e/material-soda-lime.spec.ts
@@ -30,7 +30,7 @@ test.describe("Soda-lime mass mixture walkthrough (#97)", () => {
     await page.waitForSelector(".material-popup", { timeout: 5_000 });
 
     // Open the define-form section.
-    await page.getByRole("button", { name: /Define.*save material/ }).click();
+    await page.getByRole("button", { name: /Define & save/ }).click();
 
     // Paste the glass mixture (low-confidence: chip should go amber + nudge).
     const paste = page.getByPlaceholder(/Al2O3/);


### PR DESCRIPTION
## What

Fixes **root cause 1** of #426 — the stale `Define & save material` selector that accounts for ~44 of 57 E2E failures on `main`.

The "new material" entry button was reworded to **"Define & save a custom material"** ([`SearchView.svelte:295`](https://github.com/exoma-ch/hyrr/blob/main/frontend/src/lib/components/material/SearchView.svelte#L295)), but 8 e2e call sites still matched `/Define.*save material/`. That regex needs `"save material"` **contiguous**, which the new wording (`"save a custom material"`) no longer satisfies — so every test that opens the define form timed out on the first `.click()`.

## Change

Switch the selector to `/Define & save/` at all 8 sites:

| File | Sites |
|------|-------|
| `frontend/e2e/material-form-redesign.spec.ts` | 5 |
| `frontend/e2e/material-define-rows.spec.ts` | 2 |
| `frontend/e2e/material-soda-lime.spec.ts` | 1 |

Test-only, low risk — no app code touched.

## Verification

Ran the 3 affected specs locally (nix chromium 147, `PLAYWRIGHT_NO_SANDBOX=1`) across **all 4 viewport projects**:

```
8 specs × { desktop-1280, iphone-se, iphone-14, ipad } = 32 tests → 32 passed
```

The issue warned to watch for *further* selector drift in the redesigned material form once the click is unblocked — there is none. Every downstream assertion (rows, mode chips, density suggestions, per-row enrich button, Save & Use flow) passes.

## Scope

This PR is **root cause 1 only**. Root cause 2 (stale golden `#config=` fixtures yielding empty results in `presets.spec.ts` / `current-profile.spec.ts` / `csv-exports.spec.ts`) needs an app-running repro to regenerate the hashes and is tracked separately in #426.

Refs: #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)