### PR TITLE
docs(legal): reconcile license to MIT + disclaimer, privacy, terms, citation, compliance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use HYRR, please cite it as below, and cite the nuclear data libraries you use (see nucl-parquet/ATTRIBUTION.md)."
+title: "HYRR: accelerator-driven radionuclide-production calculations"
+abstract: >-
+  HYRR computes accelerator-driven radionuclide production — cross sections,
+  stopping power, production yields, and decay chains — from evaluated nuclear
+  data, with a browser app, Python package, desktop app, and MCP server.
+type: software
+authors:
+  - name: "eXoma (Exotic Matter Applications), ETH Zürich"
+    # TODO: add individual authors (name + ORCID) before minting the DOI.
+repository-code: "https://github.com/exoma-ch/hyrr"
+license: MIT
+keywords:
+  - radionuclide production
+  - nuclear data
+  - cross sections
+  - cyclotron targetry
+# TODO: add `doi:` once a Zenodo release DOI is minted (issue #420).

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -1,0 +1,33 @@
+# Compliance record
+
+> Status: DRAFT determinations — pending ETH legal / Technology Transfer
+> sign-off. Not legal advice. Tracks issues #421, #422, #424.
+
+## Export control / dual-use (#421)
+
+HYRR and its bundled, published evaluated nuclear data fall under the
+**"publicly available" / "basic scientific research"** carve-outs of EU Dual-Use
+Regulation **(EU) 2021/821** and the Swiss **Güterkontrollverordnung (GKV)**.
+This is the determination of record, **pending ETH export-control sign-off**.
+The data-layer determination — including the Russian- and Chinese-origin
+libraries — is in `nucl-parquet/COMPLIANCE.md`.
+
+## IP / open-source release rights (#422)
+
+HYRR is developed by eXoma (ETH Zürich). Confirm with **ETH Transfer** that the
+group holds the right to release HYRR under MIT. Copyright holder string:
+**"eXoma (Exotic Matter Applications), ETH Zürich."**
+
+## Naming / trademark (#424)
+
+Check "HYRR" for trademark collision in the relevant classes and jurisdictions
+(CH/EU). HYRR replaces the legacy Fortran tool ISOTOPIA; README phrasing must not
+imply ISOTOPIA endorsement.
+
+## Sign-off
+
+| Item | Owner | Status |
+|---|---|---|
+| Export-control / dual-use exemption | ETH legal / export-control | pending |
+| IP / OSI-release authorisation | ETH Transfer | pending |
+| HYRR / ISOTOPIA naming check | ETH legal | pending |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+## Contribution license (inbound = outbound)
+
+By submitting a contribution you certify that you wrote it (or have the right to
+submit it) and you agree it is licensed under the project's [MIT License](LICENSE).
+We follow the [Developer Certificate of Origin](https://developercertificate.org/);
+sign off your commits with `git commit -s`.
+
+Do not contribute third-party nuclear data here — data lives in the
+[`nucl-parquet`](https://github.com/exoma-ch/nucl-parquet) submodule, where its
+provenance and terms are recorded.
+
+## Development
+
+See [docs/development/contributing.md](docs/development/contributing.md) for the
+dev environment, test commands, and the lint gate.

--- a/DISCLAIMER.md
+++ b/DISCLAIMER.md
@@ -1,0 +1,13 @@
+# Disclaimer
+
+HYRR computes radionuclide-production yields, stopping power, dose, and decay from
+evaluated nuclear data. Those results carry the inherent uncertainties of the
+underlying data (see the `nucl-parquet` [ATTRIBUTION](nucl-parquet/ATTRIBUTION.md)).
+
+- Provided **"as is", without warranty** of any kind.
+- **Not validated** for clinical, dosimetric, radiation-safety, shielding, or
+  regulatory use, and **not a medical device** — not for clinical decision-making.
+- Not a substitute for a qualified, validated code. **Verify results against
+  primary sources** before any safety-, health-, or compliance-critical decision.
+
+Use of HYRR is at your own risk.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2024-2026 eXoma (Exotic Matter Applications), ETH Zürich
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2025 MorePET
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,24 @@
+# Privacy
+
+The HYRR web app (<https://exoma-ch.github.io/hyrr/>) runs **entirely in your
+browser**. It performs all computation client-side and caches nuclear data
+locally in your browser's IndexedDB. It does **not** use analytics, advertising,
+cookies, third-party fonts, or CDNs.
+
+## What is collected
+
+- **Hosting logs.** The app is served from GitHub Pages; GitHub, as host, may log
+  request metadata such as IP addresses (see GitHub's privacy statement).
+- **Bug reports (optional).** If you submit a bug report, its contents — which may
+  include your message, the current input configuration, and any email you
+  provide — are sent to our report endpoint and used only to diagnose the issue.
+
+Nothing else leaves your device.
+
+## Your rights
+
+eXoma (ETH Zürich) is the controller. Under the Swiss revFADP and the EU GDPR you
+may request access to, or deletion of, any personal data contained in a bug
+report you sent; contact the maintainers.
+
+> Draft — pending review by ETH legal.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ cd desktop && npx tauri dev
 
 **eXoma** — *Exotic Matter Applications* — is a research group at ETH Zürich focused on novel radioisotope production methods and targetry.
 
-## License
+## License & legal
 
-MIT
+- **Code:** [MIT](LICENSE).
+- **Bundled nuclear data** (via the `nucl-parquet` submodule): third-party — each
+  library keeps its own terms and required citation. See
+  [nucl-parquet/ATTRIBUTION.md](nucl-parquet/ATTRIBUTION.md); HYRR does not
+  relicense the data.
+- **Disclaimer:** results carry evaluated-data uncertainties and are **not
+  validated** for clinical, safety, or regulatory use — see [DISCLAIMER](DISCLAIMER.md).
+- [Privacy](PRIVACY.md) · [Terms](TERMS.md) · [How to cite](CITATION.cff) · [Compliance](COMPLIANCE.md) · [Contributing](CONTRIBUTING.md)

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,17 @@
+# Terms of use
+
+HYRR (<https://exoma-ch.github.io/hyrr/>) is provided free of charge by eXoma
+(ETH Zürich) for research and educational use.
+
+- The tool and its results are provided **"as is", without warranty** of any
+  kind. See the [Disclaimer](DISCLAIMER.md) — results are not validated for
+  clinical, safety, or regulatory use.
+- To the maximum extent permitted by law, eXoma and ETH Zürich accept **no
+  liability** for any loss or damage arising from use of the tool or reliance on
+  its output.
+- You are responsible for complying with the terms of the underlying nuclear data
+  (see [nucl-parquet ATTRIBUTION](nucl-parquet/ATTRIBUTION.md)).
+- These terms are governed by the laws of **Switzerland**; the courts of Zürich
+  have jurisdiction.
+
+> Draft — pending review by ETH legal.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "hyrr-frontend",
   "private": true,
   "version": "0.13.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite dev",


### PR DESCRIPTION
The app-layer legal docs + the license-mismatch fix.

## Changed
- **`LICENSE`: Apache-2.0 → MIT** — resolves the mismatch (#414). `pyproject.toml`, every `Cargo.toml`, the README, and the `nucl-parquet` submodule all already declare MIT; only the root LICENSE file was Apache. Reconciled to MIT for consistency. *(If ETH legal prefers Apache-2.0 for its explicit patent grant, the reverse — Apache text + flip the 5 metadata declarations — is the alternative; flagging the tradeoff.)*
- **`frontend/package.json`**: added `"license": "MIT"` (was missing).
- **`DISCLAIMER.md`** (#417): no-warranty / not-for-clinical-safety-regulatory-use / not-a-medical-device / verify-against-primary-sources. Linked from README.
- **`PRIVACY.md`** (#418): browser-only, no analytics/cookies/CDN; documents GitHub Pages IP logging + the optional bug-report worker. revFADP/GDPR baseline.
- **`TERMS.md`** (#419): as-is, liability limitation, Swiss governing law.
- **`CITATION.cff`** (#420): citation metadata (Zenodo DOI TODO).
- **`COMPLIANCE.md`** (#421/#422/#424): export-control, IP, and naming determinations — **pending ETH legal/TTO sign-off**.
- **`CONTRIBUTING.md`** (#423): inbound=outbound MIT + DCO.
- **README**: license scoped to code; links the legal docs and the data attribution.

## Closes / advances
Closes **#414, #417, #418, #419, #420, #423**. Advances **#421, #422, #424** (recorded, need ETH sign-off). Epic #425.

## Still needs a human
- ETH legal review of PRIVACY/TERMS wording and sign-off on COMPLIANCE.md.
- Confirm the MIT-vs-Apache license direction with ETH Transfer.
- Add authors + mint the Zenodo DOI for CITATION.cff.
- In-app surfacing of the disclaimer (web About/footer + CLI/MCP startup) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)