### PR TITLE
feat(mcp): structured data export — dataset/inventory/emission-curve tools + result cache (#427)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: core
-      - name: MCP tool unit tests (pure layer-selection helpers)
+      - name: MCP tool unit tests (layer selection, result cache, dataset round-trip)
         working-directory: core
         run: "cargo test --features mcp --lib mcp::"
       - name: MCP layer-selection integration test (real tendl-2023-iso data)
@@ -127,6 +127,11 @@ jobs:
         env:
           HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
         run: cargo test --features mcp --test mcp_layer_selection
+      - name: MCP structured-export integration test (inventory / dataset / emission curve)
+        working-directory: core
+        env:
+          HYRR_DATA: ${{ github.workspace }}/nucl-parquet/data
+        run: cargo test --features mcp --test mcp_structured_export
 
   hyrr-py-check:
     # Catches PyO3 binding type drift against hyrr-core (Refs: #181).

--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -641,10 +641,13 @@ name = "hyrr-core"
 version = "0.13.0"
 dependencies = [
  "approx",
+ "arrow",
+ "base64",
  "flate2",
  "fs2",
  "home",
  "nucl-parquet",
+ "parquet",
  "regex",
  "reqwest",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -11,7 +11,9 @@ exclude = [".cargo/**"]
 [features]
 default = ["parquet-store"]
 parquet-store = ["dep:nucl-parquet"]
-mcp = ["parquet-store"]
+# Structured export (#427) needs arrow/parquet for the parquet resource and
+# base64 to embed it in MCP content blocks — pulled in only with `mcp`.
+mcp = ["parquet-store", "dep:arrow", "dep:parquet", "dep:base64"]
 embed-data = ["parquet-store", "dep:tempfile"]
 
 [dependencies]
@@ -21,6 +23,13 @@ thiserror = "2"
 nucl-parquet = { path = "../nucl-parquet/clients/rs/nucl-parquet", optional = true, default-features = false }
 regex = "1"
 flate2 = { version = "1.1.9", default-features = false, features = ["rust_backend"] }
+# Parquet/Arrow writer + base64 for the #427 dataset tools. Versions match
+# nucl-parquet's (already in the tree). `default-features = false` keeps this to
+# the array/schema/record-batch core nucl-parquet already pulls — no csv/ipc/json
+# umbrella. mcp-only.
+arrow = { version = "54", optional = true, default-features = false }
+parquet = { version = "54", optional = true, default-features = false, features = ["arrow"] }
+base64 = { version = "0.22", optional = true }
 
 # Native-only deps for the lazy data-fetch path (#52). Gated so wasm32
 # consumers don't pull reqwest/tar/zstd into their dependency graph.

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -70,6 +70,17 @@ pub trait DatabaseProtocol: Send + Sync {
     /// Get gamma dose rate constant k (µSv·m²/MBq·h).
     fn get_dose_constant(&self, z: u32, a: u32, state: &str) -> Option<(f64, String)>;
 
+    /// Per-decay emission lines for the *parent* nuclide `(z, a, state)` (#427).
+    ///
+    /// Returns every γ / X-ray / Auger / conversion-electron / β± /
+    /// annihilation line emitted per decay of the parent, with absolute
+    /// `intensity_per_decay`. Default implementation returns an empty vec for
+    /// stores without emission data (in-memory / WASM); the parquet-backed
+    /// store overrides it.
+    fn get_emissions(&self, _z: u32, _a: u32, _state: &str) -> Vec<crate::types::EmissionLine> {
+        Vec::new()
+    }
+
     fn get_element_symbol(&self, z: u32) -> String;
     fn get_element_z(&self, symbol: &str) -> u32;
 
@@ -220,8 +231,8 @@ mod np_store {
 use super::*;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use nucl_parquet::{AbundancesDb, CrossSectionDb, DecayDb, DoseDb, StoppingDb};
-use crate::types::{CrossSectionData, DecayMode};
+use nucl_parquet::{AbundancesDb, CrossSectionDb, DecayDb, DoseDb, ParquetStore, StoppingDb};
+use crate::types::{CrossSectionData, DecayMode, EmissionLine};
 
 /// Nuclear data store backed by the `nucl-parquet` Rust client crate.
 ///
@@ -238,6 +249,10 @@ pub struct NpDataStore {
     elements: HashMap<u32, String>,
     symbol_to_z: HashMap<String, u32>,
     xs_cache: Mutex<HashMap<String, Vec<CrossSectionData>>>,
+    /// Generic reader for the parent-keyed `meta/ensdf/emissions/` dataset
+    /// (#427). nucl-parquet's typed DBs don't cover it, so we go through the
+    /// crate's generic `ParquetStore` (which caches loaded files internally).
+    emissions: ParquetStore,
 }
 
 impl NpDataStore {
@@ -255,6 +270,9 @@ impl NpDataStore {
         let decay = DecayDb::open(root.join("meta"))?;
         let dose = DoseDb::open(root.join("meta"))?;
         let stopping = StoppingDb::open(root.join("stopping"))?;
+        // Rooted at data_root so rel paths read as `meta/ensdf/...`. No I/O
+        // until the first emission query.
+        let emissions = ParquetStore::new(&root);
 
         // Build Z ↔ symbol maps from abundances
         let mut elements = HashMap::new();
@@ -277,6 +295,7 @@ impl NpDataStore {
             elements,
             symbol_to_z,
             xs_cache: Mutex::new(HashMap::new()),
+            emissions,
         })
     }
 
@@ -409,6 +428,57 @@ impl DatabaseProtocol for NpDataStore {
         self.dose
             .dose_constant(z, a, lookup_state)
             .map(|dc| (dc.k, dc.source.clone()))
+    }
+
+    fn get_emissions(&self, z: u32, a: u32, state: &str) -> Vec<EmissionLine> {
+        // Emission rows live in the parent's element file, keyed by parent.
+        let symbol = self.get_element_symbol(z);
+        let rel = format!("meta/ensdf/emissions/{symbol}.parquet");
+        let lookup_state = normalize_decay_state(state);
+
+        // No emission file for this element → no lines (not an error).
+        let Ok(rows) = self.emissions.load(&rel) else {
+            return Vec::new();
+        };
+
+        // Filter in Rust (not ParquetStore::Filter) to control cross-int-type
+        // number matching and ground-state ("" vs "g") normalization.
+        rows.iter()
+            .filter(|row| {
+                row.get("parent_Z").and_then(|v| v.as_u64()) == Some(z as u64)
+                    && row.get("parent_A").and_then(|v| v.as_u64()) == Some(a as u64)
+                    && row
+                        .get("parent_state")
+                        .and_then(|v| v.as_str())
+                        .map(normalize_decay_state)
+                        .unwrap_or("")
+                        == lookup_state
+            })
+            .filter_map(|row| {
+                Some(EmissionLine {
+                    rad_type: row.get("rad_type")?.as_str()?.to_string(),
+                    energy_kev: row.get("energy_keV")?.as_f64()?,
+                    intensity_per_decay: row.get("intensity_pct")?.as_f64()? / 100.0,
+                    decay_mode: row
+                        .get("decay_mode")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                    daughter_z: row
+                        .get("daughter_Z")
+                        .and_then(|v| v.as_u64())
+                        .map(|n| n as u32),
+                    daughter_a: row
+                        .get("daughter_A")
+                        .and_then(|v| v.as_u64())
+                        .map(|n| n as u32),
+                    icc_total: row.get("icc_total").and_then(|v| v.as_f64()),
+                    rad_subtype: row
+                        .get("rad_subtype")
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string),
+                })
+            })
+            .collect()
     }
 
     fn get_element_symbol(&self, z: u32) -> String {

--- a/core/src/mcp/cache.rs
+++ b/core/src/mcp/cache.rs
@@ -1,0 +1,299 @@
+//! Process-scoped, config-hashed cache of `StackResult`s (#427).
+//!
+//! Follow-up dataset / inventory / emission-curve queries should be cheap
+//! lazy views over an already-computed simulation, not full re-runs. This
+//! module keys a small LRU on a canonical hash of the simulation config
+//! (projectile, energy, current, times, ordered layers incl. density &
+//! enrichment overrides, current profile) plus the library id, the
+//! hyrr-core version, and a session-material fingerprint.
+//!
+//! `simulate` populates the cache; the read-only tools look it up first.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use serde_json::Value;
+
+use crate::types::StackResult;
+
+/// Bump invalidates every cached entry across the process — keep in lockstep
+/// with anything that changes simulation numerics but not the config surface.
+const CACHE_SALT: &str = concat!("hyrr-core@", env!("CARGO_PKG_VERSION"));
+
+/// Max distinct simulations retained. An interactive session rarely juggles
+/// more than a handful; 100 is comfortable headroom (issue #427).
+const CAPACITY: usize = 100;
+
+/// Minimal LRU: most-recently-used at the front of `order`.
+struct Lru {
+    map: HashMap<u64, Arc<StackResult>>,
+    order: VecDeque<u64>,
+}
+
+impl Lru {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn touch(&mut self, key: u64) {
+        if let Some(pos) = self.order.iter().position(|&k| k == key) {
+            self.order.remove(pos);
+        }
+        self.order.push_front(key);
+    }
+
+    fn get(&mut self, key: u64) -> Option<Arc<StackResult>> {
+        let hit = self.map.get(&key).cloned();
+        if hit.is_some() {
+            self.touch(key);
+        }
+        hit
+    }
+
+    fn put(&mut self, key: u64, value: Arc<StackResult>) {
+        self.map.insert(key, value);
+        self.touch(key);
+        while self.order.len() > CAPACITY {
+            if let Some(evicted) = self.order.pop_back() {
+                self.map.remove(&evicted);
+            }
+        }
+    }
+}
+
+fn cache() -> &'static Mutex<Lru> {
+    static CACHE: OnceLock<Mutex<Lru>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(Lru::new()))
+}
+
+/// Look up the cached `StackResult` for `args`, or run `compute` and store it.
+///
+/// `registry_fp` is a fingerprint of session-defined materials (empty when
+/// none) so a redefined alloy can't return a stale result for the same args.
+pub fn cached_stack<F>(
+    args: &Value,
+    library: &str,
+    registry_fp: &str,
+    compute: F,
+) -> Result<Arc<StackResult>, String>
+where
+    F: FnOnce() -> Result<StackResult, String>,
+{
+    let key = hash_config(args, library, registry_fp);
+
+    if let Some(hit) = cache().lock().unwrap_or_else(|e| e.into_inner()).get(key) {
+        return Ok(hit);
+    }
+
+    let result = Arc::new(compute()?);
+    cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .put(key, Arc::clone(&result));
+    Ok(result)
+}
+
+/// Short, stable identifier for a simulation config — the cache key as hex.
+/// Used to tag exported tables / Parquet resource URIs so a consumer can tell
+/// which simulation a dataset came from.
+pub fn sim_id(args: &Value, library: &str, registry_fp: &str) -> String {
+    format!("{:016x}", hash_config(args, library, registry_fp))
+}
+
+/// Stable 64-bit key for a simulation config. Deterministic within a process
+/// run (std's `DefaultHasher` uses fixed keys), which is all a process-scoped
+/// cache needs.
+fn hash_config(args: &Value, library: &str, registry_fp: &str) -> u64 {
+    let mut h = std::collections::hash_map::DefaultHasher::new();
+    canonical_config(args, library, registry_fp).hash(&mut h);
+    h.finish()
+}
+
+/// Build a canonical, formatting-stable string for the semantic config.
+///
+/// Explicit field extraction (not `serde_json` map iteration) so the key is
+/// independent of JSON key order and of whether `preserve_order` is enabled.
+/// All numbers route through `as_f64` + `{:?}` so `12` and `12.0` collapse.
+fn canonical_config(args: &Value, library: &str, registry_fp: &str) -> String {
+    let mut s = String::new();
+    s.push_str(CACHE_SALT);
+    s.push('|');
+    s.push_str(library);
+    s.push('|');
+    s.push_str(registry_fp);
+    s.push('|');
+
+    push_str(&mut s, args, "projectile");
+    push_num(&mut s, args, "energy_mev", f64::NAN);
+    push_num(&mut s, args, "current_ma", f64::NAN);
+    push_num(&mut s, args, "irradiation_time_s", 86400.0);
+    push_num(&mut s, args, "cooling_time_s", 86400.0);
+
+    s.push_str("layers=");
+    if let Some(layers) = args.get("layers").and_then(|v| v.as_array()) {
+        for layer in layers {
+            s.push('[');
+            // Material resolution is case-insensitive, so normalize.
+            let material = layer
+                .get("material")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_lowercase();
+            s.push_str(&material);
+            push_num(&mut s, layer, "thickness_cm", f64::NAN);
+            push_num(&mut s, layer, "energy_out_mev", f64::NAN);
+            push_num(&mut s, layer, "density_g_cm3", f64::NAN);
+            // Enrichment overrides: sort by (element, A) so order is irrelevant.
+            if let Some(enr) = layer.get("enrichment").and_then(|v| v.as_array()) {
+                let mut entries: Vec<(String, u64, f64)> = enr
+                    .iter()
+                    .map(|e| {
+                        (
+                            e.get("element")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or("")
+                                .to_string(),
+                            e.get("A").and_then(|v| v.as_u64()).unwrap_or(0),
+                            e.get("fraction").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                        )
+                    })
+                    .collect();
+                entries.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+                s.push_str("enr{");
+                for (el, a, f) in entries {
+                    s.push_str(&format!("{el}-{a}:{f:?};"));
+                }
+                s.push('}');
+            }
+            s.push(']');
+        }
+    }
+
+    if let Some(cp) = args.get("current_profile") {
+        if !cp.is_null() {
+            s.push_str("cp=");
+            push_num_array(&mut s, cp, "times_s");
+            push_num_array(&mut s, cp, "currents_ma");
+        }
+    }
+    s
+}
+
+fn push_str(s: &mut String, obj: &Value, key: &str) {
+    s.push_str(key);
+    s.push('=');
+    s.push_str(obj.get(key).and_then(|v| v.as_str()).unwrap_or(""));
+    s.push('|');
+}
+
+fn push_num(s: &mut String, obj: &Value, key: &str, default: f64) {
+    let v = obj.get(key).and_then(|v| v.as_f64()).unwrap_or(default);
+    s.push_str(key);
+    s.push('=');
+    s.push_str(&format!("{v:?}"));
+    s.push('|');
+}
+
+fn push_num_array(s: &mut String, obj: &Value, key: &str) {
+    s.push_str(key);
+    s.push('=');
+    if let Some(arr) = obj.get(key).and_then(|v| v.as_array()) {
+        for n in arr {
+            s.push_str(&format!("{:?},", n.as_f64().unwrap_or(f64::NAN)));
+        }
+    }
+    s.push('|');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn key_is_order_and_format_independent() {
+        // Same config, different JSON key order + int-vs-float, must collide.
+        let a = json!({"projectile":"p","energy_mev":18,"current_ma":0.04,
+            "layers":[{"material":"Ti","thickness_cm":0.02}]});
+        let b = json!({"current_ma":0.04,"layers":[{"thickness_cm":0.02,"material":"ti"}],
+            "energy_mev":18.0,"projectile":"p"});
+        assert_eq!(hash_config(&a, "lib", ""), hash_config(&b, "lib", ""));
+    }
+
+    #[test]
+    fn key_separates_distinct_configs() {
+        let a = json!({"projectile":"p","energy_mev":18.0,"current_ma":0.04,"layers":[]});
+        let b = json!({"projectile":"p","energy_mev":16.0,"current_ma":0.04,"layers":[]});
+        assert_ne!(hash_config(&a, "lib", ""), hash_config(&b, "lib", ""));
+        // Library and registry fingerprint participate in the key.
+        assert_ne!(hash_config(&a, "lib1", ""), hash_config(&a, "lib2", ""));
+        assert_ne!(hash_config(&a, "lib", "fp1"), hash_config(&a, "lib", "fp2"));
+    }
+
+    #[test]
+    fn enrichment_order_does_not_matter() {
+        let a = json!({"projectile":"p","energy_mev":18.0,"current_ma":0.04,"layers":[
+            {"material":"MoO3","enrichment":[
+                {"element":"Mo","A":100,"fraction":0.95},
+                {"element":"Mo","A":98,"fraction":0.05}]}]});
+        let b = json!({"projectile":"p","energy_mev":18.0,"current_ma":0.04,"layers":[
+            {"material":"MoO3","enrichment":[
+                {"element":"Mo","A":98,"fraction":0.05},
+                {"element":"Mo","A":100,"fraction":0.95}]}]});
+        assert_eq!(hash_config(&a, "lib", ""), hash_config(&b, "lib", ""));
+    }
+
+    #[test]
+    fn cached_stack_computes_once_then_serves_from_cache() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        // Unique config so this can't collide with another test on the shared
+        // process-global cache.
+        let args = json!({"projectile":"p","energy_mev":7.7777,"current_ma":0.0123,"layers":[]});
+        let lib = "lib-cache-once-test";
+        let calls = AtomicUsize::new(0);
+        let mk = |t: f64| StackResult {
+            layer_results: vec![],
+            irradiation_time_s: t,
+            cooling_time_s: 0.0,
+        };
+
+        let a = cached_stack(&args, lib, "", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(mk(11.0))
+        })
+        .unwrap();
+        let b = cached_stack(&args, lib, "", || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(mk(22.0))
+        })
+        .unwrap();
+
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "second call must hit the cache");
+        // Both Arcs are the cached (first) result, so the second closure's
+        // value (22.0) was never used.
+        assert_eq!(a.irradiation_time_s, 11.0);
+        assert_eq!(b.irradiation_time_s, 11.0);
+    }
+
+    #[test]
+    fn lru_evicts_oldest_beyond_capacity() {
+        let mut lru = Lru::new();
+        let sr = || {
+            Arc::new(StackResult {
+                layer_results: vec![],
+                irradiation_time_s: 0.0,
+                cooling_time_s: 0.0,
+            })
+        };
+        for k in 0..(CAPACITY as u64 + 5) {
+            lru.put(k, sr());
+        }
+        assert!(lru.map.len() <= CAPACITY);
+        assert!(lru.get(0).is_none(), "oldest key should have been evicted");
+        assert!(lru.get(CAPACITY as u64 + 4).is_some(), "newest key retained");
+    }
+}

--- a/core/src/mcp/dataset.rs
+++ b/core/src/mcp/dataset.rs
@@ -1,0 +1,538 @@
+//! Structured-export tables for the #427 dataset tools.
+//!
+//! A [`Table`] is a set of named, typed columns in long format. The same
+//! column source feeds both the inline JSON (`to_json_rows`) and the embedded
+//! Parquet resource (`to_parquet_bytes`), so the two representations can never
+//! drift. Builders turn a [`StackResult`] (+ decay/emission data) into the
+//! inventory / cooling-tail / depth-profile / emission tables the issue spells
+//! out.
+
+use serde_json::{Map, Number, Value};
+
+use crate::db::DatabaseProtocol;
+use crate::types::{EmissionLine, IsotopeResult, StackResult};
+
+/// One typed column. `&'static str` names keep the schema literal at the call
+/// site; nullable variants map to Parquet nullable + JSON `null`.
+pub enum Col {
+    I64(&'static str, Vec<i64>),
+    OptI64(&'static str, Vec<Option<i64>>),
+    F64(&'static str, Vec<f64>),
+    OptF64(&'static str, Vec<Option<f64>>),
+    Str(&'static str, Vec<String>),
+    OptStr(&'static str, Vec<Option<String>>),
+}
+
+impl Col {
+    fn name(&self) -> &'static str {
+        match self {
+            Col::I64(n, _)
+            | Col::OptI64(n, _)
+            | Col::F64(n, _)
+            | Col::OptF64(n, _)
+            | Col::Str(n, _)
+            | Col::OptStr(n, _) => n,
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Col::I64(_, v) => v.len(),
+            Col::OptI64(_, v) => v.len(),
+            Col::F64(_, v) => v.len(),
+            Col::OptF64(_, v) => v.len(),
+            Col::Str(_, v) => v.len(),
+            Col::OptStr(_, v) => v.len(),
+        }
+    }
+
+    fn json_at(&self, i: usize) -> Value {
+        let f64_to_json = |x: f64| Number::from_f64(x).map(Value::Number).unwrap_or(Value::Null);
+        match self {
+            Col::I64(_, v) => Value::Number(v[i].into()),
+            Col::OptI64(_, v) => v[i].map(|x| Value::Number(x.into())).unwrap_or(Value::Null),
+            Col::F64(_, v) => f64_to_json(v[i]),
+            Col::OptF64(_, v) => v[i].map(f64_to_json).unwrap_or(Value::Null),
+            Col::Str(_, v) => Value::String(v[i].clone()),
+            Col::OptStr(_, v) => v[i].clone().map(Value::String).unwrap_or(Value::Null),
+        }
+    }
+}
+
+/// A named long-format table.
+pub struct Table {
+    pub name: &'static str,
+    pub cols: Vec<Col>,
+}
+
+impl Table {
+    pub fn nrows(&self) -> usize {
+        self.cols.first().map(Col::len).unwrap_or(0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.nrows() == 0
+    }
+
+    /// Long-format rows as JSON objects (one per row).
+    pub fn to_json_rows(&self) -> Vec<Value> {
+        (0..self.nrows())
+            .map(|i| {
+                let mut obj = Map::new();
+                for col in &self.cols {
+                    obj.insert(col.name().to_string(), col.json_at(i));
+                }
+                Value::Object(obj)
+            })
+            .collect()
+    }
+
+    /// Serialize to in-memory Parquet bytes via Arrow.
+    pub fn to_parquet_bytes(&self) -> Result<Vec<u8>, String> {
+        use arrow::array::{ArrayRef, Float64Array, Int64Array, StringArray};
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::record_batch::RecordBatch;
+        use parquet::arrow::ArrowWriter;
+        use std::sync::Arc;
+
+        let mut fields = Vec::with_capacity(self.cols.len());
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.cols.len());
+        for col in &self.cols {
+            let (field, array): (Field, ArrayRef) = match col {
+                Col::I64(n, v) => (
+                    Field::new(*n, DataType::Int64, false),
+                    Arc::new(Int64Array::from(v.clone())),
+                ),
+                Col::OptI64(n, v) => (
+                    Field::new(*n, DataType::Int64, true),
+                    Arc::new(Int64Array::from(v.clone())),
+                ),
+                Col::F64(n, v) => (
+                    Field::new(*n, DataType::Float64, false),
+                    Arc::new(Float64Array::from(v.clone())),
+                ),
+                Col::OptF64(n, v) => (
+                    Field::new(*n, DataType::Float64, true),
+                    Arc::new(Float64Array::from(v.clone())),
+                ),
+                Col::Str(n, v) => (
+                    Field::new(*n, DataType::Utf8, false),
+                    Arc::new(StringArray::from_iter(v.iter().map(|s| Some(s.as_str())))),
+                ),
+                Col::OptStr(n, v) => (
+                    Field::new(*n, DataType::Utf8, true),
+                    Arc::new(StringArray::from_iter(v.iter().map(|o| o.as_deref()))),
+                ),
+            };
+            fields.push(field);
+            arrays.push(array);
+        }
+
+        let schema = Arc::new(Schema::new(fields));
+        let batch = RecordBatch::try_new(Arc::clone(&schema), arrays).map_err(|e| e.to_string())?;
+        let mut buf = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut buf, schema, None).map_err(|e| e.to_string())?;
+            writer.write(&batch).map_err(|e| e.to_string())?;
+            writer.close().map_err(|e| e.to_string())?;
+        }
+        Ok(buf)
+    }
+}
+
+/// β+ / EC / β- / IT branching fractions for a nuclide, summed across the
+/// sub-modes the data splits EC into (`KshellEC`, `LshellEC`, …).
+pub fn branching_split(db: &dyn DatabaseProtocol, z: u32, a: u32, state: &str) -> (f64, f64, f64, f64) {
+    let (mut bp, mut ec, mut bm, mut it) = (0.0, 0.0, 0.0, 0.0);
+    if let Some(decay) = db.get_decay_data(z, a, state) {
+        for m in &decay.decay_modes {
+            match m.mode.as_str() {
+                "beta+" => bp += m.branching,
+                "beta-" => bm += m.branching,
+                "IT" => it += m.branching,
+                s if s.ends_with("shellEC") || s == "EC" => ec += m.branching,
+                _ => {}
+            }
+        }
+    }
+    (bp, ec, bm, it)
+}
+
+/// Activity [Bq] at end of bombardment — the first time-grid sample at or after
+/// the irradiation time (matching the cooling-curve tool's EOB convention).
+pub fn eob_activity(iso: &IsotopeResult, t_irr: f64) -> f64 {
+    iso.time_grid_s
+        .iter()
+        .position(|&t| t >= t_irr)
+        .and_then(|i| iso.activity_vs_time_bq.get(i).copied())
+        .unwrap_or(iso.activity_bq)
+}
+
+/// Sorted, de-duplicated list of every isotope produced anywhere in the stack,
+/// as `(z, a, state, name)`. Used by the (layer-independent) emission table.
+fn distinct_isotopes(result: &StackResult) -> Vec<(u32, u32, String, String)> {
+    let mut seen = std::collections::BTreeMap::new();
+    for lr in &result.layer_results {
+        for iso in lr.isotope_results.values() {
+            seen.entry((iso.z, iso.a, iso.state.clone()))
+                .or_insert_with(|| iso.name.clone());
+        }
+    }
+    seen.into_iter()
+        .map(|((z, a, st), name)| (z, a, st, name))
+        .collect()
+}
+
+/// Inventory table: one row per (isotope × layer × source).
+pub fn build_inventory(
+    db: &dyn DatabaseProtocol,
+    result: &StackResult,
+    layer_materials: &[String],
+    sim_id: &str,
+) -> Table {
+    let t_irr = result.irradiation_time_s;
+    let (mut sid, mut li, mut mat) = (vec![], vec![], vec![]);
+    let (mut z, mut a, mut state, mut iso_name) = (vec![], vec![], vec![], vec![]);
+    let (mut src, mut rate, mut sat) = (vec![], vec![], vec![]);
+    let (mut eob, mut cool, mut hl) = (vec![], vec![], vec![]);
+    let (mut bp, mut ec, mut bm, mut it) = (vec![], vec![], vec![], vec![]);
+
+    for (idx, lr) in result.layer_results.iter().enumerate() {
+        let mut isos: Vec<&IsotopeResult> = lr.isotope_results.values().collect();
+        isos.sort_by(|x, y| {
+            y.activity_bq
+                .partial_cmp(&x.activity_bq)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| x.name.cmp(&y.name))
+        });
+        for iso in isos {
+            sid.push(sim_id.to_string());
+            li.push((idx + 1) as i64);
+            mat.push(layer_materials.get(idx).cloned().unwrap_or_default());
+            z.push(iso.z as i64);
+            a.push(iso.a as i64);
+            state.push(iso.state.clone());
+            iso_name.push(iso.name.clone());
+            src.push(iso.source.clone());
+            rate.push(iso.production_rate);
+            sat.push(iso.saturation_yield_bq_ua);
+            eob.push(eob_activity(iso, t_irr));
+            cool.push(iso.activity_bq);
+            hl.push(iso.half_life_s);
+            let (b_p, b_ec, b_m, b_it) = branching_split(db, iso.z, iso.a, &iso.state);
+            bp.push(b_p);
+            ec.push(b_ec);
+            bm.push(b_m);
+            it.push(b_it);
+        }
+    }
+
+    Table {
+        name: "inventory",
+        cols: vec![
+            Col::Str("simulation_id", sid),
+            Col::I64("layer_index", li),
+            Col::Str("layer_material", mat),
+            Col::I64("z", z),
+            Col::I64("a", a),
+            Col::Str("state", state),
+            Col::Str("isotope", iso_name),
+            Col::Str("production_source", src),
+            Col::F64("production_rate_per_s", rate),
+            Col::F64("saturation_yield_bq_per_ua", sat),
+            Col::F64("activity_at_eob_bq", eob),
+            Col::F64("activity_at_cooling_bq", cool),
+            Col::OptF64("half_life_s", hl),
+            Col::F64("beta_plus_branching", bp),
+            Col::F64("ec_branching", ec),
+            Col::F64("beta_minus_branching", bm),
+            Col::F64("it_branching", it),
+        ],
+    }
+}
+
+/// Cooling-tail table: activity [Bq] vs time for t ≥ irradiation time, one row
+/// per (isotope × layer × time point).
+pub fn build_cooling(result: &StackResult, sim_id: &str) -> Table {
+    let t_irr = result.irradiation_time_s;
+    let (mut sid, mut li, mut iso_name, mut t, mut act) = (vec![], vec![], vec![], vec![], vec![]);
+    for (idx, lr) in result.layer_results.iter().enumerate() {
+        for iso in lr.isotope_results.values() {
+            for (&ts, &av) in iso.time_grid_s.iter().zip(iso.activity_vs_time_bq.iter()) {
+                if ts >= t_irr {
+                    sid.push(sim_id.to_string());
+                    li.push((idx + 1) as i64);
+                    iso_name.push(iso.name.clone());
+                    t.push(ts);
+                    act.push(av);
+                }
+            }
+        }
+    }
+    Table {
+        name: "cooling",
+        cols: vec![
+            Col::Str("simulation_id", sid),
+            Col::I64("layer_index", li),
+            Col::Str("isotope", iso_name),
+            Col::F64("t_s", t),
+            Col::F64("activity_bq", act),
+        ],
+    }
+}
+
+/// Depth-profile table: local production rate [atoms/s/cm] along depth, one row
+/// per (isotope × layer × depth point).
+pub fn build_depth(result: &StackResult, sim_id: &str) -> Table {
+    let (mut sid, mut li, mut iso_name) = (vec![], vec![], vec![]);
+    let (mut depth, mut energy, mut prate) = (vec![], vec![], vec![]);
+    for (idx, lr) in result.layer_results.iter().enumerate() {
+        for (name, rates) in &lr.depth_production_rates {
+            if lr.depth_profile.len() != rates.len() {
+                continue; // sibling-array invariant broken — skip rather than zip-truncate
+            }
+            for (dp, &r) in lr.depth_profile.iter().zip(rates.iter()) {
+                sid.push(sim_id.to_string());
+                li.push((idx + 1) as i64);
+                iso_name.push(name.clone());
+                depth.push(dp.depth_cm);
+                energy.push(dp.energy_mev);
+                prate.push(r);
+            }
+        }
+    }
+    Table {
+        name: "depth",
+        cols: vec![
+            Col::Str("simulation_id", sid),
+            Col::I64("layer_index", li),
+            Col::Str("isotope", iso_name),
+            Col::F64("depth_cm", depth),
+            Col::F64("energy_mev", energy),
+            Col::F64("production_rate_atoms_per_s_per_cm", prate),
+        ],
+    }
+}
+
+/// Total activity time series for `isotope`, summed across every layer that
+/// produces it (photons leave the whole stack, not one layer). Returns the
+/// shared time grid and the elementwise activity sum; layers whose grid length
+/// disagrees with the reference are skipped (should not happen within one sim).
+fn total_activity(result: &StackResult, isotope: &str) -> (Vec<f64>, Vec<f64>) {
+    let mut grid: Vec<f64> = Vec::new();
+    let mut total: Vec<f64> = Vec::new();
+    for lr in &result.layer_results {
+        if let Some(iso) = lr.isotope_results.get(isotope) {
+            if grid.is_empty() {
+                grid = iso.time_grid_s.clone();
+                total = iso.activity_vs_time_bq.clone();
+            } else if iso.activity_vs_time_bq.len() == total.len() {
+                for (acc, v) in total.iter_mut().zip(iso.activity_vs_time_bq.iter()) {
+                    *acc += v;
+                }
+            }
+        }
+    }
+    (grid, total)
+}
+
+/// Emission-rate curve table (#427): photon/particle emission rate
+/// `rate_per_s(t) = total_activity(t) × intensity_per_decay` per (isotope ×
+/// line × time point). Filters: `iso_filter` (exact isotope), `type_filter`
+/// (rad_type), `energy_filter` (± `energy_tol` keV). `cooling_only` keeps only
+/// t ≥ irradiation time.
+#[allow(clippy::too_many_arguments)]
+pub fn build_emission_curve(
+    db: &dyn DatabaseProtocol,
+    result: &StackResult,
+    sim_id: &str,
+    cooling_only: bool,
+    iso_filter: Option<&str>,
+    type_filter: Option<&str>,
+    energy_filter: Option<f64>,
+    energy_tol: f64,
+) -> Table {
+    let t_irr = result.irradiation_time_s;
+    let (mut sid, mut iso_name, mut energy, mut etype, mut t, mut rate) =
+        (vec![], vec![], vec![], vec![], vec![], vec![]);
+
+    for (z, a, state, name) in distinct_isotopes(result) {
+        if iso_filter.is_some_and(|f| f != name) {
+            continue;
+        }
+        let lines: Vec<EmissionLine> = db
+            .get_emissions(z, a, &state)
+            .into_iter()
+            .filter(|l| {
+                type_filter.is_none_or(|tf| l.rad_type == tf)
+                    && energy_filter.is_none_or(|e| (l.energy_kev - e).abs() <= energy_tol)
+            })
+            .collect();
+        if lines.is_empty() {
+            continue;
+        }
+
+        let (grid, activity) = total_activity(result, &name);
+        if grid.is_empty() {
+            continue;
+        }
+
+        for line in &lines {
+            for (ti, &ts) in grid.iter().enumerate() {
+                if cooling_only && ts < t_irr {
+                    continue;
+                }
+                sid.push(sim_id.to_string());
+                iso_name.push(name.clone());
+                energy.push(line.energy_kev);
+                etype.push(line.rad_type.clone());
+                t.push(ts);
+                rate.push(activity[ti] * line.intensity_per_decay);
+            }
+        }
+    }
+
+    Table {
+        name: "emission_curve",
+        cols: vec![
+            Col::Str("simulation_id", sid),
+            Col::Str("isotope", iso_name),
+            Col::F64("energy_kev", energy),
+            Col::Str("emission_type", etype),
+            Col::F64("t_s", t),
+            Col::F64("rate_per_s", rate),
+        ],
+    }
+}
+
+/// Emission table: per-decay γ / X-ray / Auger / CE / β± / annihilation lines
+/// for every produced isotope (layer-independent), one row per (isotope × line).
+pub fn build_emissions(db: &dyn DatabaseProtocol, result: &StackResult, sim_id: &str) -> Table {
+    let (mut sid, mut iso_name, mut z, mut a, mut state) = (vec![], vec![], vec![], vec![], vec![]);
+    let (mut rad, mut energy, mut intensity) = (vec![], vec![], vec![]);
+    let (mut dmode, mut dz, mut da, mut icc, mut subtype) = (vec![], vec![], vec![], vec![], vec![]);
+
+    for (iso_z, iso_a, iso_state, name) in distinct_isotopes(result) {
+        for line in db.get_emissions(iso_z, iso_a, &iso_state) {
+            sid.push(sim_id.to_string());
+            iso_name.push(name.clone());
+            z.push(iso_z as i64);
+            a.push(iso_a as i64);
+            state.push(iso_state.clone());
+            rad.push(line.rad_type);
+            energy.push(line.energy_kev);
+            intensity.push(line.intensity_per_decay);
+            dmode.push(line.decay_mode);
+            dz.push(line.daughter_z.map(|v| v as i64));
+            da.push(line.daughter_a.map(|v| v as i64));
+            icc.push(line.icc_total);
+            subtype.push(line.rad_subtype);
+        }
+    }
+
+    Table {
+        name: "emissions",
+        cols: vec![
+            Col::Str("simulation_id", sid),
+            Col::Str("isotope", iso_name),
+            Col::I64("z", z),
+            Col::I64("a", a),
+            Col::Str("state", state),
+            Col::Str("rad_type", rad),
+            Col::F64("energy_kev", energy),
+            Col::F64("intensity_per_decay", intensity),
+            Col::OptStr("decay_mode", dmode),
+            Col::OptI64("daughter_z", dz),
+            Col::OptI64("daughter_a", da),
+            Col::OptF64("icc_total", icc),
+            Col::OptStr("rad_subtype", subtype),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample() -> Table {
+        Table {
+            name: "t",
+            cols: vec![
+                Col::I64("i", vec![1, 2]),
+                Col::OptI64("oi", vec![Some(7), None]),
+                Col::F64("f", vec![1.5, 2.5]),
+                Col::OptF64("of", vec![None, Some(9.0)]),
+                Col::Str("s", vec!["a".into(), "b".into()]),
+                Col::OptStr("os", vec![Some("x".into()), None]),
+            ],
+        }
+    }
+
+    #[test]
+    fn json_rows_are_long_format_with_nulls() {
+        let rows = sample().to_json_rows();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["i"], json!(1));
+        assert_eq!(rows[0]["oi"], json!(7));
+        assert_eq!(rows[1]["oi"], Value::Null);
+        assert_eq!(rows[0]["of"], Value::Null);
+        assert_eq!(rows[1]["of"], json!(9.0));
+        assert_eq!(rows[0]["s"], json!("a"));
+        assert_eq!(rows[1]["os"], Value::Null);
+    }
+
+    #[test]
+    fn empty_table_reports_empty() {
+        let t = Table { name: "e", cols: vec![Col::I64("i", vec![])] };
+        assert!(t.is_empty());
+        assert_eq!(t.to_json_rows().len(), 0);
+    }
+
+    #[test]
+    fn parquet_round_trips_through_a_reader() {
+        use arrow::array::{Array, Float64Array, Int64Array, StringArray};
+        use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
+        use std::io::Write;
+
+        let bytes = sample().to_parquet_bytes().unwrap();
+        // Structurally a Parquet container.
+        assert_eq!(&bytes[..4], b"PAR1");
+        assert_eq!(&bytes[bytes.len() - 4..], b"PAR1");
+
+        // Read it back with a real Parquet reader and check the values survive.
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(&bytes).unwrap();
+        let file = tmp.reopen().unwrap();
+        let mut reader = ParquetRecordBatchReaderBuilder::try_new(file)
+            .unwrap()
+            .build()
+            .unwrap();
+        let batch = reader.next().unwrap().unwrap();
+        assert_eq!(batch.num_rows(), 2);
+
+        let col = |name: &str| batch.column(batch.schema().index_of(name).unwrap()).clone();
+        let i = col("i");
+        let i = i.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(i.value(0), 1);
+        assert_eq!(i.value(1), 2);
+
+        let oi = col("oi");
+        let oi = oi.as_any().downcast_ref::<Int64Array>().unwrap();
+        assert_eq!(oi.value(0), 7);
+        assert!(oi.is_null(1), "OptI64 None must round-trip to a Parquet null");
+
+        let f = col("f");
+        let f = f.as_any().downcast_ref::<Float64Array>().unwrap();
+        assert!((f.value(1) - 2.5).abs() < 1e-12);
+
+        let s = col("s");
+        let s = s.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(s.value(0), "a");
+
+        let os = col("os");
+        let os = os.as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(os.value(0), "x");
+        assert!(os.is_null(1), "OptStr None must round-trip to a Parquet null");
+    }
+}

--- a/core/src/mcp/mod.rs
+++ b/core/src/mcp/mod.rs
@@ -4,5 +4,7 @@
 //! instead of the GUI. This enables AI assistants to invoke
 //! nuclear physics calculations directly.
 
+pub mod cache;
+pub mod dataset;
 pub mod tools;
 pub mod transport;

--- a/core/src/mcp/tools.rs
+++ b/core/src/mcp/tools.rs
@@ -8,6 +8,109 @@ use crate::materials::{
 use crate::types::*;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
+
+use super::cache;
+use super::dataset::{self, Table};
+
+/// An embedded binary resource attached to a tool result. `blob_base64` holds
+/// standard-base64-encoded bytes (#427 uses this for Parquet tables).
+#[derive(Debug)]
+pub struct ToolResource {
+    pub uri: String,
+    pub mime_type: String,
+    pub blob_base64: String,
+}
+
+/// A tool's output: LLM-readable text plus any embedded resources. Most tools
+/// return text only (via `From<String>`); the dataset tools also attach
+/// Parquet resources alongside the inline JSON.
+#[derive(Debug)]
+pub struct ToolResponse {
+    pub text: String,
+    pub resources: Vec<ToolResource>,
+}
+
+impl From<String> for ToolResponse {
+    fn from(text: String) -> Self {
+        Self { text, resources: Vec::new() }
+    }
+}
+
+/// Base64-encode bytes for an embedded MCP resource blob.
+fn b64(bytes: &[u8]) -> String {
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+/// Attach a table as a Parquet resource under a stable `hyrr://` URI.
+fn parquet_resource(sim_id: &str, table: &Table) -> Result<ToolResource, String> {
+    Ok(ToolResource {
+        uri: format!("hyrr://sim/{sim_id}/{}.parquet", table.name),
+        mime_type: "application/vnd.apache.parquet".to_string(),
+        blob_base64: b64(&table.to_parquet_bytes()?),
+    })
+}
+
+/// Fingerprint of session-defined materials so the result cache can't return a
+/// stale simulation after an alloy is (re)defined. Empty when no session
+/// materials exist (the common case → no effect on the cache key).
+fn registry_fingerprint(reg: &MaterialRegistry) -> String {
+    if reg.is_empty() {
+        return String::new();
+    }
+    let mut names: Vec<&String> = reg.keys().collect();
+    names.sort();
+    let mut s = String::new();
+    for name in names {
+        let m = &reg[name];
+        s.push_str(name);
+        s.push_str(&format!(":{:?}:", m.density_g_cm3));
+        let mut fr: Vec<(&String, &f64)> = m.mass_fractions.iter().collect();
+        fr.sort_by(|a, b| a.0.cmp(b.0));
+        for (e, f) in fr {
+            s.push_str(&format!("{e}={f:?},"));
+        }
+        s.push(';');
+    }
+    s
+}
+
+/// Run a simulation through the process-scoped result cache (#427). Repeat
+/// queries on the same config are lazy views over the cached `StackResult`.
+fn cached_sim(
+    db: &dyn DatabaseProtocol,
+    registry: &MaterialRegistry,
+    args: &Value,
+) -> Result<Arc<StackResult>, String> {
+    let fp = registry_fingerprint(registry);
+    cache::cached_stack(args, db.library(), &fp, || {
+        build_and_run_sim(db, registry, args).map(|(_stack, result, ..)| result)
+    })
+}
+
+/// Beam params for display headers, read directly from args (the cache returns
+/// only a `StackResult`, so metadata comes from the request).
+fn beam_args(args: &Value) -> (String, f64, f64) {
+    (
+        args.get("projectile").and_then(|v| v.as_str()).unwrap_or("?").to_string(),
+        args.get("energy_mev").and_then(|v| v.as_f64()).unwrap_or(0.0),
+        args.get("current_ma").and_then(|v| v.as_f64()).unwrap_or(0.0),
+    )
+}
+
+/// Layer material names in beam order, as written in the request (the
+/// `StackResult` doesn't carry them).
+fn layer_materials(args: &Value) -> Vec<String> {
+    args.get("layers")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .map(|l| l.get("material").and_then(|v| v.as_str()).unwrap_or("").to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 /// JSON Schema for a single target layer. Shared by every tool that takes
 /// `layers`. `require_thickness` toggles whether `thickness_cm` is required —
@@ -290,6 +393,62 @@ pub fn list_tools() -> Vec<Value> {
                 "required": ["z", "a"]
             }
         }),
+        serde_json::json!({
+            "name": "get_simulation_dataset",
+            "description": "Full structured export of a simulation as long-format tables — both inline JSON (for direct reasoning) and attached Parquet resources (for polars/pandas). Always returns the inventory table (one row per isotope × layer × source, with production rate, saturation yield, end-of-bombardment + end-of-cooling activity, half-life, and β+/EC/β−/IT branching). Set `cooling`, `depth`, and/or `emissions` to also include the cooling-tail (activity vs time), depth-profile (production rate vs depth), and per-decay emission-line tables. Cheap: backed by a config-hashed cache, so repeat queries on the same config don't recompute.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "projectile": { "type": "string", "enum": ["p", "d", "t", "h", "a"] },
+                    "energy_mev": { "type": "number" },
+                    "current_ma": { "type": "number" },
+                    "layers": { "type": "array", "items": layer_schema(false) },
+                    "irradiation_time_s": { "type": "number" },
+                    "cooling_time_s": { "type": "number" },
+                    "cooling": { "type": "boolean", "description": "Include the cooling-tail table (activity [Bq] vs time, t ≥ irradiation). Default false." },
+                    "depth": { "type": "boolean", "description": "Include the depth-profile table (production rate [atoms/s/cm] vs depth). Default false." },
+                    "emissions": { "type": "boolean", "description": "Include the emission table (per γ/x-ray/Auger/β±/annihilation line with intensity_per_decay). Default false." }
+                },
+                "required": ["projectile", "energy_mev", "current_ma", "layers"]
+            }
+        }),
+        serde_json::json!({
+            "name": "get_isotope_inventory",
+            "description": "Cheap 'what's in the can' query: just the inventory table (one row per isotope × layer × source — production rate, saturation yield, EOB + cooling activity, half-life, branching). No time series, no depth. Inline JSON plus a Parquet resource. Same stack arguments as `simulate`.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "projectile": { "type": "string", "enum": ["p", "d", "t", "h", "a"] },
+                    "energy_mev": { "type": "number" },
+                    "current_ma": { "type": "number" },
+                    "layers": { "type": "array", "items": layer_schema(false) },
+                    "irradiation_time_s": { "type": "number" },
+                    "cooling_time_s": { "type": "number" }
+                },
+                "required": ["projectile", "energy_mev", "current_ma", "layers"]
+            }
+        }),
+        serde_json::json!({
+            "name": "get_emission_curve",
+            "description": "Per-isotope / per-line photon (or particle) emission-rate time series: rate_per_s(t) = total stack activity × intensity_per_decay, summed across layers. Long-format {t_s, isotope, energy_kev, emission_type, rate_per_s}, inline JSON + Parquet resource. The load-bearing surface for 511 keV purity windows, HPGe spectrum prediction, and dose-rate envelopes. Optional filters narrow the output: `isotope`, `emission_type` (gamma/xray/auger/ce/beta-/beta+/annihilation), `energy_kev` (± `energy_tolerance_kev`).",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "projectile": { "type": "string", "enum": ["p", "d", "t", "h", "a"] },
+                    "energy_mev": { "type": "number" },
+                    "current_ma": { "type": "number" },
+                    "layers": { "type": "array", "items": layer_schema(false) },
+                    "irradiation_time_s": { "type": "number" },
+                    "cooling_time_s": { "type": "number" },
+                    "isotope": { "type": "string", "description": "Restrict to one isotope, e.g. 'F-18'. Optional — default sums every produced isotope." },
+                    "emission_type": { "type": "string", "description": "Restrict to one radiation type: gamma | xray | auger | ce | beta- | beta+ | annihilation." },
+                    "energy_kev": { "type": "number", "description": "Restrict to lines within ± energy_tolerance_kev of this energy (e.g. 511)." },
+                    "energy_tolerance_kev": { "type": "number", "description": "Tolerance for energy_kev matching [keV]. Default 1.0." },
+                    "vs": { "type": "string", "enum": ["time", "cooling"], "description": "'time' = full irradiation + cooling timeline; 'cooling' = cooling tail only. Default 'time'." }
+                },
+                "required": ["projectile", "energy_mev", "current_ma", "layers"]
+            }
+        }),
     ]
 }
 
@@ -303,21 +462,27 @@ pub fn call_tool(
     materials: &mut MaterialRegistry,
     name: &str,
     arguments: &Value,
-) -> Result<String, String> {
-    let body = match name {
-        "define_material" => tool_define_material(materials, arguments),
-        "simulate" => tool_simulate(db, &*materials, arguments),
-        "list_materials" => tool_list_materials(&*materials),
-        "list_reaction_channels" => tool_list_reaction_channels(db, arguments),
-        "get_decay_data" => tool_get_decay_data(db, arguments),
-        "compare_simulations" => tool_compare_simulations(db, &*materials, arguments),
-        "get_stack_energy_budget" => tool_get_stack_energy_budget(db, &*materials, arguments),
-        "get_stopping_power" => tool_get_stopping_power(db, &*materials, arguments),
-        "get_isotope_production_curve" => tool_get_isotope_production_curve(db, &*materials, arguments),
-        "list_producing_layers" => tool_list_producing_layers(db, &*materials, arguments),
+) -> Result<ToolResponse, String> {
+    // Text-only tools return a String (→ ToolResponse via From); the dataset
+    // tools return a ToolResponse directly (text + Parquet resources).
+    let mut response: ToolResponse = match name {
+        "define_material" => tool_define_material(materials, arguments)?.into(),
+        "simulate" => tool_simulate(db, &*materials, arguments)?.into(),
+        "list_materials" => tool_list_materials(&*materials)?.into(),
+        "list_reaction_channels" => tool_list_reaction_channels(db, arguments)?.into(),
+        "get_decay_data" => tool_get_decay_data(db, arguments)?.into(),
+        "compare_simulations" => tool_compare_simulations(db, &*materials, arguments)?.into(),
+        "get_stack_energy_budget" => tool_get_stack_energy_budget(db, &*materials, arguments)?.into(),
+        "get_stopping_power" => tool_get_stopping_power(db, &*materials, arguments)?.into(),
+        "get_isotope_production_curve" => tool_get_isotope_production_curve(db, &*materials, arguments)?.into(),
+        "list_producing_layers" => tool_list_producing_layers(db, &*materials, arguments)?.into(),
+        "get_simulation_dataset" => tool_get_simulation_dataset(db, &*materials, arguments)?,
+        "get_isotope_inventory" => tool_get_isotope_inventory(db, &*materials, arguments)?,
+        "get_emission_curve" => tool_get_emission_curve(db, &*materials, arguments)?,
         _ => return Err(format!("Unknown tool: {}", name)),
-    }?;
-    Ok(format!("{body}\n\n---\n*Library: {}*\n", db.library()))
+    };
+    response.text = format!("{}\n\n---\n*Library: {}*\n", response.text, db.library());
+    Ok(response)
 }
 
 /// Parse the flat enrichment array `[{element, A, fraction}]` into the
@@ -628,9 +793,12 @@ fn tool_define_material(
 }
 
 fn tool_simulate(db: &dyn DatabaseProtocol, registry: &MaterialRegistry, args: &Value) -> Result<String, String> {
-    let (stack, result, projectile_str, energy_mev, current_ma) = build_and_run_sim(db, registry, args)?;
-    let irr_time = stack.irradiation_time_s;
-    let cool_time = stack.cooling_time_s;
+    // Populate the result cache so follow-up dataset / inventory / emission
+    // queries on the same config are lazy views instead of re-runs (#427).
+    let result = cached_sim(db, registry, args)?;
+    let (projectile_str, energy_mev, current_ma) = beam_args(args);
+    let irr_time = result.irradiation_time_s;
+    let cool_time = result.cooling_time_s;
 
     let mut output = String::new();
     output.push_str(&format!(
@@ -1157,7 +1325,7 @@ fn tool_get_isotope_production_curve(
         _ => None,
     };
 
-    let (_stack, result, _, _, _) = build_and_run_sim(db, registry, args)?;
+    let result = cached_sim(db, registry, args)?;
 
     let sel = select_producing_layer(&result, &isotope, layer_index)?;
     let layer_idx = sel.layer_idx;
@@ -1272,7 +1440,7 @@ fn tool_list_producing_layers(
         .ok_or("Missing 'isotope'")?
         .to_string();
 
-    let (_stack, result, _, _, _) = build_and_run_sim(db, registry, args)?;
+    let result = cached_sim(db, registry, args)?;
 
     let producers = producing_layers(&result, &isotope);
     if producers.is_empty() {
@@ -1324,6 +1492,171 @@ fn tool_list_producing_layers(
     }
 
     Ok(output)
+}
+
+/// Max table rows inlined as JSON in a tool response. The full table always
+/// ships in the Parquet resource; inlining is capped so a large cooling/depth
+/// series can't blow up the LLM context (truncation is stated, not silent).
+const INLINE_ROW_CAP: usize = 200;
+
+/// Render a table as a `## name` section: a JSON code block (row-capped) noting
+/// any truncation. Shared by the dataset and inventory tools.
+fn render_table_section(table: &Table) -> Result<String, String> {
+    let rows = table.to_json_rows();
+    let shown = rows.len().min(INLINE_ROW_CAP);
+    let json = serde_json::to_string(&rows[..shown]).map_err(|e| e.to_string())?;
+    let note = if rows.len() > shown {
+        format!(
+            " — showing {shown} of {} rows (full table in the Parquet resource)",
+            rows.len()
+        )
+    } else {
+        String::new()
+    };
+    Ok(format!("## {}{}\n\n```json\n{}\n```\n", table.name, note, json))
+}
+
+fn tool_get_simulation_dataset(
+    db: &dyn DatabaseProtocol,
+    registry: &MaterialRegistry,
+    args: &Value,
+) -> Result<ToolResponse, String> {
+    let want_cooling = args.get("cooling").and_then(|v| v.as_bool()).unwrap_or(false);
+    let want_depth = args.get("depth").and_then(|v| v.as_bool()).unwrap_or(false);
+    let want_emissions = args.get("emissions").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    let result = cached_sim(db, registry, args)?;
+    let sim_id = cache::sim_id(args, db.library(), &registry_fingerprint(registry));
+    let mats = layer_materials(args);
+    let (proj, energy, current) = beam_args(args);
+
+    let mut tables: Vec<Table> = vec![dataset::build_inventory(db, &result, &mats, &sim_id)];
+    if want_cooling {
+        tables.push(dataset::build_cooling(&result, &sim_id));
+    }
+    if want_depth {
+        tables.push(dataset::build_depth(&result, &sim_id));
+    }
+    if want_emissions {
+        tables.push(dataset::build_emissions(db, &result, &sim_id));
+    }
+
+    let mut text = format!("# Simulation dataset `{sim_id}`\n\n");
+    text.push_str(&format!(
+        "**Beam:** {proj} at {energy:.1} MeV, {current:.3} mA | **Irradiation:** {:.0}s | **Cooling:** {:.0}s\n\n",
+        result.irradiation_time_s, result.cooling_time_s
+    ));
+    text.push_str(
+        "Each table is inlined as JSON below and attached as a Parquet resource \
+         (`hyrr://sim/<id>/<table>.parquet`). Long-format, one row per record.\n\n",
+    );
+    text.push_str("**Tables:** ");
+    text.push_str(
+        &tables
+            .iter()
+            .map(|t| format!("`{}` ({} rows)", t.name, t.nrows()))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    text.push('\n');
+
+    let mut resources = Vec::new();
+    for table in &tables {
+        if table.is_empty() {
+            text.push_str(&format!("\n## {} — (no rows)\n", table.name));
+            continue;
+        }
+        text.push('\n');
+        text.push_str(&render_table_section(table)?);
+        resources.push(parquet_resource(&sim_id, table)?);
+    }
+
+    Ok(ToolResponse { text, resources })
+}
+
+fn tool_get_isotope_inventory(
+    db: &dyn DatabaseProtocol,
+    registry: &MaterialRegistry,
+    args: &Value,
+) -> Result<ToolResponse, String> {
+    let result = cached_sim(db, registry, args)?;
+    let sim_id = cache::sim_id(args, db.library(), &registry_fingerprint(registry));
+    let mats = layer_materials(args);
+    let table = dataset::build_inventory(db, &result, &mats, &sim_id);
+
+    let mut text = format!(
+        "# Isotope inventory `{sim_id}` ({} rows)\n\n\
+         One row per isotope × layer × source. Full table also attached as a Parquet resource.\n\n",
+        table.nrows()
+    );
+    let resources = if table.is_empty() {
+        text.push_str("No isotopes produced.\n");
+        Vec::new()
+    } else {
+        text.push_str(&render_table_section(&table)?);
+        vec![parquet_resource(&sim_id, &table)?]
+    };
+    Ok(ToolResponse { text, resources })
+}
+
+fn tool_get_emission_curve(
+    db: &dyn DatabaseProtocol,
+    registry: &MaterialRegistry,
+    args: &Value,
+) -> Result<ToolResponse, String> {
+    let vs = args.get("vs").and_then(|v| v.as_str()).unwrap_or("time");
+    if !["time", "cooling"].contains(&vs) {
+        return Err(format!("'vs' must be 'time' or 'cooling' (got '{vs}')"));
+    }
+    let iso_filter = args.get("isotope").and_then(|v| v.as_str());
+    let type_filter = args.get("emission_type").and_then(|v| v.as_str());
+    let energy_filter = args.get("energy_kev").and_then(|v| v.as_f64());
+    let energy_tol = args
+        .get("energy_tolerance_kev")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1.0);
+
+    let result = cached_sim(db, registry, args)?;
+    let sim_id = cache::sim_id(args, db.library(), &registry_fingerprint(registry));
+
+    let table = dataset::build_emission_curve(
+        db,
+        &result,
+        &sim_id,
+        vs == "cooling",
+        iso_filter,
+        type_filter,
+        energy_filter,
+        energy_tol,
+    );
+
+    let mut text = format!(
+        "# Emission-rate curve `{sim_id}` ({}) — {} rows\n\n\
+         `rate_per_s` = total stack activity × intensity_per_decay, summed over layers, \
+         per (isotope × line × time). Full table attached as a Parquet resource.\n\n",
+        vs,
+        table.nrows()
+    );
+    if let Some(f) = iso_filter {
+        text.push_str(&format!("Filter: isotope = {f}. "));
+    }
+    if let Some(f) = type_filter {
+        text.push_str(&format!("Filter: emission_type = {f}. "));
+    }
+    if let Some(f) = energy_filter {
+        text.push_str(&format!("Filter: energy = {f} ± {energy_tol} keV. "));
+    }
+    text.push('\n');
+
+    let resources = if table.is_empty() {
+        text.push_str("\nNo emission lines match (no produced isotope emits a matching line).\n");
+        Vec::new()
+    } else {
+        text.push('\n');
+        text.push_str(&render_table_section(&table)?);
+        vec![parquet_resource(&sim_id, &table)?]
+    };
+    Ok(ToolResponse { text, resources })
 }
 
 fn format_halflife(seconds: f64) -> String {

--- a/core/src/mcp/transport.rs
+++ b/core/src/mcp/transport.rs
@@ -210,12 +210,23 @@ fn handle_request(
 
             match tools::call_tool(db, materials, name, &arguments) {
                 Ok(result) => {
-                    let response = serde_json::json!({
-                        "content": [{
-                            "type": "text",
-                            "text": result
-                        }]
-                    });
+                    // Text block first, then one embedded `resource` block per
+                    // attached Parquet table (#427).
+                    let mut content = vec![serde_json::json!({
+                        "type": "text",
+                        "text": result.text
+                    })];
+                    for res in &result.resources {
+                        content.push(serde_json::json!({
+                            "type": "resource",
+                            "resource": {
+                                "uri": res.uri,
+                                "mimeType": res.mime_type,
+                                "blob": res.blob_base64
+                            }
+                        }));
+                    }
+                    let response = serde_json::json!({ "content": content });
                     JsonRpcResponse::success(id, response)
                 }
                 Err(e) => {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -335,6 +335,31 @@ pub struct StackResult {
     pub cooling_time_s: f64,
 }
 
+/// A single radiation emission line for a decaying nuclide (#427).
+///
+/// Sourced from the parent-keyed `meta/ensdf/emissions/{Symbol}.parquet`
+/// dataset: each row is one γ / X-ray / Auger / conversion-electron / β± /
+/// annihilation line emitted *per decay of the parent* `(z, a, state)`.
+/// `intensity_per_decay` is absolute (the raw `intensity_pct / 100`), so a
+/// 511 keV annihilation pair reads `2.0` and Co-60's 1173 keV γ reads `0.9986`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmissionLine {
+    /// `gamma` | `xray` | `auger` | `ce` | `beta-` | `beta+` | `annihilation`.
+    pub rad_type: String,
+    pub energy_kev: f64,
+    /// Photons/particles emitted per parent decay (absolute, not %).
+    pub intensity_per_decay: f64,
+    /// Feeding decay channel: `EC` | `beta-` | `beta+` | `IT` |
+    /// `KshellEC` / `LshellEC` / `MshellEC`. `None` when unfiled.
+    pub decay_mode: Option<String>,
+    pub daughter_z: Option<u32>,
+    pub daughter_a: Option<u32>,
+    /// Total internal-conversion coefficient (γ lines only).
+    pub icc_total: Option<f64>,
+    /// Line subtype, e.g. `Kα1` (X-ray) or `KLL` (Auger). `None` for γ.
+    pub rad_subtype: Option<String>,
+}
+
 /// Chain isotope used in the coupled ODE solver.
 #[derive(Debug, Clone)]
 pub struct ChainIsotope {

--- a/core/tests/mcp_layer_selection.rs
+++ b/core/tests/mcp_layer_selection.rs
@@ -56,11 +56,11 @@ fn list_producing_layers_reports_both_ti_layers() {
         .expect("list_producing_layers should succeed");
     // Both Ti layers produce V-48.
     assert!(
-        out.contains("2 of 2 layer(s) produce V-48"),
-        "expected both layers to produce V-48; got:\n{out}"
+        out.text.contains("2 of 2 layer(s) produce V-48"),
+        "expected both layers to produce V-48; got:\n{}", out.text
     );
     // The peak-activity layer is flagged.
-    assert!(out.contains("← peak"), "should flag the peak-activity layer:\n{out}");
+    assert!(out.text.contains("← peak"), "should flag the peak-activity layer:\n{}", out.text);
 }
 
 #[test]
@@ -74,11 +74,11 @@ fn production_curve_warns_when_defaulting_to_first_layer() {
         &ti_stack_args(json!({ "isotope": ISO, "vs": "time" })),
     )
     .expect("curve should succeed");
-    assert!(out.contains("— layer 1"), "default picks first producing layer:\n{out}");
-    assert!(out.contains("⚠️"), "must warn about ambiguity when defaulting:\n{out}");
+    assert!(out.text.contains("— layer 1"), "default picks first producing layer:\n{}", out.text);
+    assert!(out.text.contains("⚠️"), "must warn about ambiguity when defaulting:\n{}", out.text);
     assert!(
-        out.contains("layer_index"),
-        "warning should point at the layer_index selector:\n{out}"
+        out.text.contains("layer_index"),
+        "warning should point at the layer_index selector:\n{}", out.text
     );
 }
 
@@ -93,8 +93,8 @@ fn production_curve_honors_explicit_layer_index() {
         &ti_stack_args(json!({ "isotope": ISO, "vs": "time", "layer_index": 2 })),
     )
     .expect("curve for layer 2 should succeed");
-    assert!(out.contains("— layer 2"), "explicit layer_index=2 should select layer 2:\n{out}");
-    assert!(!out.contains("⚠️"), "explicit selection must not warn:\n{out}");
+    assert!(out.text.contains("— layer 2"), "explicit layer_index=2 should select layer 2:\n{}", out.text);
+    assert!(!out.text.contains("⚠️"), "explicit selection must not warn:\n{}", out.text);
 }
 
 #[test]

--- a/core/tests/mcp_structured_export.rs
+++ b/core/tests/mcp_structured_export.rs
@@ -1,0 +1,165 @@
+//! #427 — structured data export: emission accessor, dataset/inventory tools,
+//! emission curves, and the config-hashed result cache. Driven against real
+//! tendl-2023-iso + ensdf emission data. Runs only with `--features mcp`.
+
+#![cfg(feature = "mcp")]
+
+use hyrr_core::db::{DatabaseProtocol, ParquetDataStore};
+
+fn store() -> ParquetDataStore {
+    let data_dir = std::env::var("HYRR_DATA").unwrap_or_else(|_| {
+        concat!(env!("CARGO_MANIFEST_DIR"), "/../nucl-parquet/data").to_string()
+    });
+    ParquetDataStore::new(&data_dir, "tendl-2023-iso").unwrap_or_else(|e| {
+        panic!("ParquetDataStore::new({data_dir}) failed — is the data present? {e}")
+    })
+}
+
+#[test]
+fn emissions_co60_matches_nudat_absolute_intensities() {
+    let db = store();
+    // Co-60 (Z=27, A=60, ground), parent-keyed.
+    let lines = db.get_emissions(27, 60, "");
+    assert!(!lines.is_empty(), "Co-60 must have emission lines");
+
+    // The two NuDat-anchored γ lines (handoff: Co-60 1173 keV = 99.86%).
+    let g1173 = lines
+        .iter()
+        .find(|l| l.rad_type == "gamma" && (l.energy_kev - 1173.2).abs() < 1.0)
+        .expect("Co-60 1173 keV γ must be present");
+    let g1332 = lines
+        .iter()
+        .find(|l| l.rad_type == "gamma" && (l.energy_kev - 1332.5).abs() < 1.0)
+        .expect("Co-60 1332 keV γ must be present");
+
+    // Absolute per-decay intensities (~0.9986 / ~0.9998), NOT percentages.
+    assert!(
+        (g1173.intensity_per_decay - 0.9986).abs() < 0.002,
+        "1173 keV intensity_per_decay ~0.9986, got {}",
+        g1173.intensity_per_decay
+    );
+    assert!(
+        (g1332.intensity_per_decay - 0.9998).abs() < 0.002,
+        "1332 keV intensity_per_decay ~0.9998, got {}",
+        g1332.intensity_per_decay
+    );
+    // β- decay channel, daughter Ni-60.
+    assert_eq!(g1173.decay_mode.as_deref(), Some("beta-"));
+    assert_eq!(g1173.daughter_z, Some(28));
+    assert_eq!(g1173.daughter_a, Some(60));
+}
+
+#[test]
+fn emissions_absent_for_stable_nuclide() {
+    let db = store();
+    // Fe-56 is stable — no decay emissions filed under it as parent.
+    assert!(
+        db.get_emissions(26, 56, "").is_empty(),
+        "stable Fe-56 should have no parent-keyed emission lines"
+    );
+}
+
+#[test]
+fn emissions_f18_has_511_annihilation_pair() {
+    let db = store();
+    // F-18 β+ decay → positron → 511 keV annihilation pair (2 photons/decay).
+    let lines = db.get_emissions(9, 18, "");
+    let ann = lines
+        .iter()
+        .find(|l| l.rad_type == "annihilation" && (l.energy_kev - 511.0).abs() < 1.0)
+        .expect("F-18 must emit a 511 keV annihilation line");
+    assert!(
+        (ann.intensity_per_decay - 2.0 * 0.967).abs() < 0.1,
+        "511 keV pair ~2 × β+ branch (~0.967), got {}",
+        ann.intensity_per_decay
+    );
+}
+
+// --- Tool-level tests (get_isotope_inventory / get_simulation_dataset / get_emission_curve) ---
+
+use hyrr_core::materials::MaterialRegistry;
+use hyrr_core::mcp::tools::call_tool;
+use serde_json::{json, Value};
+
+/// Classic F-18 stack: p @ 18 MeV → havar window → 97% O-18 water. `extra`
+/// merges in tool-specific keys (cooling/depth/emissions, isotope, vs, ...).
+fn f18_args(extra: Value) -> Value {
+    let mut base = json!({
+        "projectile": "p",
+        "energy_mev": 18.0,
+        "current_ma": 0.04,
+        "layers": [
+            { "material": "havar", "thickness_cm": 0.0025 },
+            { "material": "H2O-18", "thickness_cm": 0.3,
+              "enrichment": [{ "element": "O", "A": 18, "fraction": 0.97 }] }
+        ],
+        "irradiation_time_s": 7200.0,
+        "cooling_time_s": 3600.0
+    });
+    let m = base.as_object_mut().unwrap();
+    for (k, v) in extra.as_object().unwrap() {
+        m.insert(k.clone(), v.clone());
+    }
+    base
+}
+
+fn parquet_resources(out: &hyrr_core::mcp::tools::ToolResponse) -> usize {
+    for r in &out.resources {
+        assert_eq!(r.mime_type, "application/vnd.apache.parquet", "resource mime");
+        assert!(!r.blob_base64.is_empty(), "resource blob must be non-empty");
+        assert!(r.uri.starts_with("hyrr://sim/"), "resource uri: {}", r.uri);
+    }
+    out.resources.len()
+}
+
+#[test]
+fn inventory_tool_reports_f18_with_branching_and_parquet() {
+    let db = store();
+    let mut reg = MaterialRegistry::new();
+    let out = call_tool(&db, &mut reg, "get_isotope_inventory", &f18_args(json!({})))
+        .expect("inventory should succeed");
+
+    assert!(out.text.contains("F-18"), "F-18 must appear in inventory:\n{}", out.text);
+    // Long-format schema columns are present in the inline JSON.
+    for col in ["production_source", "activity_at_eob_bq", "beta_plus_branching", "half_life_s"] {
+        assert!(out.text.contains(col), "inventory JSON should carry `{col}`");
+    }
+    assert_eq!(parquet_resources(&out), 1, "exactly one (inventory) Parquet resource");
+}
+
+#[test]
+fn dataset_tool_emits_all_requested_tables_and_resources() {
+    let db = store();
+    let mut reg = MaterialRegistry::new();
+    let out = call_tool(
+        &db,
+        &mut reg,
+        "get_simulation_dataset",
+        &f18_args(json!({ "cooling": true, "depth": true, "emissions": true })),
+    )
+    .expect("dataset should succeed");
+
+    for table in ["inventory", "cooling", "depth", "emissions"] {
+        assert!(out.text.contains(table), "dataset should mention `{table}` table");
+    }
+    // F-18 produced ⇒ inventory + cooling + depth + emissions all non-empty.
+    assert_eq!(parquet_resources(&out), 4, "one Parquet resource per non-empty table:\n{}", out.text);
+}
+
+#[test]
+fn emission_curve_tool_f18_511_is_positive_and_parquet() {
+    let db = store();
+    let mut reg = MaterialRegistry::new();
+    let out = call_tool(
+        &db,
+        &mut reg,
+        "get_emission_curve",
+        &f18_args(json!({ "isotope": "F-18", "energy_kev": 511.0, "vs": "time" })),
+    )
+    .expect("emission curve should succeed");
+
+    assert!(out.text.contains("rate_per_s"), "curve JSON has rate_per_s column");
+    assert!(out.text.contains("annihilation"), "511 keV line is the annihilation pair");
+    assert!(out.text.contains("\"energy_kev\":511"), "511 keV line present:\n{}", out.text);
+    assert_eq!(parquet_resources(&out), 1, "one (emission_curve) Parquet resource");
+}


### PR DESCRIPTION
Closes #427. **Stacked on #431** (base = `feat/428-mcp-layer-selection`); GitHub will retarget to `main` once #431 merges.

## Problem

MCP tools returned markdown only, so any cross-isotope analysis meant N per-isotope round trips + hand-scraping numbers. #427 asks for a structured pull from hyrr-core so consumers can compute joint metrics (511 keV purity windows, dose-rate envelopes, gamma indices) directly.

## New tools

| Tool | Returns |
|------|---------|
| `get_simulation_dataset` | Long-format **inventory** (isotope × layer × source: production rate, saturation yield, EOB + cooling activity, half-life, β+/EC/β−/IT branching) + optional **cooling-tail**, **depth-profile**, and **emission** tables (`cooling`/`depth`/`emissions` flags). |
| `get_isotope_inventory` | Just the inventory table — cheap "what's in the can". |
| `get_emission_curve` | Per-isotope/per-line photon **emission-rate time series** (`rate_per_s = total stack activity × intensity_per_decay`), with `isotope` / `emission_type` / `energy_kev (±tol)` filters, `vs=time\|cooling`. |

Every tool emits **inline JSON** (directly LLM-readable; row-capped with the full table noted as living in the resource) **and** an embedded **Parquet resource** (`hyrr://sim/<id>/<table>.parquet`) for polars/pandas — the "both" option chosen for the format question.

## How the emission data is sourced (no nucl-parquet fork)

The emission table needs the parent-keyed `meta/ensdf/emissions/` set, which the Rust core didn't read. Rather than a submodule PR, `DatabaseProtocol::get_emissions` goes through nucl-parquet's **generic `ParquetStore`** (its catalog-agnostic reader) — so it stays within the data-access layer, in-repo. Verified against NuDat: Co-60 → 1173 keV @ 99.86 %, 1332 keV @ 99.98 %; F-18 → 511 keV annihilation pair (~2/decay); stable Fe-56 → none.

## Config-hashed result cache

Process-scoped LRU (N=100) keyed on a canonical hash of the config (projectile, energy, current, times, ordered layers incl. density + enrichment, current profile) + library + core version + a session-material fingerprint. `simulate` populates it; the dataset/inventory/emission-curve tools (and the #428 curve tools) are lazy views over the cached `StackResult` instead of re-runs.

## Transport / types

`call_tool` now returns a `ToolResponse { text, resources }`; the JSON-RPC transport emits the text block followed by one `resource` content block (base64 Parquet blob) per table. Text-only tools convert via `From<String>`.

## Tests

- **Lib unit:** emission accessor vs NuDat; Parquet write→read round-trip with null handling; cache key invariants (order/format-independent, separates distinct configs, enrichment-order-independent) + computes-once + LRU eviction.
- **Integration (real tendl-2023-iso):** inventory carries F-18 + branching + 1 Parquet resource; dataset with all flags emits 4 tables + 4 resources; emission curve for F-18 511 keV is the annihilation line + 1 resource.
- New **`mcp-tools` CI step** runs `mcp_structured_export`.

## Deps

`arrow` / `parquet` / `base64` are **mcp-only** (`dep:` gated) with `default-features = false`, matching the arrow/parquet subset nucl-parquet already pulls — no csv/ipc/json umbrella added to the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)